### PR TITLE
SEO: Person schema on 15 team pages + MPAC/ARB heading upgrades

### DIFF
--- a/ali-mahfoud/index.html
+++ b/ali-mahfoud/index.html
@@ -43,6 +43,38 @@
             box-shadow: 0 10px 25px rgba(35, 60, 117, 0.15);
         }
     </style>
+
+    <script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Ali Mahfoud",
+    "honorificSuffix": "B.A., P.App., AACI",
+    "jobTitle": "Senior Appraiser",
+    "url": "https://metrixrealty.com/ali-mahfoud/",
+    "worksFor": {
+        "@type": "Organization",
+        "@id": "https://metrixrealty.com/#organization",
+        "name": "Metrix Realty Group",
+        "url": "https://metrixrealty.com"
+    },
+    "hasCredential": [
+        {
+            "name": "Accredited Appraiser Canadian Institute (AACI)"
+        },
+        {
+            "name": "Professional Appraiser (P.App.)"
+        }
+    ],
+    "knowsAbout": [
+        "Real estate appraisal",
+        "Property valuation",
+        "CUSPAP compliant appraisal",
+        "Commercial real estate",
+        "Southwestern Ontario real estate"
+    ]
+}
+    </script>
 </head>
 <body class="font-inter">
     <!-- Global Header -->

--- a/dan-van-houtte/index.html
+++ b/dan-van-houtte/index.html
@@ -96,6 +96,44 @@
             box-shadow: 0 10px 25px rgba(35, 60, 117, 0.25);
         }
     </style>
+
+    <script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Daniel J. Van Houtte",
+    "honorificSuffix": "MRICS, P.App., AACI, PLE",
+    "jobTitle": "CEO and President",
+    "url": "https://metrixrealty.com/dan-van-houtte/",
+    "worksFor": {
+        "@type": "Organization",
+        "@id": "https://metrixrealty.com/#organization",
+        "name": "Metrix Realty Group",
+        "url": "https://metrixrealty.com"
+    },
+    "hasCredential": [
+        {
+            "name": "Accredited Appraiser Canadian Institute (AACI)"
+        },
+        {
+            "name": "Member of the Royal Institution of Chartered Surveyors (MRICS)"
+        },
+        {
+            "name": "Professional Legal Expert (PLE)"
+        },
+        {
+            "name": "Professional Appraiser (P.App.)"
+        }
+    ],
+    "knowsAbout": [
+        "Real estate appraisal",
+        "Property valuation",
+        "CUSPAP compliant appraisal",
+        "Commercial real estate",
+        "Southwestern Ontario real estate"
+    ]
+}
+    </script>
 </head>
 <body class="font-inter">
     <!-- Global Header -->

--- a/james-sibbald/index.html
+++ b/james-sibbald/index.html
@@ -62,6 +62,35 @@
             box-shadow: 0 10px 25px rgba(35, 60, 117, 0.15);
         }
     </style>
+
+    <script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "James Sibbald",
+    "honorificSuffix": "B.Sc., M.Sc., AIC Candidate",
+    "jobTitle": "Appraiser Candidate",
+    "url": "https://metrixrealty.com/james-sibbald/",
+    "worksFor": {
+        "@type": "Organization",
+        "@id": "https://metrixrealty.com/#organization",
+        "name": "Metrix Realty Group",
+        "url": "https://metrixrealty.com"
+    },
+    "hasCredential": [
+        {
+            "name": "AIC Candidate Member"
+        }
+    ],
+    "knowsAbout": [
+        "Real estate appraisal",
+        "Property valuation",
+        "CUSPAP compliant appraisal",
+        "Commercial real estate",
+        "Southwestern Ontario real estate"
+    ]
+}
+    </script>
 </head>
 <body class="font-inter">
     <!-- Google Tag Manager (noscript) -->

--- a/jeff-petruzella/index.html
+++ b/jeff-petruzella/index.html
@@ -43,6 +43,38 @@
             box-shadow: 0 10px 25px rgba(35, 60, 117, 0.15);
         }
     </style>
+
+    <script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Jeff J.N. Petruzella",
+    "honorificSuffix": "Hons. B.A., P.App., CRA",
+    "jobTitle": "Vice-President of Residential Operations",
+    "url": "https://metrixrealty.com/jeff-petruzella/",
+    "worksFor": {
+        "@type": "Organization",
+        "@id": "https://metrixrealty.com/#organization",
+        "name": "Metrix Realty Group",
+        "url": "https://metrixrealty.com"
+    },
+    "hasCredential": [
+        {
+            "name": "Canadian Residential Appraiser (CRA)"
+        },
+        {
+            "name": "Professional Appraiser (P.App.)"
+        }
+    ],
+    "knowsAbout": [
+        "Real estate appraisal",
+        "Property valuation",
+        "CUSPAP compliant appraisal",
+        "Commercial real estate",
+        "Southwestern Ontario real estate"
+    ]
+}
+    </script>
 </head>
 <body class="font-inter">
     <!-- Global Header -->

--- a/john-carter/index.html
+++ b/john-carter/index.html
@@ -43,6 +43,38 @@
             box-shadow: 0 10px 25px rgba(35, 60, 117, 0.15);
         }
     </style>
+
+    <script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "John S. Carter",
+    "honorificSuffix": "Hons. B.Comm., P.App., AACI",
+    "jobTitle": "Senior Appraiser",
+    "url": "https://metrixrealty.com/john-carter/",
+    "worksFor": {
+        "@type": "Organization",
+        "@id": "https://metrixrealty.com/#organization",
+        "name": "Metrix Realty Group",
+        "url": "https://metrixrealty.com"
+    },
+    "hasCredential": [
+        {
+            "name": "Accredited Appraiser Canadian Institute (AACI)"
+        },
+        {
+            "name": "Professional Appraiser (P.App.)"
+        }
+    ],
+    "knowsAbout": [
+        "Real estate appraisal",
+        "Property valuation",
+        "CUSPAP compliant appraisal",
+        "Commercial real estate",
+        "Southwestern Ontario real estate"
+    ]
+}
+    </script>
 </head>
 <body class="font-inter">
     <!-- Global Header -->

--- a/madison-collver/index.html
+++ b/madison-collver/index.html
@@ -43,6 +43,38 @@
             box-shadow: 0 10px 25px rgba(35, 60, 117, 0.15);
         }
     </style>
+
+    <script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Madison Collver",
+    "honorificSuffix": "B.Comm., P.App., AACI",
+    "jobTitle": "Appraiser",
+    "url": "https://metrixrealty.com/madison-collver/",
+    "worksFor": {
+        "@type": "Organization",
+        "@id": "https://metrixrealty.com/#organization",
+        "name": "Metrix Realty Group",
+        "url": "https://metrixrealty.com"
+    },
+    "hasCredential": [
+        {
+            "name": "Accredited Appraiser Canadian Institute (AACI)"
+        },
+        {
+            "name": "Professional Appraiser (P.App.)"
+        }
+    ],
+    "knowsAbout": [
+        "Real estate appraisal",
+        "Property valuation",
+        "CUSPAP compliant appraisal",
+        "Commercial real estate",
+        "Southwestern Ontario real estate"
+    ]
+}
+    </script>
 </head>
 <body class="font-inter">
     <!-- Global Header -->

--- a/maia-mcclintock/index.html
+++ b/maia-mcclintock/index.html
@@ -43,6 +43,38 @@
             box-shadow: 0 10px 25px rgba(35, 60, 117, 0.15);
         }
     </style>
+
+    <script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Maia McClintock",
+    "honorificSuffix": "Hons. B.A., P.App., AACI",
+    "jobTitle": "Senior Appraiser",
+    "url": "https://metrixrealty.com/maia-mcclintock/",
+    "worksFor": {
+        "@type": "Organization",
+        "@id": "https://metrixrealty.com/#organization",
+        "name": "Metrix Realty Group",
+        "url": "https://metrixrealty.com"
+    },
+    "hasCredential": [
+        {
+            "name": "Accredited Appraiser Canadian Institute (AACI)"
+        },
+        {
+            "name": "Professional Appraiser (P.App.)"
+        }
+    ],
+    "knowsAbout": [
+        "Real estate appraisal",
+        "Property valuation",
+        "CUSPAP compliant appraisal",
+        "Commercial real estate",
+        "Southwestern Ontario real estate"
+    ]
+}
+    </script>
 </head>
 <body class="font-inter">
     <!-- Global Header -->

--- a/mark-penhale/index.html
+++ b/mark-penhale/index.html
@@ -43,6 +43,38 @@
             box-shadow: 0 10px 25px rgba(35, 60, 117, 0.15);
         }
     </style>
+
+    <script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Mark Penhale",
+    "honorificSuffix": "P.App., AACI",
+    "jobTitle": "Agricultural and Industrial Property Specialist",
+    "url": "https://metrixrealty.com/mark-penhale/",
+    "worksFor": {
+        "@type": "Organization",
+        "@id": "https://metrixrealty.com/#organization",
+        "name": "Metrix Realty Group",
+        "url": "https://metrixrealty.com"
+    },
+    "hasCredential": [
+        {
+            "name": "Accredited Appraiser Canadian Institute (AACI)"
+        },
+        {
+            "name": "Professional Appraiser (P.App.)"
+        }
+    ],
+    "knowsAbout": [
+        "Real estate appraisal",
+        "Property valuation",
+        "CUSPAP compliant appraisal",
+        "Commercial real estate",
+        "Southwestern Ontario real estate"
+    ]
+}
+    </script>
 </head>
 <body class="font-inter">
     <!-- Global Header -->

--- a/mason-hewitt/index.html
+++ b/mason-hewitt/index.html
@@ -62,6 +62,35 @@
             box-shadow: 0 10px 25px rgba(35, 60, 117, 0.15);
         }
     </style>
+
+    <script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Mason L. Hewitt",
+    "honorificSuffix": "B.A., AIC Candidate",
+    "jobTitle": "Appraiser Candidate",
+    "url": "https://metrixrealty.com/mason-hewitt/",
+    "worksFor": {
+        "@type": "Organization",
+        "@id": "https://metrixrealty.com/#organization",
+        "name": "Metrix Realty Group",
+        "url": "https://metrixrealty.com"
+    },
+    "hasCredential": [
+        {
+            "name": "AIC Candidate Member"
+        }
+    ],
+    "knowsAbout": [
+        "Real estate appraisal",
+        "Property valuation",
+        "CUSPAP compliant appraisal",
+        "Commercial real estate",
+        "Southwestern Ontario real estate"
+    ]
+}
+    </script>
 </head>
 <body class="font-inter">
     <!-- Google Tag Manager (noscript) -->

--- a/michael-fry/index.html
+++ b/michael-fry/index.html
@@ -43,6 +43,35 @@
             box-shadow: 0 10px 25px rgba(35, 60, 117, 0.15);
         }
     </style>
+
+    <script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Michael R. Fry",
+    "honorificSuffix": "B.A., AIC Candidate",
+    "jobTitle": "Appraiser Candidate",
+    "url": "https://metrixrealty.com/michael-fry/",
+    "worksFor": {
+        "@type": "Organization",
+        "@id": "https://metrixrealty.com/#organization",
+        "name": "Metrix Realty Group",
+        "url": "https://metrixrealty.com"
+    },
+    "hasCredential": [
+        {
+            "name": "AIC Candidate Member"
+        }
+    ],
+    "knowsAbout": [
+        "Real estate appraisal",
+        "Property valuation",
+        "CUSPAP compliant appraisal",
+        "Commercial real estate",
+        "Southwestern Ontario real estate"
+    ]
+}
+    </script>
 </head>
 <body class="font-inter">
     <!-- Global Header -->

--- a/paula-busch/index.html
+++ b/paula-busch/index.html
@@ -43,6 +43,38 @@
             box-shadow: 0 10px 25px rgba(35, 60, 117, 0.15);
         }
     </style>
+
+    <script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Paula E. Busch",
+    "honorificSuffix": "Hons. B.A., P.App., AACI",
+    "jobTitle": "Vice President of Commercial Appraisal Operations",
+    "url": "https://metrixrealty.com/paula-busch/",
+    "worksFor": {
+        "@type": "Organization",
+        "@id": "https://metrixrealty.com/#organization",
+        "name": "Metrix Realty Group",
+        "url": "https://metrixrealty.com"
+    },
+    "hasCredential": [
+        {
+            "name": "Accredited Appraiser Canadian Institute (AACI)"
+        },
+        {
+            "name": "Professional Appraiser (P.App.)"
+        }
+    ],
+    "knowsAbout": [
+        "Real estate appraisal",
+        "Property valuation",
+        "CUSPAP compliant appraisal",
+        "Commercial real estate",
+        "Southwestern Ontario real estate"
+    ]
+}
+    </script>
 </head>
 <body class="font-inter">
     <!-- Global Header -->

--- a/roman-virk/index.html
+++ b/roman-virk/index.html
@@ -43,6 +43,38 @@
             box-shadow: 0 10px 25px rgba(35, 60, 117, 0.15);
         }
     </style>
+
+    <script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Roman Virk",
+    "honorificSuffix": "BMOS, P.App., AACI",
+    "jobTitle": "Appraiser",
+    "url": "https://metrixrealty.com/roman-virk/",
+    "worksFor": {
+        "@type": "Organization",
+        "@id": "https://metrixrealty.com/#organization",
+        "name": "Metrix Realty Group",
+        "url": "https://metrixrealty.com"
+    },
+    "hasCredential": [
+        {
+            "name": "Accredited Appraiser Canadian Institute (AACI)"
+        },
+        {
+            "name": "Professional Appraiser (P.App.)"
+        }
+    ],
+    "knowsAbout": [
+        "Real estate appraisal",
+        "Property valuation",
+        "CUSPAP compliant appraisal",
+        "Commercial real estate",
+        "Southwestern Ontario real estate"
+    ]
+}
+    </script>
 </head>
 <body class="font-inter">
     <!-- Global Header -->

--- a/sam-van-houtte/index.html
+++ b/sam-van-houtte/index.html
@@ -43,6 +43,38 @@
             box-shadow: 0 10px 25px rgba(35, 60, 117, 0.15);
         }
     </style>
+
+    <script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Sam Van Houtte",
+    "honorificSuffix": "BMOS, AACI, P.App.",
+    "jobTitle": "Vice-President of Appraisal Operations",
+    "url": "https://metrixrealty.com/sam-van-houtte/",
+    "worksFor": {
+        "@type": "Organization",
+        "@id": "https://metrixrealty.com/#organization",
+        "name": "Metrix Realty Group",
+        "url": "https://metrixrealty.com"
+    },
+    "hasCredential": [
+        {
+            "name": "Accredited Appraiser Canadian Institute (AACI)"
+        },
+        {
+            "name": "Professional Appraiser (P.App.)"
+        }
+    ],
+    "knowsAbout": [
+        "Real estate appraisal",
+        "Property valuation",
+        "CUSPAP compliant appraisal",
+        "Commercial real estate",
+        "Southwestern Ontario real estate"
+    ]
+}
+    </script>
 </head>
 <body class="font-inter">
     <!-- Global Header -->

--- a/seo_schema_patch.py
+++ b/seo_schema_patch.py
@@ -1,0 +1,262 @@
+"""
+SEO Schema Patch — Metrix Realty Group
+Adds Person schema to 15 team pages + upgrades MPAC/ARB headings on litigation page.
+Run from repo root: python3 seo_schema_patch.py
+"""
+
+import json, re, sys
+from pathlib import Path
+
+ROOT = Path(__file__).parent
+
+# ---------------------------------------------------------------------------
+# Team member data
+# ---------------------------------------------------------------------------
+
+TEAM = [
+    {
+        "slug":        "dan-van-houtte",
+        "name":        "Daniel J. Van Houtte",
+        "jobTitle":    "CEO and President",
+        "honorific":   "MRICS, P.App., AACI, PLE",
+        "credentials": [
+            {"name": "Accredited Appraiser Canadian Institute (AACI)"},
+            {"name": "Member of the Royal Institution of Chartered Surveyors (MRICS)"},
+            {"name": "Professional Legal Expert (PLE)"},
+            {"name": "Professional Appraiser (P.App.)"},
+        ],
+    },
+    {
+        "slug":        "sam-van-houtte",
+        "name":        "Sam Van Houtte",
+        "jobTitle":    "Vice-President of Appraisal Operations",
+        "honorific":   "BMOS, AACI, P.App.",
+        "credentials": [
+            {"name": "Accredited Appraiser Canadian Institute (AACI)"},
+            {"name": "Professional Appraiser (P.App.)"},
+        ],
+    },
+    {
+        "slug":        "ali-mahfoud",
+        "name":        "Ali Mahfoud",
+        "jobTitle":    "Senior Appraiser",
+        "honorific":   "B.A., P.App., AACI",
+        "credentials": [
+            {"name": "Accredited Appraiser Canadian Institute (AACI)"},
+            {"name": "Professional Appraiser (P.App.)"},
+        ],
+    },
+    {
+        "slug":        "james-sibbald",
+        "name":        "James Sibbald",
+        "jobTitle":    "Appraiser Candidate",
+        "honorific":   "B.Sc., M.Sc., AIC Candidate",
+        "credentials": [
+            {"name": "AIC Candidate Member"},
+        ],
+    },
+    {
+        "slug":        "jeff-petruzella",
+        "name":        "Jeff J.N. Petruzella",
+        "jobTitle":    "Vice-President of Residential Operations",
+        "honorific":   "Hons. B.A., P.App., CRA",
+        "credentials": [
+            {"name": "Canadian Residential Appraiser (CRA)"},
+            {"name": "Professional Appraiser (P.App.)"},
+        ],
+    },
+    {
+        "slug":        "john-carter",
+        "name":        "John S. Carter",
+        "jobTitle":    "Senior Appraiser",
+        "honorific":   "Hons. B.Comm., P.App., AACI",
+        "credentials": [
+            {"name": "Accredited Appraiser Canadian Institute (AACI)"},
+            {"name": "Professional Appraiser (P.App.)"},
+        ],
+    },
+    {
+        "slug":        "madison-collver",
+        "name":        "Madison Collver",
+        "jobTitle":    "Appraiser",
+        "honorific":   "B.Comm., P.App., AACI",
+        "credentials": [
+            {"name": "Accredited Appraiser Canadian Institute (AACI)"},
+            {"name": "Professional Appraiser (P.App.)"},
+        ],
+    },
+    {
+        "slug":        "maia-mcclintock",
+        "name":        "Maia McClintock",
+        "jobTitle":    "Senior Appraiser",
+        "honorific":   "Hons. B.A., P.App., AACI",
+        "credentials": [
+            {"name": "Accredited Appraiser Canadian Institute (AACI)"},
+            {"name": "Professional Appraiser (P.App.)"},
+        ],
+    },
+    {
+        "slug":        "mark-penhale",
+        "name":        "Mark Penhale",
+        "jobTitle":    "Agricultural and Industrial Property Specialist",
+        "honorific":   "P.App., AACI",
+        "credentials": [
+            {"name": "Accredited Appraiser Canadian Institute (AACI)"},
+            {"name": "Professional Appraiser (P.App.)"},
+        ],
+    },
+    {
+        "slug":        "mason-hewitt",
+        "name":        "Mason L. Hewitt",
+        "jobTitle":    "Appraiser Candidate",
+        "honorific":   "B.A., AIC Candidate",
+        "credentials": [
+            {"name": "AIC Candidate Member"},
+        ],
+    },
+    {
+        "slug":        "michael-fry",
+        "name":        "Michael R. Fry",
+        "jobTitle":    "Appraiser Candidate",
+        "honorific":   "B.A., AIC Candidate",
+        "credentials": [
+            {"name": "AIC Candidate Member"},
+        ],
+    },
+    {
+        "slug":        "paula-busch",
+        "name":        "Paula E. Busch",
+        "jobTitle":    "Vice President of Commercial Appraisal Operations",
+        "honorific":   "Hons. B.A., P.App., AACI",
+        "credentials": [
+            {"name": "Accredited Appraiser Canadian Institute (AACI)"},
+            {"name": "Professional Appraiser (P.App.)"},
+        ],
+    },
+    {
+        "slug":        "roman-virk",
+        "name":        "Roman Virk",
+        "jobTitle":    "Appraiser",
+        "honorific":   "BMOS, P.App., AACI",
+        "credentials": [
+            {"name": "Accredited Appraiser Canadian Institute (AACI)"},
+            {"name": "Professional Appraiser (P.App.)"},
+        ],
+    },
+    {
+        "slug":        "suzanne-de-jong",
+        "name":        "Suzanne De Jong",
+        "jobTitle":    "Vice President of Commercial Appraisal Operations",
+        "honorific":   "Hons. B.A., P.App., AACI",
+        "credentials": [
+            {"name": "Accredited Appraiser Canadian Institute (AACI)"},
+            {"name": "Professional Appraiser (P.App.)"},
+        ],
+    },
+    {
+        "slug":        "tyler-munn",
+        "name":        "Tyler Munn",
+        "jobTitle":    "Appraiser Candidate",
+        "honorific":   "B.A., AIC Candidate",
+        "credentials": [
+            {"name": "AIC Candidate Member"},
+        ],
+    },
+]
+
+ORG = {
+    "@type": "Organization",
+    "@id":   "https://metrixrealty.com/#organization",
+    "name":  "Metrix Realty Group",
+    "url":   "https://metrixrealty.com",
+}
+
+# ---------------------------------------------------------------------------
+# Helper: insert JSON-LD before </head>
+# ---------------------------------------------------------------------------
+
+def inject_schema(html: str, schema_obj: dict) -> str:
+    block = (
+        '\n    <script type="application/ld+json">\n'
+        + json.dumps(schema_obj, indent=4, ensure_ascii=False)
+        + "\n    </script>"
+    )
+    # Insert before </head> — avoid duplicating if already present
+    marker = '"@type": "Person"'
+    if marker in html:
+        print("  [skip] Person schema already present")
+        return html
+    return html.replace("</head>", block + "\n</head>", 1)
+
+# ---------------------------------------------------------------------------
+# 1. Person schema on all 15 team pages
+# ---------------------------------------------------------------------------
+
+print("=== Adding Person schema to team pages ===\n")
+
+for member in TEAM:
+    path = ROOT / member["slug"] / "index.html"
+    if not path.exists():
+        print(f"  [warn] not found: {path}")
+        continue
+
+    schema = {
+        "@context":      "https://schema.org",
+        "@type":         "Person",
+        "name":          member["name"],
+        "honorificSuffix": member["honorific"],
+        "jobTitle":      member["jobTitle"],
+        "url":           f"https://metrixrealty.com/{member['slug']}/",
+        "worksFor":      ORG,
+        "hasCredential": member["credentials"],
+        "knowsAbout": [
+            "Real estate appraisal",
+            "Property valuation",
+            "CUSPAP compliant appraisal",
+            "Commercial real estate",
+            "Southwestern Ontario real estate",
+        ],
+    }
+
+    html = path.read_text(encoding="utf-8")
+    updated = inject_schema(html, schema)
+    if updated != html:
+        path.write_text(updated, encoding="utf-8")
+        print(f"  [ok] {member['slug']} — Person schema added")
+    else:
+        print(f"  [skip] {member['slug']} — no change")
+
+# ---------------------------------------------------------------------------
+# 2. Litigation page — promote MPAC / ARB / OLT into H2 headings
+# ---------------------------------------------------------------------------
+
+print("\n=== Upgrading MPAC/ARB headings on litigation page ===\n")
+
+lit_path = ROOT / "services" / "litigation-support-expert-testimony" / "index.html"
+html = lit_path.read_text(encoding="utf-8")
+original = html
+
+# Change H3 "Property Tax Appeals" -> more keyword-rich text
+html = html.replace(
+    '<h3 class="text-lg font-bold text-gray-900 mb-3">Property Tax Appeals</h3>',
+    '<h3 class="text-lg font-bold text-gray-900 mb-3">MPAC Property Tax Appeals and Assessment Review Board (ARB)</h3>',
+)
+
+# Upgrade H3 "Courts & Tribunals Experience" to H2 so ARB/OLT get H2 weight
+html = html.replace(
+    '<h3 class="text-lg font-bold text-gray-900 mb-3">Courts &amp; Tribunals Experience</h3>',
+    '<h2 class="text-lg font-bold text-gray-900 mb-3">Courts and Tribunals: Assessment Review Board (ARB), Ontario Land Tribunal (OLT), and Ontario Superior Court</h2>',
+)
+# Also handle unescaped ampersand version just in case
+html = html.replace(
+    '<h3 class="text-lg font-bold text-gray-900 mb-3">Courts & Tribunals Experience</h3>',
+    '<h2 class="text-lg font-bold text-gray-900 mb-3">Courts and Tribunals: Assessment Review Board (ARB), Ontario Land Tribunal (OLT), and Ontario Superior Court</h2>',
+)
+
+if html != original:
+    lit_path.write_text(html, encoding="utf-8")
+    print("  [ok] litigation page headings updated")
+else:
+    print("  [warn] no changes made — check heading text matches exactly")
+
+print("\nDone.")

--- a/services/litigation-support-expert-testimony/index.html
+++ b/services/litigation-support-expert-testimony/index.html
@@ -228,7 +228,7 @@
                         <div class="w-12 h-12 bg-metrix-blue/10 rounded-full flex items-center justify-center mb-6">
                             <svg class="w-6 h-6 text-metrix-blue" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 14l6-6m-5.5.5h.01m4.99 5h.01M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5"/></svg>
                         </div>
-                        <h3 class="text-lg font-bold text-gray-900 mb-3">Property Tax Appeals</h3>
+                        <h3 class="text-lg font-bold text-gray-900 mb-3">MPAC Property Tax Appeals and Assessment Review Board (ARB)</h3>
                         <p class="text-gray-600 leading-relaxed">If your MPAC property assessment is inaccurate, a professional appraisal provides the evidence needed to support an appeal before the Assessment Review Board (ARB). We prepare reports that address MPAC's methodology.</p>
                     </div>
                     <div class="bg-gradient-to-br from-gray-50 to-blue-50 rounded-xl p-8 border border-blue-100 professional-hover" data-aos="fade-up" data-aos-delay="200">
@@ -272,7 +272,7 @@
                         <p class="text-gray-600">Professional valuation support for alternative dispute resolution proceedings — a cost-effective path to resolution outside the courtroom.</p>
                     </div>
                     <div class="bg-white rounded-xl p-8 border border-gray-100 professional-hover" data-aos="fade-up" data-aos-delay="200">
-                        <h3 class="text-lg font-bold text-gray-900 mb-3">Courts & Tribunals Experience</h3>
+                        <h2 class="text-lg font-bold text-gray-900 mb-3">Courts and Tribunals: Assessment Review Board (ARB), Ontario Land Tribunal (OLT), and Ontario Superior Court</h2>
                         <p class="text-gray-600">Ontario Superior Court, Assessment Review Board, Ontario Land Tribunal, Ontario Family Court, arbitration panels, and mediation proceedings.</p>
                     </div>
                 </div>

--- a/suzanne-de-jong/index.html
+++ b/suzanne-de-jong/index.html
@@ -43,6 +43,38 @@
             box-shadow: 0 10px 25px rgba(35, 60, 117, 0.15);
         }
     </style>
+
+    <script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Suzanne De Jong",
+    "honorificSuffix": "Hons. B.A., P.App., AACI",
+    "jobTitle": "Vice President of Commercial Appraisal Operations",
+    "url": "https://metrixrealty.com/suzanne-de-jong/",
+    "worksFor": {
+        "@type": "Organization",
+        "@id": "https://metrixrealty.com/#organization",
+        "name": "Metrix Realty Group",
+        "url": "https://metrixrealty.com"
+    },
+    "hasCredential": [
+        {
+            "name": "Accredited Appraiser Canadian Institute (AACI)"
+        },
+        {
+            "name": "Professional Appraiser (P.App.)"
+        }
+    ],
+    "knowsAbout": [
+        "Real estate appraisal",
+        "Property valuation",
+        "CUSPAP compliant appraisal",
+        "Commercial real estate",
+        "Southwestern Ontario real estate"
+    ]
+}
+    </script>
 </head>
 <body class="font-inter">
     <!-- Global Header -->

--- a/tyler-munn/index.html
+++ b/tyler-munn/index.html
@@ -43,6 +43,35 @@
             box-shadow: 0 10px 25px rgba(35, 60, 117, 0.15);
         }
     </style>
+
+    <script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Tyler Munn",
+    "honorificSuffix": "B.A., AIC Candidate",
+    "jobTitle": "Appraiser Candidate",
+    "url": "https://metrixrealty.com/tyler-munn/",
+    "worksFor": {
+        "@type": "Organization",
+        "@id": "https://metrixrealty.com/#organization",
+        "name": "Metrix Realty Group",
+        "url": "https://metrixrealty.com"
+    },
+    "hasCredential": [
+        {
+            "name": "AIC Candidate Member"
+        }
+    ],
+    "knowsAbout": [
+        "Real estate appraisal",
+        "Property valuation",
+        "CUSPAP compliant appraisal",
+        "Commercial real estate",
+        "Southwestern Ontario real estate"
+    ]
+}
+    </script>
 </head>
 <body class="font-inter">
     <!-- Global Header -->


### PR DESCRIPTION
## Summary

- Added `Person` schema (JSON-LD) to all 15 team member pages — includes name, job title, honorific suffix, full credential list (`hasCredential`), and `worksFor` linking back to the Metrix org entity
- Upgraded H3 "Property Tax Appeals" on the litigation support page to explicitly name MPAC and Assessment Review Board (ARB) in the heading text
- Promoted "Courts & Tribunals Experience" from H3 to H2 on the litigation page, with Assessment Review Board (ARB), Ontario Land Tribunal (OLT), and Ontario Superior Court named in the heading

## Why this matters

No competitor in the London and Southwestern Ontario appraisal market has Person schema on any team page. This is a first-mover E-E-A-T signal for professional services content. MPAC, ARB, and Ontario Land Tribunal are the exact terms clients search when initiating property tax appeals — they need heading-level weight, not just body text.

## Files changed

- 15 team member pages: `{slug}/index.html` — Person schema added to `<head>`
- `services/litigation-support-expert-testimony/index.html` — heading text upgrades
- `seo_schema_patch.py` — script used to generate the schema blocks

## Test plan

- [ ] Validate schema on any team page using Google Rich Results Test (search.google.com/test/rich-results)
- [ ] Confirm litigation page headings render correctly in browser — no visual changes expected on team pages (schema is in `<head>`)
- [ ] Spot-check that no existing schema blocks were duplicated or overwritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `Person` JSON-LD schema to all 15 team pages and updates litigation support headings to surface MPAC, ARB, and OLT for better SEO and clarity. No visual changes on team pages.

- **New Features**
  - Added `Person` schema to 15 team pages (name, jobTitle, honorificSuffix, `hasCredential`, and `worksFor` linking to Metrix org).
  - Updated litigation page headings: “Property Tax Appeals” → “MPAC Property Tax Appeals and Assessment Review Board (ARB)”; promoted “Courts & Tribunals Experience” to H2 with ARB, OLT, and Ontario Superior Court.
  - Included `seo_schema_patch.py` to generate and insert schema blocks.

<sup>Written for commit db0e270c441b16e5813980aac055b126e3e4c6fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

