### PR TITLE
SEO: FAQPage schema on commercial, residential, and litigation service pages

### DIFF
--- a/services/commercial-property-valuations/index.html
+++ b/services/commercial-property-valuations/index.html
@@ -132,6 +132,46 @@
       ]
     }
     </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "When is a commercial property valuation required?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Commercial appraisals are required across a wide range of situations: financing and refinancing (lender-approved appraisals for commercial mortgage applications, refinancing, and construction financing); acquisition and disposition (independent market value opinions for the purchase or sale of commercial properties); portfolio management (periodic valuations for institutional investors, REITs, and property managers); financial reporting and tax (IFRS reporting, capital gains calculations, CRA compliance, and property tax assessment appeals before the Assessment Review Board); insurance purposes (replacement cost and market value assessments); and legal and partnership disputes (court-ready valuations for litigation, partnership buyouts, shareholder disputes, and expropriation proceedings)."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "What types of commercial properties does Metrix Realty Group appraise?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Metrix Realty Group appraises office buildings and corporate centres, retail and shopping centres, industrial and warehouse properties (manufacturing, distribution, flex industrial), multi-unit residential investments, mixed-use developments, and special purpose and development land including hotels, gas stations, automotive facilities, and development land across Southwestern Ontario."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "What credentials do Metrix Realty commercial appraisers hold?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Our commercial appraisers hold the AACI (Accredited Appraiser Canadian Institute) designation — the highest professional designation in Canadian real estate appraisal — and are fully compliant with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice). Many also hold the RICS (Royal Institution of Chartered Surveyors) designation. Reports are accepted by all major Canadian banks, credit unions, CMHC, and private lenders."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "What is the commercial appraisal process at Metrix Realty?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "The process involves four steps: (1) Consultation — we discuss your requirements, property details, purpose of the appraisal, and provide a transparent fee quote and timeline; (2) Property Inspection — a thorough on-site inspection documenting physical condition, improvements, tenancy, and all factors affecting value; (3) Market Research — analysis of comparable sales, lease rates, cap rates, and market conditions using CoStar Professional and TRREB data; (4) Report Delivery — a detailed, professionally formatted appraisal report. Standard turnaround is 5–10 business days; rush assignments are available in 24–48 hours."
+          }
+        }
+      ]
+    }
+    </script>
 </head>
 <body class="font-inter">
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/services/litigation-support-expert-testimony/index.html
+++ b/services/litigation-support-expert-testimony/index.html
@@ -109,6 +109,46 @@
       ]
     }
     </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "When is litigation support from a real estate appraiser required?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Litigation support is required in several legal contexts: matrimonial and divorce proceedings (Ontario Family Law Act valuations at the date of marriage and date of separation to calculate net family property and equalization payments); expropriation and land acquisition (market value, Injurious Affection, and Disturbance Damages under Ontario's Expropriations Act); partnership and shareholder disputes (independent valuations for business dissolutions, buyouts, and arbitration); estate and probate litigation (date-of-death valuations and retrospective assessments for contested estates); MPAC property tax appeals before the Assessment Review Board (ARB); and insurance claims and disputes requiring independent valuations to quantify loss."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "What courts and tribunals do Metrix Realty appraisers provide expert testimony in?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Metrix Realty appraisers provide expert witness testimony before the Ontario Superior Court, Assessment Review Board (ARB), Ontario Land Tribunal (OLT), Ontario Family Court, and in arbitration panels and mediation proceedings across Ontario."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "What types of litigation appraisal reports does Metrix Realty provide?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Metrix Realty provides expert witness testimony reports formatted to court and tribunal standards, retrospective valuations (historical date-specific assessments for estate, matrimonial, and tax matters), rebuttal report preparation (critical review of opposing expert opinions), court-ready appraisal reports with full methodology disclosure, and mediation and arbitration support as a cost-effective alternative to litigation."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Are Metrix Realty appraisers qualified to provide expert witness testimony in Ontario courts?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Yes. Our AACI-designated appraisers have provided expert testimony in hundreds of proceedings across Ontario courts and tribunals. Every litigation report is prepared to withstand cross-examination, meets all court and tribunal formatting requirements, and includes detailed methodology, comprehensive analysis, and full disclosure of assumptions."
+          }
+        }
+      ]
+    }
+    </script>
 </head>
 <body class="font-inter">
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/services/residential-property-appraisals/index.html
+++ b/services/residential-property-appraisals/index.html
@@ -119,6 +119,46 @@
       ]
     }
     </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "When is a residential appraisal required?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Residential appraisals are required in many situations: mortgage and purchase financing (lenders require an independent appraisal before approving a mortgage); refinancing and HELOC (updated equity valuations to determine available equity); estate planning and probate (for estate settlement, estate taxes, and CRA reporting requirements); divorce and matrimonial property (court-ready reports for Ontario Family Law Act proceedings, valued at the date of marriage and date of separation); property tax appeals (to support an MPAC assessment appeal before Ontario's Assessment Review Board); and relocation and pre-listing (unbiased market value opinions for corporate relocations and sale negotiations)."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "What types of residential properties does Metrix Realty appraise?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Metrix Realty appraises single-family detached homes (bungalows, two-storey, back-splits, side-splits, and custom builds), condominiums and townhouses, rural and farm properties, waterfront and cottage properties, luxury and heritage properties, and multi-unit residential properties from duplexes to six-unit buildings for owner-occupied or investment purposes."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Are Metrix Realty residential appraisal reports accepted by banks and lenders?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Yes. Our AACI and CRA designated appraisers produce CUSPAP-compliant reports that are accepted by all major Canadian financial institutions, including banks, credit unions, CMHC, and private lenders."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "What credentials do Metrix Realty residential appraisers hold?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Our residential appraisers hold both the AACI (Accredited Appraiser Canadian Institute) and CRA (Canadian Residential Appraiser) designations — the highest professional credentials in Canadian real estate appraisal. All reports comply with the Canadian Uniform Standards of Professional Appraisal Practice (CUSPAP), and our appraisers maintain active membership with the Appraisal Institute of Canada (AIC)."
+          }
+        }
+      ]
+    }
+    </script>
 </head>
 <body class="font-inter">
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>


### PR DESCRIPTION
## Summary

- Adds `FAQPage` JSON-LD schema to three core service pages
- Each page gets 4 Q&A pairs sourced directly from visible on-page content
- No content changes — schema only

## Pages updated

| Page | Questions added |
|---|---|
| `/services/commercial-property-valuations` | When is a commercial appraisal required? · Property types we appraise · Credentials · Process |
| `/services/residential-property-appraisals` | When is a residential appraisal required? · Property types · Lender acceptance · Credentials |
| `/services/litigation-support-expert-testimony` | When is litigation support required? · Courts and tribunals · Report types · Expert witness qualification |

## Why this matters

No competitor (Aion, RealEx, Valco, McIver, Riverbend, Total Property Insight) uses FAQPage schema. Merging this makes Metrix the only appraisal firm in London/SWO eligible for FAQ rich results in Google Search and AI answer citations.

## Validation

All three JSON-LD blocks validated with `json.loads()` — no syntax errors.

## Test plan

- [ ] Merge to `main` (triggers DigitalOcean deploy, live in ~60s)
- [ ] Validate with [Google Rich Results Test](https://search.google.com/test/rich-results) on each of the three URLs
- [ ] Confirm FAQPage detected on all three pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added FAQ structured data (FAQPage JSON-LD) to the commercial, residential, and litigation service pages to enable FAQ rich results and improve visibility in search. Four Q&A per page are pulled from existing on-page content; no content changes.

- **New Features**
  - Added FAQPage schema to:
    - /services/commercial-property-valuations
    - /services/residential-property-appraisals
    - /services/litigation-support-expert-testimony

<sup>Written for commit de6afa4c91729b7440c0cb54c2dc97f1e38f6c6e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

