### PR TITLE
SEO PR 3: Vercel redirects for clean canonical URLs

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "outputDirectory": ".",
   "cleanUrls": true,
   "redirects": [
     {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,25 @@
+{
+  "cleanUrls": true,
+  "redirects": [
+    {
+      "source": "/:path*",
+      "has": [{ "type": "host", "value": "www.metrixrealty.com" }],
+      "destination": "https://metrixrealty.com/:path*",
+      "permanent": true
+    },
+    { "source": "/contact-enhanced.html", "destination": "/contact", "permanent": true },
+    { "source": "/contact-enhanced", "destination": "/contact", "permanent": true },
+    { "source": "/market-insights.html", "destination": "/insights/", "permanent": true },
+    { "source": "/market-insights", "destination": "/insights/", "permanent": true },
+    { "source": "/services/index.html", "destination": "/services", "permanent": true },
+    { "source": "/services/index", "destination": "/services", "permanent": true },
+    { "source": "/windsor", "destination": "/windsor/", "permanent": true },
+    { "source": "/london", "destination": "/london/", "permanent": true }
+  ],
+  "headers": [
+    {
+      "source": "/assets/(.*)",
+      "headers": [{ "key": "X-Robots-Tag", "value": "noindex" }]
+    }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,8 @@
       "destination": "https://metrixrealty.com/:path*",
       "permanent": true
     },
+    { "source": "/services-enhanced.html", "destination": "/services", "permanent": true },
+    { "source": "/services-enhanced", "destination": "/services", "permanent": true },
     { "source": "/contact-enhanced.html", "destination": "/contact", "permanent": true },
     { "source": "/contact-enhanced", "destination": "/contact", "permanent": true },
     { "source": "/market-insights.html", "destination": "/insights/", "permanent": true },


### PR DESCRIPTION
## What this does

Adds `vercel.json` to the repo root. This is the technical SEO foundation — everything in PR 3 and beyond depends on this being live first.

---

## Before merging — Kyle action required

1. **Check if a `vercel.json` already exists in the Vercel dashboard settings** — if Vercel has any custom config applied at the project level, we need to reconcile it before merging. If none exists, this is safe to merge as-is.
2. **Merge this PR first, before any copy or page PRs.** The `cleanUrls` setting changes how all `.html` URLs are served — internal links will be updated in PR 3 to match.

---

## What each setting does

### `cleanUrls: true`
Strips `.html` from every page automatically. `/team.html` becomes `/team`, `/services/commercial.html` becomes `/services/commercial`, etc. Vercel handles the 301 redirect automatically — no per-page entries needed. This fixes ~15 duplicate URL pairs currently indexed in Google.

### www → non-www redirect
`https://www.metrixrealty.com/` currently returns a 404. This 301 redirects all www traffic to the canonical non-www domain.

### `/contact-enhanced.html` → `/contact`
Legacy duplicate with 924 impressions in GSC. Redirects to the canonical contact page.

### `/market-insights.html` → `/insights/`
Legacy URL rename. Merges equity into the canonical insights hub.

### `/services/index.html` → `/services`
Index file duplicate of the services hub.

### `/windsor` → `/windsor/` and `/london` → `/london/`
Trailing slash consistency — both slash and non-slash versions are currently indexed.

### `X-Robots-Tag: noindex` on `/assets/*`
The Metrix logo PNG was appearing in Google's Pages report as an indexed "page". This header tells Google not to index asset files.

---

## What is intentionally NOT in this PR

**`services-enhanced.html` → `/services` redirect is excluded.** That page has 3,361 impressions and 5 fragment variants indexed by Google. It needs its own PR (PR 4) after confirming all unique content has been migrated to `/services` and the new service pages.

---

## After this deploys — QA checklist

- [ ] `https://www.metrixrealty.com/` returns 301 → `https://metrixrealty.com/`
- [ ] `https://metrixrealty.com/team.html` returns 301 → `https://metrixrealty.com/team`
- [ ] `https://metrixrealty.com/contact-enhanced.html` returns 301 → `https://metrixrealty.com/contact`
- [ ] `https://metrixrealty.com/market-insights.html` returns 301 → `https://metrixrealty.com/insights/`
- [ ] `https://metrixrealty.com/windsor` returns 301 → `https://metrixrealty.com/windsor/`
- [ ] `https://metrixrealty.com/assets/images/metrix-realty-logo.png` response includes `X-Robots-Tag: noindex`
- [ ] No redirect chains (each URL resolves in a single hop)

---

## PR sequence

| PR | Status | Depends on |
|---|---|---|
| PR #10 — Service pages + SEO metadata | ✅ Merged | — |
| **PR 2 — vercel.json redirects (this PR)** | 🔄 Open | PR #10 deployed |
| PR 3 — NAP fixes + copy updates | Pending | This PR deployed |
| PR 4 — services-enhanced redirect + sitemap | Pending | PR 3 deployed |
| PR 5 — New priority pages | Pending | PR 4 deployed |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `vercel.json` to standardize canonical URLs and clean up legacy routes. Enables clean URLs, forces the root domain, noindexes assets, and sets `outputDirectory` so Vercel applies these rules.

- **New Features**
  - Clean URLs: strip `.html` with 301s.
  - Force root domain: 301 `www.metrixrealty.com` → `metrixrealty.com`.
  - Legacy redirects: `/services-enhanced(.html)?` → `/services`, `/contact-enhanced(.html)?` → `/contact`, `/market-insights(.html)?` → `/insights/`, `/services/index(.html)?` → `/services`, `/windsor` and `/london` → trailing slash.
  - Asset noindex: `X-Robots-Tag: noindex` on `/assets/*`.
  - Vercel config: set `outputDirectory: "."`.

- **Migration**
  - Check Vercel project settings for existing `vercel.json` or redirects and reconcile.
  - Merge before content/copy updates; internal links will use clean URLs.

<sup>Written for commit 781468b5e40426b13c885f3c05f04afb2ab56506. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

