### PR TITLE
Add Vercel output directory config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "outputDirectory": "."
+}


### PR DESCRIPTION
Adds a minimal vercel.json so Vercel previews use the repository root as the static output directory instead of looking for a public folder. This is a follow-up for main after PR #10 and does not include redirect or content changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `vercel.json` to set the Vercel `outputDirectory` to `.` so previews serve from the repository root instead of a `public` folder. No redirects or content changes; this just aligns preview builds with the repo structure.

<sup>Written for commit 5f71e14a7aaafe84afb67aa5a26be81cea5d8d80. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

