### PR TITLE
SEO on-page optimisation: nav dropdown, header/footer, titles, meta, OG tags

### DIFF
--- a/404.html
+++ b/404.html
@@ -30,16 +30,116 @@
 </head>
 <body class="font-inter bg-gray-50">
     <!-- Header -->
-    <header class="bg-white border-b border-gray-100">
+    <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex items-center justify-between h-16 sm:h-20">
+                <!-- Logo -->
                 <div class="flex-shrink-0">
                     <a href="/">
                         <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
                     </a>
                 </div>
+                
+                <!-- Desktop Navigation -->
+                <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
+                    <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
+                    <div class="relative group">
+                        <a href="/services" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Services</a>
+                        <!-- Mega Menu -->
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-96 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50 backdrop-blur-sm">
+                            <div class="p-8">
+                                <div>
+                                    <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
+                                    <div class="space-y-1">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
+                                        </a>
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
+                                        </a>
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
+                                        </a>
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
+                                        </a>
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
+                </div>
+                
+                <!-- CTA Button -->
+                <div class="hidden md:block">
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
+                        Connect with an Appraiser
+                    </a>
+                </div>
+                
+                <!-- Mobile menu button -->
+                <div class="md:hidden">
+                    <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
+                        <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                        </div>
+                    </button>
+                </div>
             </div>
         </nav>
+
+        <!-- Mobile Menu -->
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+            
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+                    
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+
+        <!-- Mobile Menu Overlay -->
+        <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
     </header>
 
     <!-- 404 Content -->
@@ -80,10 +180,106 @@
     </main>
 
     <!-- Footer -->
-    <footer class="bg-white border-t border-gray-100">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-            <div class="text-center text-gray-500 text-sm">
+    <footer class="bg-black text-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
+                <!-- Company Info -->
+                <div class="lg:col-span-1">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-6 leading-relaxed">
+                        Trusted • Valued • Experienced
+                    </p>
+                    <div class="text-gray-300">
+                        <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
+                        <p class="mb-4">London, ON N6A 5J9</p>
+                        <p class="font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
+                            </svg>
+                            <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
+                        </p>
+                        <p>Toll Free: 1-866-672-9101</p>
+                        <p>Fax: (519) 672-9321</p>
+                        <p class="mt-4 font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                            </svg>
+                            <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
+                        </p>
+                    </div>
+                </div>
+                
+                <!-- Services -->
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
+                    <ul class="space-y-3 text-gray-300">
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
+                        <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
+                    </ul>
+                </div>
+                
+                <!-- Market Areas -->
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
+                    </ul>
+                </div>
+                
+                <!-- Company -->
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
+                        <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
+                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
+                    </ul>
+                </div>
+            </div>
+            
+            <!-- Professional Affiliations -->
+            <div class="border-t border-gray-800 pt-8 mb-8 text-center">
+                <div class="mb-6">
+                    <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
+                    <span>AIC - Appraisal Institute of Canada</span>
+                    <span>RICS - Royal Institution of Chartered Surveyors</span>
+                    <span>AOLE - Association of Ontario Land Economists</span>
+                    <span>IRWA - International Right of Way Association</span>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6">
+                    <span>Data Providers:</span>
+                    <span>CoStar Professional</span>
+                    <span>TRREB - Toronto Regional Real Estate Board</span>
+                </div>
+                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
+                    <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
+                </div>
+            </div>
+            
+            <!-- Copyright -->
+            <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
                 <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
             </div>
         </div>
     </footer>

--- a/accessibility/index.html
+++ b/accessibility/index.html
@@ -32,15 +32,116 @@
 </head>
 <body class="font-inter bg-gray-50">
     <!-- Header -->
-    <header class="bg-white border-b border-gray-200">
-        <div class="max-w-4xl mx-auto px-4 py-6">
-            <div class="flex items-center">
-                <a href="/" class="flex items-center">
-                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-8 w-auto mr-4">
-                    <span class="text-lg font-semibold text-gray-900">Accessibility Statement</span>
-                </a>
+    <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
+        <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center justify-between h-16 sm:h-20">
+                <!-- Logo -->
+                <div class="flex-shrink-0">
+                    <a href="/">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
+                    </a>
+                </div>
+                
+                <!-- Desktop Navigation -->
+                <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
+                    <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
+                    <div class="relative group">
+                        <a href="/services" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Services</a>
+                        <!-- Mega Menu -->
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-96 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50 backdrop-blur-sm">
+                            <div class="p-8">
+                                <div>
+                                    <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
+                                    <div class="space-y-1">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
+                                        </a>
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
+                                        </a>
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
+                                        </a>
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
+                                        </a>
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
+                </div>
+                
+                <!-- CTA Button -->
+                <div class="hidden md:block">
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
+                        Connect with an Appraiser
+                    </a>
+                </div>
+                
+                <!-- Mobile menu button -->
+                <div class="md:hidden">
+                    <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
+                        <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                        </div>
+                    </button>
+                </div>
+            </div>
+        </nav>
+
+        <!-- Mobile Menu -->
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+            
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+                    
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
+                    </div>
+                </nav>
             </div>
         </div>
+
+        <!-- Mobile Menu Overlay -->
+        <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
     </header>
 
     <!-- Main Content -->
@@ -105,13 +206,106 @@
     </main>
 
     <!-- Footer -->
-    <footer class="bg-metrix-blue text-white mt-16">
-        <div class="max-w-4xl mx-auto px-4 py-8 text-center">
-            <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
-            <div class="mt-4 space-x-6">
-                <a href="/privacy-policy" class="text-gray-300 hover:text-white">Privacy Policy</a>
-                <a href="/terms-of-service" class="text-gray-300 hover:text-white">Terms of Service</a>
-                <a href="/" class="text-gray-300 hover:text-white">Home</a>
+    <footer class="bg-black text-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
+                <!-- Company Info -->
+                <div class="lg:col-span-1">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-6 leading-relaxed">
+                        Trusted • Valued • Experienced
+                    </p>
+                    <div class="text-gray-300">
+                        <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
+                        <p class="mb-4">London, ON N6A 5J9</p>
+                        <p class="font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
+                            </svg>
+                            <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
+                        </p>
+                        <p>Toll Free: 1-866-672-9101</p>
+                        <p>Fax: (519) 672-9321</p>
+                        <p class="mt-4 font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                            </svg>
+                            <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
+                        </p>
+                    </div>
+                </div>
+                
+                <!-- Services -->
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
+                    <ul class="space-y-3 text-gray-300">
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
+                        <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
+                    </ul>
+                </div>
+                
+                <!-- Market Areas -->
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
+                    </ul>
+                </div>
+                
+                <!-- Company -->
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
+                        <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
+                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
+                    </ul>
+                </div>
+            </div>
+            
+            <!-- Professional Affiliations -->
+            <div class="border-t border-gray-800 pt-8 mb-8 text-center">
+                <div class="mb-6">
+                    <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
+                    <span>AIC - Appraisal Institute of Canada</span>
+                    <span>RICS - Royal Institution of Chartered Surveyors</span>
+                    <span>AOLE - Association of Ontario Land Economists</span>
+                    <span>IRWA - International Right of Way Association</span>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6">
+                    <span>Data Providers:</span>
+                    <span>CoStar Professional</span>
+                    <span>TRREB - Toronto Regional Real Estate Board</span>
+                </div>
+                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
+                    <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
+                </div>
+            </div>
+            
+            <!-- Copyright -->
+            <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
+                <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
             </div>
         </div>
     </footer>

--- a/ali-mahfoud/index.html
+++ b/ali-mahfoud/index.html
@@ -91,17 +91,17 @@
     <!-- Global Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex items-center justify-between h-20">
+            <div class="flex items-center justify-between h-16 sm:h-20">
                 <!-- Logo -->
                 <div class="flex-shrink-0">
                     <a href="/">
-                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
                     </a>
                 </div>
                 
                 <!-- Desktop Navigation -->
-                <div class="hidden md:flex items-center space-x-8">
-                    <a href="/" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Home</a>
+                <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
+                    <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
                     <div class="relative group">
                         <a href="/services" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Services</a>
                         <!-- Mega Menu -->
@@ -110,23 +110,23 @@
                                 <div>
                                     <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
                                     <div class="space-y-1">
-                                        <a href="/services#commercial" class="mega-menu-item block p-4">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
                                         </a>
-                                        <a href="/services#residential" class="mega-menu-item block p-4">
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
                                         </a>
-                                        <a href="/services#litigation" class="mega-menu-item block p-4">
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
                                         </a>
-                                        <a href="/services#consulting" class="mega-menu-item block p-4">
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
                                         </a>
-                                        <a href="/services#government" class="mega-menu-item block p-4">
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
                                         </a>
@@ -135,19 +135,70 @@
                             </div>
                         </div>
                     </div>
-                    <a href="/market-areas" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Market Areas</a>
-                    <a href="/team" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Team</a>
-                    <a href="/contact" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Contact</a>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link active text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
                 </div>
                 
                 <!-- CTA Button -->
                 <div class="hidden md:block">
-                    <a href="/contact" class="inline-flex items-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-black-dark transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg">
-                        Request an Appraisal
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
+                        Connect with an Appraiser
                     </a>
+                </div>
+                
+                <!-- Mobile menu button -->
+                <div class="md:hidden">
+                    <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
+                        <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                        </div>
+                    </button>
                 </div>
             </div>
         </nav>
+
+        <!-- Mobile Menu -->
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+            
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link active">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+                    
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+
+        <!-- Mobile Menu Overlay -->
+        <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
     </header>
 
     <!-- Hero Section -->
@@ -358,49 +409,61 @@
 
     <!-- Professional Footer -->
     <footer class="bg-black text-white">
-        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-12 mb-12 text-center lg:text-left">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
                 <!-- Company Info -->
                 <div class="lg:col-span-1">
-                    <div class="flex justify-center lg:justify-start items-center gap-3 mb-6">
-                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 w-auto brightness-0 invert">
-                    </div>
-                    <p class="text-gray-300 mb-6 leading-relaxed text-sm">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-6 leading-relaxed">
                         Trusted • Valued • Experienced
                     </p>
-                    <div class="text-gray-300 text-sm space-y-1">
-                        <p class="font-semibold text-white">620A Richmond Street, Suite 203</p>
-                        <p>London, ON N6A 5J9</p>
-                        <p class="mt-3 flex items-center">
-                            <svg class="w-4 h-4 mr-2 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <div class="text-gray-300">
+                        <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
+                        <p class="mb-4">London, ON N6A 5J9</p>
+                        <p class="font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
                             </svg>
                             <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
                         </p>
-                        <p>Toll Free: 866 672 9101</p>
+                        <p>Toll Free: 1-866-672-9101</p>
                         <p>Fax: (519) 672-9321</p>
+                        <p class="mt-4 font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                            </svg>
+                            <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
+                        </p>
                     </div>
                 </div>
                 
                 <!-- Services -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
-                    <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/services#commercial" class="hover:text-white transition-colors duration-200">Commercial Valuation</a></li>
-                        <li><a href="/services#residential" class="hover:text-white transition-colors duration-200">Residential Appraisals</a></li>
-                        <li><a href="/services#litigation" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
-                        <li><a href="/services" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                    <ul class="space-y-3 text-gray-300">
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
+                        <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
                     </ul>
                 </div>
                 
                 <!-- Market Areas -->
                 <div>
-                    <h3 class="text-white font-semibold text-lg mb-6">Market Areas</h3>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Ontario Coverage</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Urban Markets</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Industrial Properties</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Rural & Agricultural</a></li>
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
                     </ul>
                 </div>
                 
@@ -409,9 +472,7 @@
                     <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
-                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">About Us</a></li>
                         <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
-                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">Careers</a></li>
                         <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
                     </ul>
                 </div>
@@ -422,16 +483,31 @@
                 <div class="mb-6">
                     <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
                 </div>
-                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300">
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
                     <span>AIC - Appraisal Institute of Canada</span>
-                    <span>OREA - Ontario Real Estate Association</span>
-                    <span>CREA - Canadian Real Estate Association</span>
+                    <span>RICS - Royal Institution of Chartered Surveyors</span>
+                    <span>AOLE - Association of Ontario Land Economists</span>
+                    <span>IRWA - International Right of Way Association</span>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6">
+                    <span>Data Providers:</span>
+                    <span>CoStar Professional</span>
+                    <span>TRREB - Toronto Regional Real Estate Board</span>
+                </div>
+                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
+                    <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
                 </div>
             </div>
             
             <!-- Copyright -->
             <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
                 <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
             </div>
         </div>
     </footer>

--- a/contact/index.html
+++ b/contact/index.html
@@ -3,9 +3,11 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Contact - Professional Property Appraisal Services | Metrix Realty Group</title>
+    <title>Contact a Real Estate Appraiser | Metrix Realty Group</title>
+    <meta property="og:title" content="Contact a Real Estate Appraiser | Metrix Realty Group">
+    <meta property="og:description" content="Contact Metrix Realty Group for expert property appraisals in London and Windsor, Ontario. AACI-designated professionals. Schedule your consultation today.">
     <link rel="icon" type="image/png" href="/favicon.png">
-    <meta name="description" content="Contact Metrix Realty Group for expert property appraisal services. Accredited professionals serving Ontario for over 30 years. Schedule your consultation today.">
+    <meta name="description" content="Contact Metrix Realty Group for expert property appraisals in London and Windsor, Ontario. AACI-designated professionals. Schedule your consultation today.">
     <link rel="canonical" href="https://metrixrealty.com/contact">
     
     <!-- Google Tag Manager -->
@@ -343,23 +345,23 @@
                                 <div>
                                     <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
                                     <div class="space-y-1">
-                                        <a href="/services#commercial" class="mega-menu-item block p-4">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
                                         </a>
-                                        <a href="/services#residential" class="mega-menu-item block p-4">
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
                                         </a>
-                                        <a href="/services#litigation" class="mega-menu-item block p-4">
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
                                         </a>
-                                        <a href="/services#consulting" class="mega-menu-item block p-4">
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
                                         </a>
-                                        <a href="/services#government" class="mega-menu-item block p-4">
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
                                         </a>
@@ -368,8 +370,17 @@
                             </div>
                         </div>
                     </div>
-                    <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
                     <a href="/team" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
                     <a href="/contact" class="nav-link active text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
                 </div>
                 
@@ -392,6 +403,37 @@
                 </div>
             </div>
         </nav>
+
+        <!-- Mobile Menu -->
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+            
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
+                    <a href="/contact" class="mobile-nav-link active">Contact</a>
+                    
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+
+        <!-- Mobile Menu Overlay -->
+        <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
     </header>
 
     <!-- Mobile Menu -->
@@ -407,6 +449,8 @@
                 <a href="/" class="mobile-nav-link">Home</a>
                 <a href="/services" class="mobile-nav-link">Services</a>
                 <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
                 <a href="/team" class="mobile-nav-link">Team</a>
                 <a href="/contact" class="mobile-nav-link active">Contact</a>
                 
@@ -627,7 +671,7 @@
     </main>
 
     <!-- Professional Footer -->
-    <footer class="bg-black text-white" style="background-color: #000000 !important;">
+    <footer class="bg-black text-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
                 <!-- Company Info -->
@@ -660,29 +704,29 @@
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
                     <ul class="space-y-3 text-gray-300">
-                        <li><a href="/services#commercial" class="hover:text-white transition-colors duration-200">Commercial Valuation</a></li>
-                        <li><a href="/services#residential" class="hover:text-white transition-colors duration-200">Residential Appraisals</a></li>
-                        <li><a href="/services#litigation" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
-                        <li><a href="/services#consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
                         <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
                     </ul>
                 </div>
                 
                 <!-- Market Areas -->
                 <div>
-                    <h3 class="text-white font-semibold text-lg mb-6">Market Areas</h3>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">London–Middlesex–Elgin</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Windsor–Essex</a></li>
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Oxford County</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Huron–Perth–Wellington</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Niagara Region</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Halton–Peel</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Full Coverage Map</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
                     </ul>
                 </div>
                 
@@ -721,6 +765,12 @@
             <!-- Copyright -->
             <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
                 <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
             </div>
         </div>
     </footer>

--- a/dan-van-houtte/index.html
+++ b/dan-van-houtte/index.html
@@ -150,17 +150,17 @@
     <!-- Global Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex items-center justify-between h-20">
+            <div class="flex items-center justify-between h-16 sm:h-20">
                 <!-- Logo -->
                 <div class="flex-shrink-0">
                     <a href="/">
-                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
                     </a>
                 </div>
                 
                 <!-- Desktop Navigation -->
-                <div class="hidden md:flex items-center space-x-8">
-                    <a href="/" class="nav-link text-gray-900 font-medium">Home</a>
+                <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
+                    <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
                     <div class="relative group">
                         <a href="/services" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Services</a>
                         <!-- Mega Menu -->
@@ -169,23 +169,23 @@
                                 <div>
                                     <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
                                     <div class="space-y-1">
-                                        <a href="/services#commercial" class="mega-menu-item block p-4">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
                                         </a>
-                                        <a href="/services#residential" class="mega-menu-item block p-4">
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
                                         </a>
-                                        <a href="/services#litigation" class="mega-menu-item block p-4">
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
                                         </a>
-                                        <a href="/services#consulting" class="mega-menu-item block p-4">
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
                                         </a>
-                                        <a href="/services#government" class="mega-menu-item block p-4">
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
                                         </a>
@@ -194,20 +194,70 @@
                             </div>
                         </div>
                     </div>
-                    <a href="/market-areas" class="nav-link text-gray-900 font-medium">Market Areas</a>
-                    <a href="/team" class="nav-link text-gray-900 font-medium">Team</a>
-                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-medium">Market Insights</a> -->
-                    <a href="/contact" class="nav-link text-gray-900 font-medium">Contact</a>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link active text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
                 </div>
                 
                 <!-- CTA Button -->
                 <div class="hidden md:block">
-                    <a href="/contact" class="btn-primary inline-flex items-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800">
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
                         Connect with an Appraiser
                     </a>
                 </div>
+                
+                <!-- Mobile menu button -->
+                <div class="md:hidden">
+                    <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
+                        <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                        </div>
+                    </button>
+                </div>
             </div>
         </nav>
+
+        <!-- Mobile Menu -->
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+            
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link active">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+                    
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+
+        <!-- Mobile Menu Overlay -->
+        <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
     </header>
 
     <!-- Hero Section -->
@@ -464,49 +514,61 @@
 
     <!-- Professional Footer -->
     <footer class="bg-black text-white">
-        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-12 mb-12 text-center lg:text-left">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
                 <!-- Company Info -->
                 <div class="lg:col-span-1">
-                    <div class="flex justify-center lg:justify-start items-center gap-3 mb-6">
-                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 w-auto brightness-0 invert">
-                    </div>
-                    <p class="text-gray-300 mb-6 leading-relaxed text-sm">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-6 leading-relaxed">
                         Trusted • Valued • Experienced
                     </p>
-                    <div class="text-gray-300 text-sm space-y-1">
-                        <p class="font-semibold text-white">620A Richmond Street, Suite 203</p>
-                        <p>London, ON N6A 5J9</p>
-                        <p class="mt-3 flex items-center">
-                            <svg class="w-4 h-4 mr-2 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <div class="text-gray-300">
+                        <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
+                        <p class="mb-4">London, ON N6A 5J9</p>
+                        <p class="font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
                             </svg>
                             <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
                         </p>
-                        <p>Toll Free: 866 672 9101</p>
+                        <p>Toll Free: 1-866-672-9101</p>
                         <p>Fax: (519) 672-9321</p>
+                        <p class="mt-4 font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                            </svg>
+                            <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
+                        </p>
                     </div>
                 </div>
                 
                 <!-- Services -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
-                    <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/services#commercial" class="hover:text-white transition-colors duration-200">Commercial Valuation</a></li>
-                        <li><a href="/services#residential" class="hover:text-white transition-colors duration-200">Residential Appraisals</a></li>
-                        <li><a href="/services#litigation" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
-                        <li><a href="/services" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                    <ul class="space-y-3 text-gray-300">
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
+                        <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
                     </ul>
                 </div>
                 
                 <!-- Market Areas -->
                 <div>
-                    <h3 class="text-white font-semibold text-lg mb-6">Market Areas</h3>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Ontario Coverage</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Urban Markets</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Industrial Properties</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Rural & Agricultural</a></li>
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
                     </ul>
                 </div>
                 
@@ -515,9 +577,7 @@
                     <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
-                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">About Us</a></li>
                         <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
-                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">Careers</a></li>
                         <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
                     </ul>
                 </div>
@@ -528,16 +588,31 @@
                 <div class="mb-6">
                     <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
                 </div>
-                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300">
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
                     <span>AIC - Appraisal Institute of Canada</span>
-                    <span>OREA - Ontario Real Estate Association</span>
-                    <span>CREA - Canadian Real Estate Association</span>
+                    <span>RICS - Royal Institution of Chartered Surveyors</span>
+                    <span>AOLE - Association of Ontario Land Economists</span>
+                    <span>IRWA - International Right of Way Association</span>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6">
+                    <span>Data Providers:</span>
+                    <span>CoStar Professional</span>
+                    <span>TRREB - Toronto Regional Real Estate Board</span>
+                </div>
+                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
+                    <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
                 </div>
             </div>
             
             <!-- Copyright -->
             <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
                 <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
             </div>
         </div>
     </footer>

--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Best Commercial Real Estate Appraisers London Ontario | AACI Designated | Metrix Realty Group</title>
-    <meta name="description" content="Metrix Realty Group is London, Ontario's leading commercial real estate appraisal firm. AACI-designated ICI (Industrial, Commercial, Investment) property specialists serving Southwestern Ontario since 1995. Lender-recognized appraisals, expert witness testimony, and litigation support.">
+    <title>Commercial Real Estate Appraisers London Ontario | Metrix</title>
+    <meta name="description" content="AACI-certified commercial appraisers serving London and Ontario. Expert real estate valuations for lenders, legal matters, estates, and corporate clients.">
     <meta name="keywords" content="best commercial appraiser London Ontario, ICI appraisal London, commercial real estate appraisal London Ontario, AACI designated appraiser, industrial commercial investment appraisal, property valuation London ON, expert witness real estate Ontario, lender recognized appraisal, Metrix Realty Group">
     <meta name="robots" content="index, follow">
     <meta name="author" content="Metrix Realty Group">
@@ -25,14 +25,14 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://metrixrealty.com/">
-    <meta property="og:title" content="Metrix Realty Group | London Ontario's Leading Commercial Real Estate Appraisers">
-    <meta property="og:description" content="London Ontario's top-ranked ICI (Industrial, Commercial, Investment) appraisal firm. AACI-designated team, lender-recognized valuations, expert witness testimony. Serving Southwestern Ontario since 1995.">
+    <meta property="og:title" content="Commercial Real Estate Appraisers London Ontario | Metrix">
+    <meta property="og:description" content="AACI-certified commercial appraisers serving London and Ontario. Expert real estate valuations for lenders, legal matters, estates, and corporate clients.">
     <meta property="og:image" content="https://metrixrealty.com/assets/images/metrix-realty-logo.png">
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://metrixrealty.com/">
-    <meta property="twitter:title" content="Metrix Realty Group | London Ontario's Leading Commercial Real Estate Appraisers">
+    <meta property="twitter:title" content="Metrix Realty Group | AACI-Certified Commercial Real Estate Appraisals in London, Ontario">
     <meta property="twitter:description" content="London Ontario's top-ranked ICI (Industrial, Commercial, Investment) appraisal firm. AACI-designated team, lender-recognized valuations, expert witness testimony. Serving Southwestern Ontario since 1995.">
     <meta property="twitter:image" content="https://metrixrealty.com/assets/images/metrix-realty-logo.png">
     
@@ -696,7 +696,15 @@
                             </div>
                         </div>
                     </div>
-                    <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
                     <a href="/team" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
                     <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
                     <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
@@ -735,6 +743,8 @@
                     <a href="#" class="mobile-nav-link active">Home</a>
                     <a href="/services" class="mobile-nav-link">Services</a>
                     <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
                     <a href="/team" class="mobile-nav-link">Team</a>
                     <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
                     <a href="/contact" class="mobile-nav-link">Contact</a>
@@ -769,7 +779,7 @@
                     </div>
                     
                     <h1 class="hero-title text-3xl sm:text-4xl md:text-5xl lg:text-6xl xl:text-7xl font-bold mb-8 sm:mb-10 lg:mb-12 leading-tight text-smooth !text-white" style="color: white !important;" data-aos="fade-up" data-aos-duration="1000">
-                        London Ontario's Leading Commercial Real Estate Appraisers
+                        AACI-Certified Commercial Real Estate Appraisals in London, Ontario
                     </h1>
                     <p class="hero-subtitle text-lg sm:text-xl md:text-2xl lg:text-2xl xl:text-3xl mb-12 sm:mb-16 lg:mb-20 opacity-90 leading-relaxed text-smooth max-w-5xl mx-auto !text-white" style="color: white !important;" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="200">
                         Since 1995, Metrix Realty Group has been Southwestern Ontario's most trusted ICI (Industrial, Commercial, Investment) appraisal firm. Over 50,000 lender-recognized valuations completed by AACI-designated professionals.

--- a/insights/appraisal-vs-realtor-cma-ontario.html
+++ b/insights/appraisal-vs-realtor-cma-ontario.html
@@ -9,8 +9,8 @@
     <link rel="canonical" href="https://metrixrealty.com/insights/appraisal-vs-realtor-cma-ontario.html">
 
     <!-- Open Graph Meta Tags -->
-    <meta property="og:title" content="Appraisal vs Realtor CMA: What Is the Difference in Ontario?">
-    <meta property="og:description" content="A practical guide to choosing between a Realtor CMA and a formal appraisal for Ontario real estate decisions.">
+    <meta property="og:title" content="Appraisal vs Realtor CMA in Ontario | Metrix Realty Group">
+    <meta property="og:description" content="Compare a Realtor CMA and formal appraisal in Ontario by purpose, users, report scope, evidence, and when each option may fit.">
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://metrixrealty.com/insights/appraisal-vs-realtor-cma-ontario.html">
     <meta property="og:image" content="https://metrixrealty.com/assets/images/metrix-realty-team.webp">
@@ -187,65 +187,112 @@
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex items-center justify-between h-16 sm:h-20">
+                <!-- Logo -->
                 <div class="flex-shrink-0">
                     <a href="/">
-                        <img src="../assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
                     </a>
                 </div>
+                
+                <!-- Desktop Navigation -->
                 <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
-                    <a href="/" class="nav-link text-gray-900 font-semibold">Home</a>
+                    <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
                     <div class="relative group">
-                        <a href="/services" class="nav-link text-gray-900 font-semibold">Services</a>
-                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-96 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                        <a href="/services" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Services</a>
+                        <!-- Mega Menu -->
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-96 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50 backdrop-blur-sm">
                             <div class="p-8">
-                                <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
-                                <div class="space-y-1">
-                                    <a href="/services#commercial" class="mega-menu-item block p-4"><div class="font-semibold text-gray-900 mb-2">Commercial Appraisals</div><div class="text-sm text-gray-600">Expert valuations for office, retail, and industrial properties</div></a>
-                                    <a href="/services#residential" class="mega-menu-item block p-4"><div class="font-semibold text-gray-900 mb-2">Residential Appraisals</div><div class="text-sm text-gray-600">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div></a>
-                                    <a href="/services#litigation" class="mega-menu-item block p-4"><div class="font-semibold text-gray-900 mb-2">Litigation Support</div><div class="text-sm text-gray-600">Expert witness testimony and legal valuations</div></a>
-                                    <a href="/services#consulting" class="mega-menu-item block p-4"><div class="font-semibold text-gray-900 mb-2">Real Estate Consulting</div><div class="text-sm text-gray-600">Strategic market analysis and investment advisory services</div></a>
-                                    <a href="/services#government" class="mega-menu-item block p-4"><div class="font-semibold text-gray-900 mb-2">Government & Institutional Services</div><div class="text-sm text-gray-600">Specialized services for federal, provincial, and municipal clients</div></a>
+                                <div>
+                                    <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
+                                    <div class="space-y-1">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
+                                        </a>
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
+                                        </a>
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
+                                        </a>
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
+                                        </a>
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
+                                        </a>
+                                    </div>
                                 </div>
                             </div>
                         </div>
                     </div>
-                    <a href="/market-areas" class="nav-link text-gray-900 font-semibold">Market Areas</a>
-                    <a href="/team" class="nav-link text-gray-900 font-semibold">Team</a>
-                    <a href="/contact" class="nav-link text-gray-900 font-semibold">Contact</a>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
                 </div>
+                
+                <!-- CTA Button -->
                 <div class="hidden md:block">
-                    <a href="/contact" class="inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
                         Connect with an Appraiser
                     </a>
                 </div>
+                
+                <!-- Mobile menu button -->
                 <div class="md:hidden">
-                    <button id="mobile-menu-button" class="text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
-                        <div class="w-6 h-6 flex flex-col justify-center space-y-1">
-                            <span class="block h-0.5 w-6 bg-current"></span>
-                            <span class="block h-0.5 w-6 bg-current"></span>
-                            <span class="block h-0.5 w-6 bg-current"></span>
+                    <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
+                        <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
                         </div>
                     </button>
                 </div>
             </div>
         </nav>
+
+        <!-- Mobile Menu -->
         <div id="mobile-menu" class="mobile-menu md:hidden">
             <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
-                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
             </button>
+            
             <div class="mobile-menu-content">
                 <nav class="mobile-nav">
                     <a href="/" class="mobile-nav-link">Home</a>
                     <a href="/services" class="mobile-nav-link">Services</a>
                     <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
                     <a href="/team" class="mobile-nav-link">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
                     <a href="/contact" class="mobile-nav-link">Contact</a>
+                    
                     <div style="margin-top: 32px;">
-                        <a href="/contact" class="block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">Connect with an Appraiser</a>
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
                     </div>
                 </nav>
             </div>
         </div>
+
+        <!-- Mobile Menu Overlay -->
         <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
     </header>
 
@@ -554,73 +601,106 @@
     </article>
 
     <!-- Footer -->
-    <footer class="bg-black text-white mt-20">
+    <footer class="bg-black text-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
+                <!-- Company Info -->
                 <div class="lg:col-span-1">
-                    <img src="../assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
-                    <p class="text-gray-300 mb-6">Trusted • Valued • Experienced</p>
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-6 leading-relaxed">
+                        Trusted • Valued • Experienced
+                    </p>
                     <div class="text-gray-300">
                         <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
                         <p class="mb-4">London, ON N6A 5J9</p>
                         <p class="font-semibold text-white flex items-center">
-                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/></svg>
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
+                            </svg>
                             <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
                         </p>
                         <p>Toll Free: 1-866-672-9101</p>
                         <p>Fax: (519) 672-9321</p>
                         <p class="mt-4 font-semibold text-white flex items-center">
-                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                            </svg>
                             <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
                         </p>
                     </div>
                 </div>
+                
+                <!-- Services -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
                     <ul class="space-y-3 text-gray-300">
-                        <li><a href="/services#commercial" class="hover:text-white transition-colors duration-200">Commercial Valuation</a></li>
-                        <li><a href="/services#residential" class="hover:text-white transition-colors duration-200">Residential Appraisals</a></li>
-                        <li><a href="/services#litigation" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
-                        <li><a href="/services#consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
                         <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
                     </ul>
                 </div>
+                
+                <!-- Market Areas -->
                 <div>
-                    <h3 class="text-white font-semibold text-lg mb-6">Market Areas</h3>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">London–Middlesex–Elgin</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Windsor–Essex</a></li>
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Oxford County</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Huron–Perth–Wellington</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
                     </ul>
                 </div>
+                
+                <!-- Company -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
-                        <li><a href="../insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
+                        <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
                         <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
                     </ul>
                 </div>
             </div>
+            
+            <!-- Professional Affiliations -->
             <div class="border-t border-gray-800 pt-8 mb-8 text-center">
-                <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
+                <div class="mb-6">
+                    <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
+                </div>
                 <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
                     <span>AIC - Appraisal Institute of Canada</span>
                     <span>RICS - Royal Institution of Chartered Surveyors</span>
                     <span>AOLE - Association of Ontario Land Economists</span>
                     <span>IRWA - International Right of Way Association</span>
                 </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6">
+                    <span>Data Providers:</span>
+                    <span>CoStar Professional</span>
+                    <span>TRREB - Toronto Regional Real Estate Board</span>
+                </div>
                 <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
                     <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
                 </div>
             </div>
+            
+            <!-- Copyright -->
             <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
-                <p>&copy; 2026 Metrix Realty Group. All rights reserved.</p>
+                <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
             </div>
         </div>
     </footer>

--- a/insights/bank-appraisal-vs-private-appraisal-ontario.html
+++ b/insights/bank-appraisal-vs-private-appraisal-ontario.html
@@ -3,14 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Bank Appraisal vs Private Appraisal in Ontario | Metrix Realty Group</title>
+    <title>Bank Appraisal vs Private Appraisal in Ontario | Metrix</title>
     <link rel="icon" type="image/png" href="/favicon.png">
     <meta name="description" content="Compare bank and private appraisals in Ontario by client, authorized use, report access, lender cautions, and when to ask about your own report.">
     <link rel="canonical" href="https://metrixrealty.com/insights/bank-appraisal-vs-private-appraisal-ontario.html">
 
     <!-- Open Graph Meta Tags -->
-    <meta property="og:title" content="Bank Appraisal vs Private Appraisal: Which Report Do You Need?">
-    <meta property="og:description" content="A practical Ontario guide to lender appraisals, private appraisal reports, authorized users, and financing-related appraisal decisions.">
+    <meta property="og:title" content="Bank Appraisal vs Private Appraisal in Ontario | Metrix">
+    <meta property="og:description" content="Compare bank and private appraisals in Ontario by client, authorized use, report access, lender cautions, and when to ask about your own report.">
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://metrixrealty.com/insights/bank-appraisal-vs-private-appraisal-ontario.html">
     <meta property="og:image" content="https://metrixrealty.com/assets/images/metrix-realty-team.webp">
@@ -185,65 +185,112 @@
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex items-center justify-between h-16 sm:h-20">
+                <!-- Logo -->
                 <div class="flex-shrink-0">
                     <a href="/">
-                        <img src="../assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
                     </a>
                 </div>
+                
+                <!-- Desktop Navigation -->
                 <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
-                    <a href="/" class="nav-link text-gray-900 font-semibold">Home</a>
+                    <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
                     <div class="relative group">
-                        <a href="/services" class="nav-link text-gray-900 font-semibold">Services</a>
-                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-96 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                        <a href="/services" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Services</a>
+                        <!-- Mega Menu -->
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-96 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50 backdrop-blur-sm">
                             <div class="p-8">
-                                <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
-                                <div class="space-y-1">
-                                    <a href="/services#commercial" class="mega-menu-item block p-4"><div class="font-semibold text-gray-900 mb-2">Commercial Appraisals</div><div class="text-sm text-gray-600">Expert valuations for office, retail, and industrial properties</div></a>
-                                    <a href="/services#residential" class="mega-menu-item block p-4"><div class="font-semibold text-gray-900 mb-2">Residential Appraisals</div><div class="text-sm text-gray-600">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div></a>
-                                    <a href="/services#litigation" class="mega-menu-item block p-4"><div class="font-semibold text-gray-900 mb-2">Litigation Support</div><div class="text-sm text-gray-600">Expert witness testimony and legal valuations</div></a>
-                                    <a href="/services#consulting" class="mega-menu-item block p-4"><div class="font-semibold text-gray-900 mb-2">Real Estate Consulting</div><div class="text-sm text-gray-600">Strategic market analysis and investment advisory services</div></a>
-                                    <a href="/services#government" class="mega-menu-item block p-4"><div class="font-semibold text-gray-900 mb-2">Government & Institutional Services</div><div class="text-sm text-gray-600">Specialized services for federal, provincial, and municipal clients</div></a>
+                                <div>
+                                    <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
+                                    <div class="space-y-1">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
+                                        </a>
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
+                                        </a>
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
+                                        </a>
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
+                                        </a>
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
+                                        </a>
+                                    </div>
                                 </div>
                             </div>
                         </div>
                     </div>
-                    <a href="/market-areas" class="nav-link text-gray-900 font-semibold">Market Areas</a>
-                    <a href="/team" class="nav-link text-gray-900 font-semibold">Team</a>
-                    <a href="/contact" class="nav-link text-gray-900 font-semibold">Contact</a>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
                 </div>
+                
+                <!-- CTA Button -->
                 <div class="hidden md:block">
-                    <a href="/contact" class="inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
                         Connect with an Appraiser
                     </a>
                 </div>
+                
+                <!-- Mobile menu button -->
                 <div class="md:hidden">
-                    <button id="mobile-menu-button" class="text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
-                        <div class="w-6 h-6 flex flex-col justify-center space-y-1">
-                            <span class="block h-0.5 w-6 bg-current"></span>
-                            <span class="block h-0.5 w-6 bg-current"></span>
-                            <span class="block h-0.5 w-6 bg-current"></span>
+                    <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
+                        <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
                         </div>
                     </button>
                 </div>
             </div>
         </nav>
+
+        <!-- Mobile Menu -->
         <div id="mobile-menu" class="mobile-menu md:hidden">
             <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
-                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
             </button>
+            
             <div class="mobile-menu-content">
                 <nav class="mobile-nav">
                     <a href="/" class="mobile-nav-link">Home</a>
                     <a href="/services" class="mobile-nav-link">Services</a>
                     <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
                     <a href="/team" class="mobile-nav-link">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
                     <a href="/contact" class="mobile-nav-link">Contact</a>
+                    
                     <div style="margin-top: 32px;">
-                        <a href="/contact" class="block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">Connect with an Appraiser</a>
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
                     </div>
                 </nav>
             </div>
         </div>
+
+        <!-- Mobile Menu Overlay -->
         <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
     </header>
 
@@ -563,73 +610,106 @@
     </article>
 
     <!-- Footer -->
-    <footer class="bg-black text-white mt-20">
+    <footer class="bg-black text-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
+                <!-- Company Info -->
                 <div class="lg:col-span-1">
-                    <img src="../assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
-                    <p class="text-gray-300 mb-6">Trusted • Valued • Experienced</p>
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-6 leading-relaxed">
+                        Trusted • Valued • Experienced
+                    </p>
                     <div class="text-gray-300">
                         <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
                         <p class="mb-4">London, ON N6A 5J9</p>
                         <p class="font-semibold text-white flex items-center">
-                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/></svg>
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
+                            </svg>
                             <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
                         </p>
                         <p>Toll Free: 1-866-672-9101</p>
                         <p>Fax: (519) 672-9321</p>
                         <p class="mt-4 font-semibold text-white flex items-center">
-                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                            </svg>
                             <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
                         </p>
                     </div>
                 </div>
+                
+                <!-- Services -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
                     <ul class="space-y-3 text-gray-300">
-                        <li><a href="/services#commercial" class="hover:text-white transition-colors duration-200">Commercial Valuation</a></li>
-                        <li><a href="/services#residential" class="hover:text-white transition-colors duration-200">Residential Appraisals</a></li>
-                        <li><a href="/services#litigation" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
-                        <li><a href="/services#consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
                         <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
                     </ul>
                 </div>
+                
+                <!-- Market Areas -->
                 <div>
-                    <h3 class="text-white font-semibold text-lg mb-6">Market Areas</h3>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">London–Middlesex–Elgin</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Windsor–Essex</a></li>
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Oxford County</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Huron–Perth–Wellington</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
                     </ul>
                 </div>
+                
+                <!-- Company -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
-                        <li><a href="../insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
+                        <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
                         <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
                     </ul>
                 </div>
             </div>
+            
+            <!-- Professional Affiliations -->
             <div class="border-t border-gray-800 pt-8 mb-8 text-center">
-                <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
+                <div class="mb-6">
+                    <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
+                </div>
                 <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
                     <span>AIC - Appraisal Institute of Canada</span>
                     <span>RICS - Royal Institution of Chartered Surveyors</span>
                     <span>AOLE - Association of Ontario Land Economists</span>
                     <span>IRWA - International Right of Way Association</span>
                 </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6">
+                    <span>Data Providers:</span>
+                    <span>CoStar Professional</span>
+                    <span>TRREB - Toronto Regional Real Estate Board</span>
+                </div>
                 <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
                     <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
                 </div>
             </div>
+            
+            <!-- Copyright -->
             <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
-                <p>&copy; 2026 Metrix Realty Group. All rights reserved.</p>
+                <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
             </div>
         </div>
     </footer>

--- a/insights/index.html
+++ b/insights/index.html
@@ -276,7 +276,7 @@
                 <!-- Logo -->
                 <div class="flex-shrink-0">
                     <a href="/">
-                        <img src="../assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
                     </a>
                 </div>
                 
@@ -291,23 +291,23 @@
                                 <div>
                                     <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
                                     <div class="space-y-1">
-                                        <a href="/services#commercial" class="mega-menu-item block p-4">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
                                         </a>
-                                        <a href="/services#residential" class="mega-menu-item block p-4">
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
                                         </a>
-                                        <a href="/services#litigation" class="mega-menu-item block p-4">
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
                                         </a>
-                                        <a href="/services#consulting" class="mega-menu-item block p-4">
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
                                         </a>
-                                        <a href="/services#government" class="mega-menu-item block p-4">
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
                                         </a>
@@ -316,8 +316,17 @@
                             </div>
                         </div>
                     </div>
-                    <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
                     <a href="/team" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
                     <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
                 </div>
                 
@@ -354,7 +363,10 @@
                     <a href="/" class="mobile-nav-link">Home</a>
                     <a href="/services" class="mobile-nav-link">Services</a>
                     <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
                     <a href="/team" class="mobile-nav-link">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
                     <a href="/contact" class="mobile-nav-link">Contact</a>
                     
                     <div style="margin-top: 32px;">
@@ -625,12 +637,12 @@
     </main>
 
     <!-- Professional Footer -->
-    <footer class="bg-black text-white mt-20">
+    <footer class="bg-black text-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
                 <!-- Company Info -->
                 <div class="lg:col-span-1">
-                    <img src="../assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
                     <p class="text-gray-300 mb-6 leading-relaxed">
                         Trusted • Valued • Experienced
                     </p>
@@ -658,29 +670,29 @@
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
                     <ul class="space-y-3 text-gray-300">
-                        <li><a href="/services#commercial" class="hover:text-white transition-colors duration-200">Commercial Valuation</a></li>
-                        <li><a href="/services#residential" class="hover:text-white transition-colors duration-200">Residential Appraisals</a></li>
-                        <li><a href="/services#litigation" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
-                        <li><a href="/services#consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
                         <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
                     </ul>
                 </div>
                 
                 <!-- Market Areas -->
                 <div>
-                    <h3 class="text-white font-semibold text-lg mb-6">Market Areas</h3>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">London–Middlesex–Elgin</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Windsor–Essex</a></li>
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Oxford County</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Huron–Perth–Wellington</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Niagara Region</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Halton–Peel</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Full Coverage Map</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
                     </ul>
                 </div>
                 
@@ -689,7 +701,7 @@
                     <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
-                        <li><a href="../insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
+                        <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
                         <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
                     </ul>
                 </div>
@@ -719,6 +731,12 @@
             <!-- Copyright -->
             <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
                 <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
             </div>
         </div>
     </footer>

--- a/insights/listing-prices-misconception.html
+++ b/insights/listing-prices-misconception.html
@@ -390,7 +390,7 @@
                 <!-- Logo -->
                 <div class="flex-shrink-0">
                     <a href="/">
-                        <img src="../assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
                     </a>
                 </div>
                 
@@ -405,23 +405,23 @@
                                 <div>
                                     <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
                                     <div class="space-y-1">
-                                        <a href="/services#commercial" class="mega-menu-item block p-4">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
                                         </a>
-                                        <a href="/services#residential" class="mega-menu-item block p-4">
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
                                         </a>
-                                        <a href="/services#litigation" class="mega-menu-item block p-4">
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
                                         </a>
-                                        <a href="/services#consulting" class="mega-menu-item block p-4">
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
                                         </a>
-                                        <a href="/services#government" class="mega-menu-item block p-4">
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
                                         </a>
@@ -430,8 +430,17 @@
                             </div>
                         </div>
                     </div>
-                    <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
                     <a href="/team" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
                     <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
                 </div>
                 
@@ -468,7 +477,10 @@
                     <a href="/" class="mobile-nav-link">Home</a>
                     <a href="/services" class="mobile-nav-link">Services</a>
                     <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
                     <a href="/team" class="mobile-nav-link">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
                     <a href="/contact" class="mobile-nav-link">Contact</a>
                     
                     <div style="margin-top: 32px;">
@@ -827,12 +839,12 @@
     </article>
 
     <!-- Professional Footer -->
-    <footer class="bg-black text-white mt-20">
+    <footer class="bg-black text-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
                 <!-- Company Info -->
                 <div class="lg:col-span-1">
-                    <img src="../assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
                     <p class="text-gray-300 mb-6 leading-relaxed">
                         Trusted • Valued • Experienced
                     </p>
@@ -860,29 +872,29 @@
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
                     <ul class="space-y-3 text-gray-300">
-                        <li><a href="/services#commercial" class="hover:text-white transition-colors duration-200">Commercial Valuation</a></li>
-                        <li><a href="/services#residential" class="hover:text-white transition-colors duration-200">Residential Appraisals</a></li>
-                        <li><a href="/services#litigation" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
-                        <li><a href="/services#consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
                         <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
                     </ul>
                 </div>
                 
                 <!-- Market Areas -->
                 <div>
-                    <h3 class="text-white font-semibold text-lg mb-6">Market Areas</h3>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">London–Middlesex–Elgin</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Windsor–Essex</a></li>
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Oxford County</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Huron–Perth–Wellington</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Niagara Region</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Halton–Peel</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Full Coverage Map</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
                     </ul>
                 </div>
                 
@@ -891,7 +903,7 @@
                     <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
-                        <li><a href="../insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
+                        <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
                         <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
                     </ul>
                 </div>
@@ -921,6 +933,12 @@
             <!-- Copyright -->
             <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
                 <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
             </div>
         </div>
     </footer>

--- a/insights/ontario-market-analysis-2016-2024.html
+++ b/insights/ontario-market-analysis-2016-2024.html
@@ -413,7 +413,7 @@
                 <!-- Logo -->
                 <div class="flex-shrink-0">
                     <a href="/">
-                        <img src="../assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
                     </a>
                 </div>
                 
@@ -428,23 +428,23 @@
                                 <div>
                                     <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
                                     <div class="space-y-1">
-                                        <a href="/services#commercial" class="mega-menu-item block p-4">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
                                         </a>
-                                        <a href="/services#residential" class="mega-menu-item block p-4">
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
                                         </a>
-                                        <a href="/services#litigation" class="mega-menu-item block p-4">
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
                                         </a>
-                                        <a href="/services#consulting" class="mega-menu-item block p-4">
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
                                         </a>
-                                        <a href="/services#government" class="mega-menu-item block p-4">
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
                                         </a>
@@ -453,8 +453,17 @@
                             </div>
                         </div>
                     </div>
-                    <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
                     <a href="/team" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
                     <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
                 </div>
                 
@@ -491,7 +500,10 @@
                     <a href="/" class="mobile-nav-link">Home</a>
                     <a href="/services" class="mobile-nav-link">Services</a>
                     <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
                     <a href="/team" class="mobile-nav-link">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
                     <a href="/contact" class="mobile-nav-link">Contact</a>
                     
                     <div style="margin-top: 32px;">
@@ -961,12 +973,12 @@
     </article>
 
     <!-- Professional Footer -->
-    <footer class="bg-black text-white mt-20">
+    <footer class="bg-black text-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
                 <!-- Company Info -->
                 <div class="lg:col-span-1">
-                    <img src="../assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
                     <p class="text-gray-300 mb-6 leading-relaxed">
                         Trusted • Valued • Experienced
                     </p>
@@ -994,29 +1006,29 @@
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
                     <ul class="space-y-3 text-gray-300">
-                        <li><a href="/services#commercial" class="hover:text-white transition-colors duration-200">Commercial Valuation</a></li>
-                        <li><a href="/services#residential" class="hover:text-white transition-colors duration-200">Residential Appraisals</a></li>
-                        <li><a href="/services#litigation" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
-                        <li><a href="/services#consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
                         <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
                     </ul>
                 </div>
                 
                 <!-- Market Areas -->
                 <div>
-                    <h3 class="text-white font-semibold text-lg mb-6">Market Areas</h3>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">London–Middlesex–Elgin</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Windsor–Essex</a></li>
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Oxford County</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Huron–Perth–Wellington</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Niagara Region</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Halton–Peel</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Full Coverage Map</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
                     </ul>
                 </div>
                 
@@ -1025,7 +1037,7 @@
                     <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
-                        <li><a href="../insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
+                        <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
                         <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
                     </ul>
                 </div>
@@ -1055,6 +1067,12 @@
             <!-- Copyright -->
             <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
                 <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
             </div>
         </div>
     </footer>

--- a/insights/sentimental-equity-problem.html
+++ b/insights/sentimental-equity-problem.html
@@ -383,7 +383,7 @@
                 <!-- Logo -->
                 <div class="flex-shrink-0">
                     <a href="/">
-                        <img src="../assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
                     </a>
                 </div>
                 
@@ -398,23 +398,23 @@
                                 <div>
                                     <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
                                     <div class="space-y-1">
-                                        <a href="/services#commercial" class="mega-menu-item block p-4">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
                                         </a>
-                                        <a href="/services#residential" class="mega-menu-item block p-4">
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
                                         </a>
-                                        <a href="/services#litigation" class="mega-menu-item block p-4">
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
                                         </a>
-                                        <a href="/services#consulting" class="mega-menu-item block p-4">
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
                                         </a>
-                                        <a href="/services#government" class="mega-menu-item block p-4">
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
                                         </a>
@@ -423,8 +423,17 @@
                             </div>
                         </div>
                     </div>
-                    <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
                     <a href="/team" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
                     <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
                 </div>
                 
@@ -461,7 +470,10 @@
                     <a href="/" class="mobile-nav-link">Home</a>
                     <a href="/services" class="mobile-nav-link">Services</a>
                     <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
                     <a href="/team" class="mobile-nav-link">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
                     <a href="/contact" class="mobile-nav-link">Contact</a>
                     
                     <div style="margin-top: 32px;">
@@ -922,12 +934,12 @@
     </article>
 
     <!-- Professional Footer -->
-    <footer class="bg-black text-white mt-20">
+    <footer class="bg-black text-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
                 <!-- Company Info -->
                 <div class="lg:col-span-1">
-                    <img src="../assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
                     <p class="text-gray-300 mb-6 leading-relaxed">
                         Trusted • Valued • Experienced
                     </p>
@@ -955,29 +967,29 @@
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
                     <ul class="space-y-3 text-gray-300">
-                        <li><a href="/services#commercial" class="hover:text-white transition-colors duration-200">Commercial Valuation</a></li>
-                        <li><a href="/services#residential" class="hover:text-white transition-colors duration-200">Residential Appraisals</a></li>
-                        <li><a href="/services#litigation" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
-                        <li><a href="/services#consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
                         <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
                     </ul>
                 </div>
                 
                 <!-- Market Areas -->
                 <div>
-                    <h3 class="text-white font-semibold text-lg mb-6">Market Areas</h3>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">London–Middlesex–Elgin</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Windsor–Essex</a></li>
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Oxford County</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Huron–Perth–Wellington</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Niagara Region</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Halton–Peel</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Full Coverage Map</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
                     </ul>
                 </div>
                 
@@ -986,7 +998,7 @@
                     <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
-                        <li><a href="../insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
+                        <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
                         <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
                     </ul>
                 </div>
@@ -1016,6 +1028,12 @@
             <!-- Copyright -->
             <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
                 <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
             </div>
         </div>
     </footer>

--- a/james-sibbald/index.html
+++ b/james-sibbald/index.html
@@ -112,17 +112,17 @@
     <!-- Global Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex items-center justify-between h-20">
+            <div class="flex items-center justify-between h-16 sm:h-20">
                 <!-- Logo -->
                 <div class="flex-shrink-0">
                     <a href="/">
-                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
                     </a>
                 </div>
                 
                 <!-- Desktop Navigation -->
-                <div class="hidden md:flex items-center space-x-8">
-                    <a href="/" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Home</a>
+                <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
+                    <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
                     <div class="relative group">
                         <a href="/services" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Services</a>
                         <!-- Mega Menu -->
@@ -131,23 +131,23 @@
                                 <div>
                                     <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
                                     <div class="space-y-1">
-                                        <a href="/services#commercial" class="mega-menu-item block p-4">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
                                         </a>
-                                        <a href="/services#residential" class="mega-menu-item block p-4">
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
                                         </a>
-                                        <a href="/services#litigation" class="mega-menu-item block p-4">
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
                                         </a>
-                                        <a href="/services#consulting" class="mega-menu-item block p-4">
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
                                         </a>
-                                        <a href="/services#government" class="mega-menu-item block p-4">
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
                                         </a>
@@ -156,20 +156,70 @@
                             </div>
                         </div>
                     </div>
-                    <a href="/market-areas" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Market Areas</a>
-                    <a href="/team" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Team</a>
-                    <!-- <a href="/insights/" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Market Insights</a> -->
-                    <a href="/contact" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Contact</a>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link active text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
                 </div>
                 
                 <!-- CTA Button -->
                 <div class="hidden md:block">
-                    <a href="/contact" class="inline-flex items-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-black-dark transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg">
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
                         Connect with an Appraiser
                     </a>
                 </div>
+                
+                <!-- Mobile menu button -->
+                <div class="md:hidden">
+                    <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
+                        <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                        </div>
+                    </button>
+                </div>
             </div>
         </nav>
+
+        <!-- Mobile Menu -->
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+            
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link active">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+                    
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+
+        <!-- Mobile Menu Overlay -->
+        <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
     </header>
 
     <!-- Hero Section -->
@@ -396,49 +446,61 @@
 
     <!-- Professional Footer -->
     <footer class="bg-black text-white">
-        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-12 mb-12 text-center lg:text-left">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
                 <!-- Company Info -->
                 <div class="lg:col-span-1">
-                    <div class="flex justify-center lg:justify-start items-center gap-3 mb-6">
-                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 w-auto brightness-0 invert">
-                    </div>
-                    <p class="text-gray-300 mb-6 leading-relaxed text-sm">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-6 leading-relaxed">
                         Trusted • Valued • Experienced
                     </p>
-                    <div class="text-gray-300 text-sm space-y-1">
-                        <p class="font-semibold text-white">620A Richmond Street, Suite 203</p>
-                        <p>London, ON N6A 5J9</p>
-                        <p class="mt-3 flex items-center">
-                            <svg class="w-4 h-4 mr-2 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <div class="text-gray-300">
+                        <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
+                        <p class="mb-4">London, ON N6A 5J9</p>
+                        <p class="font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
                             </svg>
                             <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
                         </p>
-                        <p>Toll Free: 866 672 9101</p>
+                        <p>Toll Free: 1-866-672-9101</p>
                         <p>Fax: (519) 672-9321</p>
+                        <p class="mt-4 font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                            </svg>
+                            <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
+                        </p>
                     </div>
                 </div>
                 
                 <!-- Services -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
-                    <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/services#commercial" class="hover:text-white transition-colors duration-200">Commercial Valuation</a></li>
-                        <li><a href="/services#residential" class="hover:text-white transition-colors duration-200">Residential Appraisals</a></li>
-                        <li><a href="/services#litigation" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
-                        <li><a href="/services" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                    <ul class="space-y-3 text-gray-300">
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
+                        <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
                     </ul>
                 </div>
                 
                 <!-- Market Areas -->
                 <div>
-                    <h3 class="text-white font-semibold text-lg mb-6">Market Areas</h3>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Ontario Coverage</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Urban Markets</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Industrial Properties</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Rural & Agricultural</a></li>
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
                     </ul>
                 </div>
                 
@@ -447,9 +509,7 @@
                     <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
-                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">About Us</a></li>
                         <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
-                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">Careers</a></li>
                         <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
                     </ul>
                 </div>
@@ -460,16 +520,31 @@
                 <div class="mb-6">
                     <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
                 </div>
-                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300">
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
                     <span>AIC - Appraisal Institute of Canada</span>
-                    <span>OREA - Ontario Real Estate Association</span>
-                    <span>CREA - Canadian Real Estate Association</span>
+                    <span>RICS - Royal Institution of Chartered Surveyors</span>
+                    <span>AOLE - Association of Ontario Land Economists</span>
+                    <span>IRWA - International Right of Way Association</span>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6">
+                    <span>Data Providers:</span>
+                    <span>CoStar Professional</span>
+                    <span>TRREB - Toronto Regional Real Estate Board</span>
+                </div>
+                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
+                    <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
                 </div>
             </div>
             
             <!-- Copyright -->
             <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
                 <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
             </div>
         </div>
     </footer>

--- a/jeff-petruzella/index.html
+++ b/jeff-petruzella/index.html
@@ -91,34 +91,114 @@
     <!-- Global Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex items-center justify-between h-20">
+            <div class="flex items-center justify-between h-16 sm:h-20">
                 <!-- Logo -->
                 <div class="flex-shrink-0">
                     <a href="/">
-                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
                     </a>
                 </div>
                 
                 <!-- Desktop Navigation -->
-                <div class="hidden md:flex items-center space-x-8">
-                    <a href="/" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Home</a>
+                <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
+                    <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
                     <div class="relative group">
-                        <a href="/services" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Services</a>
+                        <a href="/services" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Services</a>
+                        <!-- Mega Menu -->
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-96 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50 backdrop-blur-sm">
+                            <div class="p-8">
+                                <div>
+                                    <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
+                                    <div class="space-y-1">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
+                                        </a>
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
+                                        </a>
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
+                                        </a>
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
+                                        </a>
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                     </div>
-                    <a href="/market-areas" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Market Areas</a>
-                    <a href="/team" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Team</a>
-                    <!-- <a href="/insights/" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Market Insights</a> -->
-                    <a href="/contact" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Contact</a>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link active text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
                 </div>
                 
                 <!-- CTA Button -->
                 <div class="hidden md:block">
-                    <a href="/contact" class="inline-flex items-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-black-dark transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg">
-                        Request an Appraisal
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
+                        Connect with an Appraiser
                     </a>
+                </div>
+                
+                <!-- Mobile menu button -->
+                <div class="md:hidden">
+                    <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
+                        <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                        </div>
+                    </button>
                 </div>
             </div>
         </nav>
+
+        <!-- Mobile Menu -->
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+            
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link active">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+                    
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+
+        <!-- Mobile Menu Overlay -->
+        <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
     </header>
 
     <!-- Hero Section -->
@@ -320,49 +400,61 @@
 
     <!-- Professional Footer -->
     <footer class="bg-black text-white">
-        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-12 mb-12 text-center lg:text-left">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
                 <!-- Company Info -->
                 <div class="lg:col-span-1">
-                    <div class="flex justify-center lg:justify-start items-center gap-3 mb-6">
-                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 w-auto brightness-0 invert">
-                    </div>
-                    <p class="text-gray-300 mb-6 leading-relaxed text-sm">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-6 leading-relaxed">
                         Trusted • Valued • Experienced
                     </p>
-                    <div class="text-gray-300 text-sm space-y-1">
-                        <p class="font-semibold text-white">620A Richmond Street, Suite 203</p>
-                        <p>London, ON N6A 5J9</p>
-                        <p class="mt-3 flex items-center">
-                            <svg class="w-4 h-4 mr-2 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <div class="text-gray-300">
+                        <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
+                        <p class="mb-4">London, ON N6A 5J9</p>
+                        <p class="font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
                             </svg>
                             <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
                         </p>
-                        <p>Toll Free: 866 672 9101</p>
+                        <p>Toll Free: 1-866-672-9101</p>
                         <p>Fax: (519) 672-9321</p>
+                        <p class="mt-4 font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                            </svg>
+                            <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
+                        </p>
                     </div>
                 </div>
                 
                 <!-- Services -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
-                    <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/services#commercial" class="hover:text-white transition-colors duration-200">Commercial Valuation</a></li>
-                        <li><a href="/services#residential" class="hover:text-white transition-colors duration-200">Residential Appraisals</a></li>
-                        <li><a href="/services#litigation" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
-                        <li><a href="/services" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                    <ul class="space-y-3 text-gray-300">
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
+                        <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
                     </ul>
                 </div>
                 
                 <!-- Market Areas -->
                 <div>
-                    <h3 class="text-white font-semibold text-lg mb-6">Market Areas</h3>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Ontario Coverage</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Urban Markets</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Industrial Properties</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Rural & Agricultural</a></li>
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
                     </ul>
                 </div>
                 
@@ -371,9 +463,7 @@
                     <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
-                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">About Us</a></li>
                         <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
-                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">Careers</a></li>
                         <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
                     </ul>
                 </div>
@@ -384,16 +474,31 @@
                 <div class="mb-6">
                     <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
                 </div>
-                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300">
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
                     <span>AIC - Appraisal Institute of Canada</span>
-                    <span>OREA - Ontario Real Estate Association</span>
-                    <span>CREA - Canadian Real Estate Association</span>
+                    <span>RICS - Royal Institution of Chartered Surveyors</span>
+                    <span>AOLE - Association of Ontario Land Economists</span>
+                    <span>IRWA - International Right of Way Association</span>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6">
+                    <span>Data Providers:</span>
+                    <span>CoStar Professional</span>
+                    <span>TRREB - Toronto Regional Real Estate Board</span>
+                </div>
+                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
+                    <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
                 </div>
             </div>
             
             <!-- Copyright -->
             <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
                 <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
             </div>
         </div>
     </footer>

--- a/john-carter/index.html
+++ b/john-carter/index.html
@@ -91,17 +91,17 @@
     <!-- Global Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex items-center justify-between h-20">
+            <div class="flex items-center justify-between h-16 sm:h-20">
                 <!-- Logo -->
                 <div class="flex-shrink-0">
                     <a href="/">
-                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
                     </a>
                 </div>
                 
                 <!-- Desktop Navigation -->
-                <div class="hidden md:flex items-center space-x-8">
-                    <a href="/" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Home</a>
+                <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
+                    <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
                     <div class="relative group">
                         <a href="/services" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Services</a>
                         <!-- Mega Menu -->
@@ -110,23 +110,23 @@
                                 <div>
                                     <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
                                     <div class="space-y-1">
-                                        <a href="/services#commercial" class="mega-menu-item block p-4">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
                                         </a>
-                                        <a href="/services#residential" class="mega-menu-item block p-4">
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
                                         </a>
-                                        <a href="/services#litigation" class="mega-menu-item block p-4">
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
                                         </a>
-                                        <a href="/services#consulting" class="mega-menu-item block p-4">
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
                                         </a>
-                                        <a href="/services#government" class="mega-menu-item block p-4">
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
                                         </a>
@@ -135,20 +135,70 @@
                             </div>
                         </div>
                     </div>
-                    <a href="/market-areas" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Market Areas</a>
-                    <a href="/team" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Team</a>
-                    <!-- <a href="/insights/" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Market Insights</a> -->
-                    <a href="/contact" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Contact</a>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link active text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
                 </div>
                 
                 <!-- CTA Button -->
                 <div class="hidden md:block">
-                    <a href="/contact" class="inline-flex items-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-black-dark transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg">
-                        Request an Appraisal
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
+                        Connect with an Appraiser
                     </a>
+                </div>
+                
+                <!-- Mobile menu button -->
+                <div class="md:hidden">
+                    <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
+                        <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                        </div>
+                    </button>
                 </div>
             </div>
         </nav>
+
+        <!-- Mobile Menu -->
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+            
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link active">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+                    
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+
+        <!-- Mobile Menu Overlay -->
+        <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
     </header>
 
     <!-- Hero Section -->
@@ -386,49 +436,61 @@
 
     <!-- Professional Footer -->
     <footer class="bg-black text-white">
-        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-12 mb-12 text-center lg:text-left">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
                 <!-- Company Info -->
                 <div class="lg:col-span-1">
-                    <div class="flex justify-center lg:justify-start items-center gap-3 mb-6">
-                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 w-auto brightness-0 invert">
-                    </div>
-                    <p class="text-gray-300 mb-6 leading-relaxed text-sm">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-6 leading-relaxed">
                         Trusted • Valued • Experienced
                     </p>
-                    <div class="text-gray-300 text-sm space-y-1">
-                        <p class="font-semibold text-white">620A Richmond Street, Suite 203</p>
-                        <p>London, ON N6A 5J9</p>
-                        <p class="mt-3 flex items-center">
-                            <svg class="w-4 h-4 mr-2 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <div class="text-gray-300">
+                        <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
+                        <p class="mb-4">London, ON N6A 5J9</p>
+                        <p class="font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
                             </svg>
                             <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
                         </p>
-                        <p>Toll Free: 866 672 9101</p>
+                        <p>Toll Free: 1-866-672-9101</p>
                         <p>Fax: (519) 672-9321</p>
+                        <p class="mt-4 font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                            </svg>
+                            <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
+                        </p>
                     </div>
                 </div>
                 
                 <!-- Services -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
-                    <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/services#commercial" class="hover:text-white transition-colors duration-200">Commercial Valuation</a></li>
-                        <li><a href="/services#residential" class="hover:text-white transition-colors duration-200">Residential Appraisals</a></li>
-                        <li><a href="/services#litigation" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
-                        <li><a href="/services" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                    <ul class="space-y-3 text-gray-300">
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
+                        <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
                     </ul>
                 </div>
                 
                 <!-- Market Areas -->
                 <div>
-                    <h3 class="text-white font-semibold text-lg mb-6">Market Areas</h3>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Ontario Coverage</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Urban Markets</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Industrial Properties</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Rural & Agricultural</a></li>
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
                     </ul>
                 </div>
                 
@@ -437,9 +499,7 @@
                     <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
-                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">About Us</a></li>
                         <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
-                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">Careers</a></li>
                         <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
                     </ul>
                 </div>
@@ -450,16 +510,31 @@
                 <div class="mb-6">
                     <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
                 </div>
-                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300">
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
                     <span>AIC - Appraisal Institute of Canada</span>
-                    <span>OREA - Ontario Real Estate Association</span>
-                    <span>CREA - Canadian Real Estate Association</span>
+                    <span>RICS - Royal Institution of Chartered Surveyors</span>
+                    <span>AOLE - Association of Ontario Land Economists</span>
+                    <span>IRWA - International Right of Way Association</span>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6">
+                    <span>Data Providers:</span>
+                    <span>CoStar Professional</span>
+                    <span>TRREB - Toronto Regional Real Estate Board</span>
+                </div>
+                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
+                    <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
                 </div>
             </div>
             
             <!-- Copyright -->
             <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
                 <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
             </div>
         </div>
     </footer>

--- a/london/commercial-appraisal/index.html
+++ b/london/commercial-appraisal/index.html
@@ -3,14 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Commercial Appraisal London Ontario | AACI Certified | Metrix Realty Group</title>
+    <title>Commercial Appraisal London Ontario | Metrix Realty</title>
     <link rel="icon" type="image/png" href="/favicon.png">
-    <meta name="description" content="Commercial appraisal London Ontario by AACI-designated professionals. Office, retail, industrial, and investment property valuations accepted by all major Canadian lenders. 30+ years serving London and Southwestern Ontario.">
+    <meta name="description" content="Commercial appraisals in London, Ontario by AACI-certified professionals. Expert valuations for offices, retail, and industrial properties. Lender approved.">
     <link rel="canonical" href="https://metrixrealty.com/london/commercial-appraisal">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Metrix Realty Group">
-    <meta property="og:title" content="Commercial Appraisal London Ontario | AACI Certified | Metrix Realty Group">
-    <meta property="og:description" content="Commercial appraisal London Ontario by AACI-designated professionals. Office, retail, industrial, and investment property valuations accepted by all major Canadian lenders.">
+    <meta property="og:title" content="Commercial Appraisal London Ontario | Metrix Realty">
+    <meta property="og:description" content="Commercial appraisals in London, Ontario by AACI-certified professionals. Expert valuations for offices, retail, and industrial properties. Lender approved.">
     <meta property="og:url" content="https://metrixrealty.com/london/commercial-appraisal">
     <meta property="og:image" content="https://metrixrealty.com/assets/images/metrix-realty-logo.png">
     <meta name="twitter:card" content="summary_large_image">
@@ -159,48 +159,71 @@
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex items-center justify-between h-16 sm:h-20">
+                <!-- Logo -->
                 <div class="flex-shrink-0">
-                    <a href="/"><img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto"></a>
+                    <a href="/">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
+                    </a>
                 </div>
+                
+                <!-- Desktop Navigation -->
                 <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
-                    <a href="/" class="nav-link text-gray-900 font-semibold">Home</a>
+                    <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
                     <div class="relative group">
-                        <a href="/services" class="nav-link active text-gray-900 font-semibold">Services</a>
+                        <a href="/services" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Services</a>
+                        <!-- Mega Menu -->
                         <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-96 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50 backdrop-blur-sm">
                             <div class="p-8">
-                                <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
-                                <div class="space-y-1">
-                                    <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
-                                        <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
-                                        <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
-                                    </a>
-                                    <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
-                                        <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
-                                        <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
-                                    </a>
-                                    <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
-                                        <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
-                                        <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
-                                    </a>
-                                    <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
-                                        <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
-                                        <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
-                                    </a>
-                                    <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
-                                        <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
-                                        <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
-                                    </a>
+                                <div>
+                                    <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
+                                    <div class="space-y-1">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
+                                        </a>
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
+                                        </a>
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
+                                        </a>
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
+                                        </a>
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
+                                        </a>
+                                    </div>
                                 </div>
                             </div>
                         </div>
                     </div>
-                    <a href="/market-areas" class="nav-link text-gray-900 font-semibold">Market Areas</a>
-                    <a href="/team" class="nav-link text-gray-900 font-semibold">Team</a>
-                    <a href="/contact" class="nav-link text-gray-900 font-semibold">Contact</a>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link active text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
                 </div>
+                
+                <!-- CTA Button -->
                 <div class="hidden md:block">
-                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">Connect with an Appraiser</a>
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
+                        Connect with an Appraiser
+                    </a>
                 </div>
+                
+                <!-- Mobile menu button -->
                 <div class="md:hidden">
                     <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
                         <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
@@ -212,23 +235,36 @@
                 </div>
             </div>
         </nav>
+
+        <!-- Mobile Menu -->
         <div id="mobile-menu" class="mobile-menu md:hidden">
             <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
-                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
             </button>
+            
             <div class="mobile-menu-content">
                 <nav class="mobile-nav">
                     <a href="/" class="mobile-nav-link">Home</a>
-                    <a href="/services" class="mobile-nav-link active">Services</a>
-                    <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link active">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
                     <a href="/team" class="mobile-nav-link">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
                     <a href="/contact" class="mobile-nav-link">Contact</a>
-                    <div style="margin-top:32px;">
-                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">Connect with an Appraiser</a>
+                    
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
                     </div>
                 </nav>
             </div>
         </div>
+
+        <!-- Mobile Menu Overlay -->
         <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
     </header>
 
@@ -470,34 +506,106 @@
     </section>
 
     <!-- Footer -->
-    <footer class="bg-gray-900 text-white py-12">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-8 mb-8">
-                <div>
-                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 w-auto mb-4 brightness-0 invert">
-                    <p class="text-gray-400 text-sm">London Ontario's leading commercial real estate appraisal firm since 1995.</p>
+    <footer class="bg-black text-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
+                <!-- Company Info -->
+                <div class="lg:col-span-1">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-6 leading-relaxed">
+                        Trusted • Valued • Experienced
+                    </p>
+                    <div class="text-gray-300">
+                        <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
+                        <p class="mb-4">London, ON N6A 5J9</p>
+                        <p class="font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
+                            </svg>
+                            <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
+                        </p>
+                        <p>Toll Free: 1-866-672-9101</p>
+                        <p>Fax: (519) 672-9321</p>
+                        <p class="mt-4 font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                            </svg>
+                            <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
+                        </p>
+                    </div>
                 </div>
+                
+                <!-- Services -->
                 <div>
-                    <h4 class="font-semibold mb-3">Services</h4>
-                    <ul class="space-y-2 text-gray-400 text-sm">
-                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors">Commercial Valuations</a></li>
-                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors">Residential Appraisals</a></li>
-                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors">Litigation Support</a></li>
-                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors">Government &amp; Institutional</a></li>
+                    <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
+                    <ul class="space-y-3 text-gray-300">
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
+                        <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
                     </ul>
                 </div>
+                
+                <!-- Market Areas -->
                 <div>
-                    <h4 class="font-semibold mb-3">London Office</h4>
-                    <address class="text-gray-400 text-sm not-italic space-y-1">
-                        <p>620A Richmond Street, Suite 203</p>
-                        <p>London, ON N6A 5J9</p>
-                        <p><a href="tel:5196727550" class="hover:text-white transition-colors">(519) 672-7550</a></p>
-                        <p><a href="mailto:info@metrixrealty.com" class="hover:text-white transition-colors">info@metrixrealty.com</a></p>
-                    </address>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
+                    </ul>
+                </div>
+                
+                <!-- Company -->
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
+                        <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
+                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
+                    </ul>
                 </div>
             </div>
-            <div class="border-t border-gray-800 pt-6 text-center text-gray-500 text-sm">
-                <p>&copy; 2025 Metrix Realty Group. All rights reserved. Reports completed in compliance with CUSPAP.</p>
+            
+            <!-- Professional Affiliations -->
+            <div class="border-t border-gray-800 pt-8 mb-8 text-center">
+                <div class="mb-6">
+                    <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
+                    <span>AIC - Appraisal Institute of Canada</span>
+                    <span>RICS - Royal Institution of Chartered Surveyors</span>
+                    <span>AOLE - Association of Ontario Land Economists</span>
+                    <span>IRWA - International Right of Way Association</span>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6">
+                    <span>Data Providers:</span>
+                    <span>CoStar Professional</span>
+                    <span>TRREB - Toronto Regional Real Estate Board</span>
+                </div>
+                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
+                    <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
+                </div>
+            </div>
+            
+            <!-- Copyright -->
+            <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
+                <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
             </div>
         </div>
     </footer>

--- a/london/index.html
+++ b/london/index.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Best Commercial Real Estate Appraiser London Ontario | ICI Specialists | Metrix Realty Group</title>
-    <meta name="description" content="Metrix Realty Group is London, Ontario's #1 commercial real estate appraisal firm. AACI-designated ICI (Industrial, Commercial, Investment) specialists. Lender-recognized valuations, expert witness testimony. Founded 1995. Call (519) 672-7550.">
+    <title>Commercial Real Estate Appraiser London Ontario | Metrix</title>
+    <meta name="description" content="AACI-certified real estate appraisers in London, Ontario. Expert commercial, residential, and industrial valuations for lenders, legal matters, and estates.">
     <meta name="keywords" content="best commercial appraiser London Ontario, ICI appraisal London Ontario, commercial real estate appraisal London, AACI appraiser London Ontario, property valuation London ON, industrial commercial investment appraiser London, expert witness London Ontario, lender recognized appraisal London, top appraisal firm London Ontario, Metrix Realty Group London">
     <meta name="robots" content="index, follow">
     <meta name="author" content="Metrix Realty Group">
@@ -27,8 +27,8 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://metrixrealty.com/london/">
-    <meta property="og:title" content="Best Commercial Real Estate Appraiser London Ontario | Metrix Realty Group">
-    <meta property="og:description" content="Metrix Realty Group is London, Ontario's leading ICI (Industrial, Commercial, Investment) appraisal firm. AACI-designated professionals, lender-recognized valuations, expert witness testimony. Founded 1995.">
+    <meta property="og:title" content="Commercial Real Estate Appraiser London Ontario | Metrix">
+    <meta property="og:description" content="AACI-certified real estate appraisers in London, Ontario. Expert commercial, residential, and industrial valuations for lenders, legal matters, and estates.">
     <meta property="og:image" content="https://metrixrealty.com/assets/images/metrix-realty-logo.png">
 
     <!-- Twitter -->
@@ -438,29 +438,73 @@
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex items-center justify-between h-16 sm:h-20">
+                <!-- Logo -->
                 <div class="flex-shrink-0">
                     <a href="/">
-                        <img src="../assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
                     </a>
                 </div>
                 
+                <!-- Desktop Navigation -->
                 <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
-                    <a href="/" class="nav-link text-gray-900 font-semibold">Home</a>
-                    <a href="/services" class="nav-link text-gray-900 font-semibold">Services</a>
-                    <a href="/market-areas" class="nav-link active text-gray-900 font-semibold">Market Areas</a>
-                    <a href="/team" class="nav-link text-gray-900 font-semibold">Team</a>
-                    <a href="/contact" class="nav-link text-gray-900 font-semibold">Contact</a>
+                    <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
+                    <div class="relative group">
+                        <a href="/services" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Services</a>
+                        <!-- Mega Menu -->
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-96 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50 backdrop-blur-sm">
+                            <div class="p-8">
+                                <div>
+                                    <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
+                                    <div class="space-y-1">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
+                                        </a>
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
+                                        </a>
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
+                                        </a>
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
+                                        </a>
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link active text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
                 </div>
                 
+                <!-- CTA Button -->
                 <div class="hidden md:block">
-                    <a href="/contact" class="inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
                         Connect with an Appraiser
                     </a>
                 </div>
                 
                 <!-- Mobile menu button -->
                 <div class="md:hidden">
-                    <button id="mobile-menu-button" class="text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
+                    <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
                         <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
                             <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
                             <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
@@ -470,6 +514,37 @@
                 </div>
             </div>
         </nav>
+
+        <!-- Mobile Menu -->
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+            
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link active">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+                    
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+
+        <!-- Mobile Menu Overlay -->
+        <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
     </header>
 
     <main>
@@ -886,14 +961,14 @@
     <footer class="bg-black text-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
+                <!-- Company Info -->
                 <div class="lg:col-span-1">
-                    <img src="../assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
                     <p class="text-gray-300 mb-6 leading-relaxed">
                         Trusted • Valued • Experienced
                     </p>
                     <div class="text-gray-300">
-                        <p class="font-semibold text-white mb-2">London Office (Headquarters)</p>
-                        <p>620 Richmond St, Suite 203</p>
+                        <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
                         <p class="mb-4">London, ON N6A 5J9</p>
                         <p class="font-semibold text-white flex items-center">
                             <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -902,48 +977,87 @@
                             <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
                         </p>
                         <p>Toll Free: 1-866-672-9101</p>
+                        <p>Fax: (519) 672-9321</p>
+                        <p class="mt-4 font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                            </svg>
+                            <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
+                        </p>
                     </div>
                 </div>
                 
+                <!-- Services -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
                     <ul class="space-y-3 text-gray-300">
-                        <li><a href="/london/commercial-appraisal" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
-                        <li><a href="/london/residential-appraisal" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
-                        <li><a href="/london/industrial-appraisal" class="hover:text-white transition-colors duration-200">Industrial Appraisal</a></li>
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
                         <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
                         <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
                     </ul>
                 </div>
                 
+                <!-- Market Areas -->
                 <div>
-                    <h3 class="text-white font-semibold text-lg mb-6">Locations</h3>
-                    <ul class="space-y-3 text-gray-300">
-                        <li><a href="../london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
-                        <li><a href="../windsor/" class="hover:text-white transition-colors duration-200">Windsor</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Market Areas</a></li>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
                     </ul>
                 </div>
                 
+                <!-- Company -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
-                    <ul class="space-y-3 text-gray-300">
+                    <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
+                        <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
                         <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
                     </ul>
                 </div>
             </div>
             
+            <!-- Professional Affiliations -->
             <div class="border-t border-gray-800 pt-8 mb-8 text-center">
+                <div class="mb-6">
+                    <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
+                </div>
                 <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
                     <span>AIC - Appraisal Institute of Canada</span>
                     <span>RICS - Royal Institution of Chartered Surveyors</span>
                     <span>AOLE - Association of Ontario Land Economists</span>
+                    <span>IRWA - International Right of Way Association</span>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6">
+                    <span>Data Providers:</span>
+                    <span>CoStar Professional</span>
+                    <span>TRREB - Toronto Regional Real Estate Board</span>
+                </div>
+                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
+                    <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
                 </div>
             </div>
             
+            <!-- Copyright -->
             <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
                 <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
             </div>
         </div>
     </footer>
@@ -961,6 +1075,8 @@
                 <a href="/" class="mobile-nav-link">Home</a>
                 <a href="/services" class="mobile-nav-link">Services</a>
                 <a href="/market-areas" class="mobile-nav-link active">Market Areas</a>
+                <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
                 <a href="/team" class="mobile-nav-link">Team</a>
                 <a href="/contact" class="mobile-nav-link">Contact</a>
                 

--- a/london/industrial-appraisal/index.html
+++ b/london/industrial-appraisal/index.html
@@ -3,14 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Industrial Appraisal London Ontario | AACI Certified | Metrix Realty Group</title>
+    <title>Industrial Appraisal London Ontario | Metrix Realty</title>
     <link rel="icon" type="image/png" href="/favicon.png">
-    <meta name="description" content="Industrial property appraisal London Ontario by AACI-designated professionals. Warehouse, manufacturing, flex industrial, and logistics valuations accepted by all major Canadian lenders.">
+    <meta name="description" content="Industrial property appraisals in London, Ontario by AACI-certified professionals. Expert valuations for manufacturing, warehousing, and industrial assets.">
     <link rel="canonical" href="https://metrixrealty.com/london/industrial-appraisal">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Metrix Realty Group">
-    <meta property="og:title" content="Industrial Appraisal London Ontario | AACI Certified | Metrix Realty Group">
-    <meta property="og:description" content="Industrial property appraisal London Ontario by AACI-designated professionals. Warehouse, manufacturing, and logistics valuations accepted by all major Canadian lenders.">
+    <meta property="og:title" content="Industrial Appraisal London Ontario | Metrix Realty">
+    <meta property="og:description" content="Industrial property appraisals in London, Ontario by AACI-certified professionals. Expert valuations for manufacturing, warehousing, and industrial assets.">
     <meta property="og:url" content="https://metrixrealty.com/london/industrial-appraisal">
     <meta property="og:image" content="https://metrixrealty.com/assets/images/metrix-realty-logo.png">
     <meta name="twitter:card" content="summary_large_image">
@@ -149,48 +149,71 @@
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex items-center justify-between h-16 sm:h-20">
+                <!-- Logo -->
                 <div class="flex-shrink-0">
-                    <a href="/"><img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto"></a>
+                    <a href="/">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
+                    </a>
                 </div>
+                
+                <!-- Desktop Navigation -->
                 <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
-                    <a href="/" class="nav-link text-gray-900 font-semibold">Home</a>
+                    <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
                     <div class="relative group">
-                        <a href="/services" class="nav-link active text-gray-900 font-semibold">Services</a>
+                        <a href="/services" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Services</a>
+                        <!-- Mega Menu -->
                         <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-96 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50 backdrop-blur-sm">
                             <div class="p-8">
-                                <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
-                                <div class="space-y-1">
-                                    <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
-                                        <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
-                                        <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
-                                    </a>
-                                    <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
-                                        <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
-                                        <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
-                                    </a>
-                                    <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
-                                        <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
-                                        <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
-                                    </a>
-                                    <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
-                                        <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
-                                        <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
-                                    </a>
-                                    <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
-                                        <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
-                                        <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
-                                    </a>
+                                <div>
+                                    <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
+                                    <div class="space-y-1">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
+                                        </a>
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
+                                        </a>
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
+                                        </a>
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
+                                        </a>
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
+                                        </a>
+                                    </div>
                                 </div>
                             </div>
                         </div>
                     </div>
-                    <a href="/market-areas" class="nav-link text-gray-900 font-semibold">Market Areas</a>
-                    <a href="/team" class="nav-link text-gray-900 font-semibold">Team</a>
-                    <a href="/contact" class="nav-link text-gray-900 font-semibold">Contact</a>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link active text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
                 </div>
+                
+                <!-- CTA Button -->
                 <div class="hidden md:block">
-                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">Connect with an Appraiser</a>
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
+                        Connect with an Appraiser
+                    </a>
                 </div>
+                
+                <!-- Mobile menu button -->
                 <div class="md:hidden">
                     <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
                         <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
@@ -202,23 +225,36 @@
                 </div>
             </div>
         </nav>
+
+        <!-- Mobile Menu -->
         <div id="mobile-menu" class="mobile-menu md:hidden">
             <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
-                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
             </button>
+            
             <div class="mobile-menu-content">
                 <nav class="mobile-nav">
                     <a href="/" class="mobile-nav-link">Home</a>
-                    <a href="/services" class="mobile-nav-link active">Services</a>
-                    <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link active">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
                     <a href="/team" class="mobile-nav-link">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
                     <a href="/contact" class="mobile-nav-link">Contact</a>
-                    <div style="margin-top:32px;">
-                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">Connect with an Appraiser</a>
+                    
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
                     </div>
                 </nav>
             </div>
         </div>
+
+        <!-- Mobile Menu Overlay -->
         <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
     </header>
 
@@ -353,34 +389,106 @@
         </div>
     </section>
 
-    <footer class="bg-gray-900 text-white py-12">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-8 mb-8">
-                <div>
-                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 w-auto mb-4 brightness-0 invert">
-                    <p class="text-gray-400 text-sm">London Ontario's leading commercial real estate appraisal firm since 1995.</p>
+    <footer class="bg-black text-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
+                <!-- Company Info -->
+                <div class="lg:col-span-1">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-6 leading-relaxed">
+                        Trusted • Valued • Experienced
+                    </p>
+                    <div class="text-gray-300">
+                        <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
+                        <p class="mb-4">London, ON N6A 5J9</p>
+                        <p class="font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
+                            </svg>
+                            <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
+                        </p>
+                        <p>Toll Free: 1-866-672-9101</p>
+                        <p>Fax: (519) 672-9321</p>
+                        <p class="mt-4 font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                            </svg>
+                            <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
+                        </p>
+                    </div>
                 </div>
+                
+                <!-- Services -->
                 <div>
-                    <h4 class="font-semibold mb-3">Services</h4>
-                    <ul class="space-y-2 text-gray-400 text-sm">
-                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors">Commercial Valuations</a></li>
-                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors">Residential Appraisals</a></li>
-                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors">Litigation Support</a></li>
-                        <li><a href="/london/commercial-appraisal" class="hover:text-white transition-colors">Commercial Appraisal London</a></li>
+                    <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
+                    <ul class="space-y-3 text-gray-300">
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
+                        <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
                     </ul>
                 </div>
+                
+                <!-- Market Areas -->
                 <div>
-                    <h4 class="font-semibold mb-3">London Office</h4>
-                    <address class="text-gray-400 text-sm not-italic space-y-1">
-                        <p>620A Richmond Street, Suite 203</p>
-                        <p>London, ON N6A 5J9</p>
-                        <p><a href="tel:5196727550" class="hover:text-white transition-colors">(519) 672-7550</a></p>
-                        <p><a href="mailto:info@metrixrealty.com" class="hover:text-white transition-colors">info@metrixrealty.com</a></p>
-                    </address>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
+                    </ul>
+                </div>
+                
+                <!-- Company -->
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
+                        <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
+                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
+                    </ul>
                 </div>
             </div>
-            <div class="border-t border-gray-800 pt-6 text-center text-gray-500 text-sm">
-                <p>&copy; 2025 Metrix Realty Group. All rights reserved. Reports completed in compliance with CUSPAP.</p>
+            
+            <!-- Professional Affiliations -->
+            <div class="border-t border-gray-800 pt-8 mb-8 text-center">
+                <div class="mb-6">
+                    <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
+                    <span>AIC - Appraisal Institute of Canada</span>
+                    <span>RICS - Royal Institution of Chartered Surveyors</span>
+                    <span>AOLE - Association of Ontario Land Economists</span>
+                    <span>IRWA - International Right of Way Association</span>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6">
+                    <span>Data Providers:</span>
+                    <span>CoStar Professional</span>
+                    <span>TRREB - Toronto Regional Real Estate Board</span>
+                </div>
+                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
+                    <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
+                </div>
+            </div>
+            
+            <!-- Copyright -->
+            <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
+                <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
             </div>
         </div>
     </footer>

--- a/london/residential-appraisal/index.html
+++ b/london/residential-appraisal/index.html
@@ -3,14 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Residential Appraisal London Ontario | AACI & CRA Certified | Metrix Realty Group</title>
+    <title>Home Appraisal London Ontario | AACI Certified | Metrix</title>
     <link rel="icon" type="image/png" href="/favicon.png">
-    <meta name="description" content="Residential appraisal London Ontario by AACI and CRA designated professionals. Home valuations for mortgage financing, estate planning, divorce proceedings, and MPAC appeals. Lender approved.">
+    <meta name="description" content="Home appraisals in London, Ontario by AACI and CRA-designated professionals. Expert residential valuations for mortgages, estates, and legal matters.">
     <link rel="canonical" href="https://metrixrealty.com/london/residential-appraisal">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Metrix Realty Group">
-    <meta property="og:title" content="Residential Appraisal London Ontario | AACI &amp; CRA Certified | Metrix Realty Group">
-    <meta property="og:description" content="Residential appraisal London Ontario by AACI and CRA designated professionals. Home valuations for mortgage financing, estate planning, divorce proceedings, and MPAC appeals.">
+    <meta property="og:title" content="Home Appraisal London Ontario | AACI Certified | Metrix">
+    <meta property="og:description" content="Home appraisals in London, Ontario by AACI and CRA-designated professionals. Expert residential valuations for mortgages, estates, and legal matters.">
     <meta property="og:url" content="https://metrixrealty.com/london/residential-appraisal">
     <meta property="og:image" content="https://metrixrealty.com/assets/images/metrix-realty-logo.png">
     <meta name="twitter:card" content="summary_large_image">
@@ -157,48 +157,71 @@
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex items-center justify-between h-16 sm:h-20">
+                <!-- Logo -->
                 <div class="flex-shrink-0">
-                    <a href="/"><img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto"></a>
+                    <a href="/">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
+                    </a>
                 </div>
+                
+                <!-- Desktop Navigation -->
                 <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
-                    <a href="/" class="nav-link text-gray-900 font-semibold">Home</a>
+                    <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
                     <div class="relative group">
-                        <a href="/services" class="nav-link active text-gray-900 font-semibold">Services</a>
+                        <a href="/services" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Services</a>
+                        <!-- Mega Menu -->
                         <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-96 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50 backdrop-blur-sm">
                             <div class="p-8">
-                                <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
-                                <div class="space-y-1">
-                                    <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
-                                        <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
-                                        <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
-                                    </a>
-                                    <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
-                                        <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
-                                        <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
-                                    </a>
-                                    <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
-                                        <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
-                                        <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
-                                    </a>
-                                    <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
-                                        <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
-                                        <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
-                                    </a>
-                                    <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
-                                        <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
-                                        <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
-                                    </a>
+                                <div>
+                                    <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
+                                    <div class="space-y-1">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
+                                        </a>
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
+                                        </a>
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
+                                        </a>
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
+                                        </a>
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
+                                        </a>
+                                    </div>
                                 </div>
                             </div>
                         </div>
                     </div>
-                    <a href="/market-areas" class="nav-link text-gray-900 font-semibold">Market Areas</a>
-                    <a href="/team" class="nav-link text-gray-900 font-semibold">Team</a>
-                    <a href="/contact" class="nav-link text-gray-900 font-semibold">Contact</a>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link active text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
                 </div>
+                
+                <!-- CTA Button -->
                 <div class="hidden md:block">
-                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">Connect with an Appraiser</a>
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
+                        Connect with an Appraiser
+                    </a>
                 </div>
+                
+                <!-- Mobile menu button -->
                 <div class="md:hidden">
                     <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
                         <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
@@ -210,23 +233,36 @@
                 </div>
             </div>
         </nav>
+
+        <!-- Mobile Menu -->
         <div id="mobile-menu" class="mobile-menu md:hidden">
             <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
-                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
             </button>
+            
             <div class="mobile-menu-content">
                 <nav class="mobile-nav">
                     <a href="/" class="mobile-nav-link">Home</a>
-                    <a href="/services" class="mobile-nav-link active">Services</a>
-                    <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link active">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
                     <a href="/team" class="mobile-nav-link">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
                     <a href="/contact" class="mobile-nav-link">Contact</a>
-                    <div style="margin-top:32px;">
-                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">Connect with an Appraiser</a>
+                    
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
                     </div>
                 </nav>
             </div>
         </div>
+
+        <!-- Mobile Menu Overlay -->
         <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
     </header>
 
@@ -243,7 +279,7 @@
             </nav>
             <div class="max-w-4xl" data-aos="fade-up">
                 <p class="text-metrix-green font-semibold text-sm uppercase tracking-wider mb-3">London, Ontario</p>
-                <h1 class="text-3xl sm:text-4xl lg:text-5xl font-bold mb-6 leading-tight">Residential Appraisal in London, Ontario</h1>
+                <h1 class="text-3xl sm:text-4xl lg:text-5xl font-bold mb-6 leading-tight">Home Appraisal Services in London, Ontario</h1>
                 <p class="text-lg sm:text-xl text-white/85 mb-8 leading-relaxed max-w-3xl">Accurate, lender-approved home valuations by AACI and CRA designated appraisers. Mortgage financing, refinancing, estate settlement, divorce proceedings, and MPAC property tax appeals across London and Middlesex County.</p>
                 <div class="flex flex-col sm:flex-row gap-4">
                     <a href="/contact" class="inline-flex items-center justify-center px-8 py-4 bg-white text-metrix-blue font-semibold rounded-lg hover:bg-gray-100 transition-colors text-lg">
@@ -373,34 +409,106 @@
         </div>
     </section>
 
-    <footer class="bg-gray-900 text-white py-12">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-8 mb-8">
-                <div>
-                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 w-auto mb-4 brightness-0 invert">
-                    <p class="text-gray-400 text-sm">London Ontario's leading real estate appraisal firm since 1995.</p>
+    <footer class="bg-black text-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
+                <!-- Company Info -->
+                <div class="lg:col-span-1">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-6 leading-relaxed">
+                        Trusted • Valued • Experienced
+                    </p>
+                    <div class="text-gray-300">
+                        <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
+                        <p class="mb-4">London, ON N6A 5J9</p>
+                        <p class="font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
+                            </svg>
+                            <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
+                        </p>
+                        <p>Toll Free: 1-866-672-9101</p>
+                        <p>Fax: (519) 672-9321</p>
+                        <p class="mt-4 font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                            </svg>
+                            <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
+                        </p>
+                    </div>
                 </div>
+                
+                <!-- Services -->
                 <div>
-                    <h4 class="font-semibold mb-3">Services</h4>
-                    <ul class="space-y-2 text-gray-400 text-sm">
-                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors">Residential Appraisals</a></li>
-                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors">Commercial Valuations</a></li>
-                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors">Litigation Support</a></li>
-                        <li><a href="/london/commercial-appraisal" class="hover:text-white transition-colors">Commercial Appraisal London</a></li>
+                    <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
+                    <ul class="space-y-3 text-gray-300">
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
+                        <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
                     </ul>
                 </div>
+                
+                <!-- Market Areas -->
                 <div>
-                    <h4 class="font-semibold mb-3">London Office</h4>
-                    <address class="text-gray-400 text-sm not-italic space-y-1">
-                        <p>620A Richmond Street, Suite 203</p>
-                        <p>London, ON N6A 5J9</p>
-                        <p><a href="tel:5196727550" class="hover:text-white transition-colors">(519) 672-7550</a></p>
-                        <p><a href="mailto:info@metrixrealty.com" class="hover:text-white transition-colors">info@metrixrealty.com</a></p>
-                    </address>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
+                    </ul>
+                </div>
+                
+                <!-- Company -->
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
+                        <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
+                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
+                    </ul>
                 </div>
             </div>
-            <div class="border-t border-gray-800 pt-6 text-center text-gray-500 text-sm">
-                <p>&copy; 2025 Metrix Realty Group. All rights reserved. Reports completed in compliance with CUSPAP.</p>
+            
+            <!-- Professional Affiliations -->
+            <div class="border-t border-gray-800 pt-8 mb-8 text-center">
+                <div class="mb-6">
+                    <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
+                    <span>AIC - Appraisal Institute of Canada</span>
+                    <span>RICS - Royal Institution of Chartered Surveyors</span>
+                    <span>AOLE - Association of Ontario Land Economists</span>
+                    <span>IRWA - International Right of Way Association</span>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6">
+                    <span>Data Providers:</span>
+                    <span>CoStar Professional</span>
+                    <span>TRREB - Toronto Regional Real Estate Board</span>
+                </div>
+                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
+                    <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
+                </div>
+            </div>
+            
+            <!-- Copyright -->
+            <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
+                <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
             </div>
         </div>
     </footer>

--- a/madison-collver/index.html
+++ b/madison-collver/index.html
@@ -91,17 +91,17 @@
     <!-- Global Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex items-center justify-between h-20">
+            <div class="flex items-center justify-between h-16 sm:h-20">
                 <!-- Logo -->
                 <div class="flex-shrink-0">
                     <a href="/">
-                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
                     </a>
                 </div>
                 
                 <!-- Desktop Navigation -->
-                <div class="hidden md:flex items-center space-x-8">
-                    <a href="/" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Home</a>
+                <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
+                    <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
                     <div class="relative group">
                         <a href="/services" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Services</a>
                         <!-- Mega Menu -->
@@ -110,23 +110,23 @@
                                 <div>
                                     <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
                                     <div class="space-y-1">
-                                        <a href="/services#commercial" class="mega-menu-item block p-4">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
                                         </a>
-                                        <a href="/services#residential" class="mega-menu-item block p-4">
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
                                         </a>
-                                        <a href="/services#litigation" class="mega-menu-item block p-4">
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
                                         </a>
-                                        <a href="/services#consulting" class="mega-menu-item block p-4">
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
                                         </a>
-                                        <a href="/services#government" class="mega-menu-item block p-4">
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
                                         </a>
@@ -135,19 +135,70 @@
                             </div>
                         </div>
                     </div>
-                    <a href="/market-areas" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Market Areas</a>
-                    <a href="/team" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Team</a>
-                    <a href="/contact" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Contact</a>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link active text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
                 </div>
                 
                 <!-- CTA Button -->
                 <div class="hidden md:block">
-                    <a href="/contact" class="inline-flex items-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-black-dark transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg">
-                        Request an Appraisal
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
+                        Connect with an Appraiser
                     </a>
+                </div>
+                
+                <!-- Mobile menu button -->
+                <div class="md:hidden">
+                    <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
+                        <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                        </div>
+                    </button>
                 </div>
             </div>
         </nav>
+
+        <!-- Mobile Menu -->
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+            
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link active">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+                    
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+
+        <!-- Mobile Menu Overlay -->
+        <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
     </header>
 
     <!-- Hero Section -->
@@ -346,49 +397,61 @@
 
     <!-- Professional Footer -->
     <footer class="bg-black text-white">
-        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-12 mb-12 text-center lg:text-left">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
                 <!-- Company Info -->
                 <div class="lg:col-span-1">
-                    <div class="flex justify-center lg:justify-start items-center gap-3 mb-6">
-                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 w-auto brightness-0 invert">
-                    </div>
-                    <p class="text-gray-300 mb-6 leading-relaxed text-sm">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-6 leading-relaxed">
                         Trusted • Valued • Experienced
                     </p>
-                    <div class="text-gray-300 text-sm space-y-1">
-                        <p class="font-semibold text-white">620A Richmond Street, Suite 203</p>
-                        <p>London, ON N6A 5J9</p>
-                        <p class="mt-3 flex items-center">
-                            <svg class="w-4 h-4 mr-2 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <div class="text-gray-300">
+                        <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
+                        <p class="mb-4">London, ON N6A 5J9</p>
+                        <p class="font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
                             </svg>
                             <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
                         </p>
-                        <p>Toll Free: 866 672 9101</p>
+                        <p>Toll Free: 1-866-672-9101</p>
                         <p>Fax: (519) 672-9321</p>
+                        <p class="mt-4 font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                            </svg>
+                            <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
+                        </p>
                     </div>
                 </div>
                 
                 <!-- Services -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
-                    <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/services#commercial" class="hover:text-white transition-colors duration-200">Commercial Valuation</a></li>
-                        <li><a href="/services#residential" class="hover:text-white transition-colors duration-200">Residential Appraisals</a></li>
-                        <li><a href="/services#litigation" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
-                        <li><a href="/services" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                    <ul class="space-y-3 text-gray-300">
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
+                        <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
                     </ul>
                 </div>
                 
                 <!-- Market Areas -->
                 <div>
-                    <h3 class="text-white font-semibold text-lg mb-6">Market Areas</h3>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Ontario Coverage</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Urban Markets</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Industrial Properties</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Rural & Agricultural</a></li>
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
                     </ul>
                 </div>
                 
@@ -397,9 +460,7 @@
                     <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
-                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">About Us</a></li>
                         <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
-                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">Careers</a></li>
                         <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
                     </ul>
                 </div>
@@ -410,16 +471,31 @@
                 <div class="mb-6">
                     <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
                 </div>
-                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300">
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
                     <span>AIC - Appraisal Institute of Canada</span>
-                    <span>OREA - Ontario Real Estate Association</span>
-                    <span>CREA - Canadian Real Estate Association</span>
+                    <span>RICS - Royal Institution of Chartered Surveyors</span>
+                    <span>AOLE - Association of Ontario Land Economists</span>
+                    <span>IRWA - International Right of Way Association</span>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6">
+                    <span>Data Providers:</span>
+                    <span>CoStar Professional</span>
+                    <span>TRREB - Toronto Regional Real Estate Board</span>
+                </div>
+                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
+                    <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
                 </div>
             </div>
             
             <!-- Copyright -->
             <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
                 <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
             </div>
         </div>
     </footer>

--- a/maia-mcclintock/index.html
+++ b/maia-mcclintock/index.html
@@ -91,17 +91,17 @@
     <!-- Global Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex items-center justify-between h-20">
+            <div class="flex items-center justify-between h-16 sm:h-20">
                 <!-- Logo -->
                 <div class="flex-shrink-0">
                     <a href="/">
-                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
                     </a>
                 </div>
                 
                 <!-- Desktop Navigation -->
-                <div class="hidden md:flex items-center space-x-8">
-                    <a href="/" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Home</a>
+                <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
+                    <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
                     <div class="relative group">
                         <a href="/services" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Services</a>
                         <!-- Mega Menu -->
@@ -110,23 +110,23 @@
                                 <div>
                                     <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
                                     <div class="space-y-1">
-                                        <a href="/services#commercial" class="mega-menu-item block p-4">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
                                         </a>
-                                        <a href="/services#residential" class="mega-menu-item block p-4">
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
                                         </a>
-                                        <a href="/services#litigation" class="mega-menu-item block p-4">
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
                                         </a>
-                                        <a href="/services#consulting" class="mega-menu-item block p-4">
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
                                         </a>
-                                        <a href="/services#government" class="mega-menu-item block p-4">
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
                                         </a>
@@ -135,20 +135,70 @@
                             </div>
                         </div>
                     </div>
-                    <a href="/market-areas" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Market Areas</a>
-                    <a href="/team" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Team</a>
-                    <!-- <a href="/insights/" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Market Insights</a> -->
-                    <a href="/contact" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Contact</a>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link active text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
                 </div>
                 
                 <!-- CTA Button -->
                 <div class="hidden md:block">
-                    <a href="/contact" class="inline-flex items-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-black-dark transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg">
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
                         Connect with an Appraiser
                     </a>
                 </div>
+                
+                <!-- Mobile menu button -->
+                <div class="md:hidden">
+                    <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
+                        <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                        </div>
+                    </button>
+                </div>
             </div>
         </nav>
+
+        <!-- Mobile Menu -->
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+            
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link active">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+                    
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+
+        <!-- Mobile Menu Overlay -->
+        <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
     </header>
 
     <!-- Hero Section -->
@@ -379,49 +429,61 @@
 
     <!-- Professional Footer -->
     <footer class="bg-black text-white">
-        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-12 mb-12 text-center lg:text-left">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
                 <!-- Company Info -->
                 <div class="lg:col-span-1">
-                    <div class="flex justify-center lg:justify-start items-center gap-3 mb-6">
-                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 w-auto brightness-0 invert">
-                    </div>
-                    <p class="text-gray-300 mb-6 leading-relaxed text-sm">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-6 leading-relaxed">
                         Trusted • Valued • Experienced
                     </p>
-                    <div class="text-gray-300 text-sm space-y-1">
-                        <p class="font-semibold text-white">620A Richmond Street, Suite 203</p>
-                        <p>London, ON N6A 5J9</p>
-                        <p class="mt-3 flex items-center">
-                            <svg class="w-4 h-4 mr-2 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <div class="text-gray-300">
+                        <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
+                        <p class="mb-4">London, ON N6A 5J9</p>
+                        <p class="font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
                             </svg>
                             <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
                         </p>
-                        <p>Toll Free: 866 672 9101</p>
+                        <p>Toll Free: 1-866-672-9101</p>
                         <p>Fax: (519) 672-9321</p>
+                        <p class="mt-4 font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                            </svg>
+                            <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
+                        </p>
                     </div>
                 </div>
                 
                 <!-- Services -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
-                    <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/services#commercial" class="hover:text-white transition-colors duration-200">Commercial Valuation</a></li>
-                        <li><a href="/services#residential" class="hover:text-white transition-colors duration-200">Residential Appraisals</a></li>
-                        <li><a href="/services#litigation" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
-                        <li><a href="/services" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                    <ul class="space-y-3 text-gray-300">
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
+                        <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
                     </ul>
                 </div>
                 
                 <!-- Market Areas -->
                 <div>
-                    <h3 class="text-white font-semibold text-lg mb-6">Market Areas</h3>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Ontario Coverage</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Urban Markets</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Industrial Properties</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Rural & Agricultural</a></li>
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
                     </ul>
                 </div>
                 
@@ -430,9 +492,7 @@
                     <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
-                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">About Us</a></li>
                         <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
-                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">Careers</a></li>
                         <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
                     </ul>
                 </div>
@@ -443,16 +503,31 @@
                 <div class="mb-6">
                     <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
                 </div>
-                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300">
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
                     <span>AIC - Appraisal Institute of Canada</span>
-                    <span>OREA - Ontario Real Estate Association</span>
-                    <span>CREA - Canadian Real Estate Association</span>
+                    <span>RICS - Royal Institution of Chartered Surveyors</span>
+                    <span>AOLE - Association of Ontario Land Economists</span>
+                    <span>IRWA - International Right of Way Association</span>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6">
+                    <span>Data Providers:</span>
+                    <span>CoStar Professional</span>
+                    <span>TRREB - Toronto Regional Real Estate Board</span>
+                </div>
+                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
+                    <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
                 </div>
             </div>
             
             <!-- Copyright -->
             <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
                 <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
             </div>
         </div>
     </footer>

--- a/mark-penhale/index.html
+++ b/mark-penhale/index.html
@@ -91,17 +91,17 @@
     <!-- Global Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex items-center justify-between h-20">
+            <div class="flex items-center justify-between h-16 sm:h-20">
                 <!-- Logo -->
                 <div class="flex-shrink-0">
                     <a href="/">
-                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
                     </a>
                 </div>
                 
                 <!-- Desktop Navigation -->
-                <div class="hidden md:flex items-center space-x-8">
-                    <a href="/" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Home</a>
+                <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
+                    <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
                     <div class="relative group">
                         <a href="/services" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Services</a>
                         <!-- Mega Menu -->
@@ -110,23 +110,23 @@
                                 <div>
                                     <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
                                     <div class="space-y-1">
-                                        <a href="/services#commercial" class="mega-menu-item block p-4">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
                                         </a>
-                                        <a href="/services#residential" class="mega-menu-item block p-4">
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
                                         </a>
-                                        <a href="/services#litigation" class="mega-menu-item block p-4">
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
                                         </a>
-                                        <a href="/services#consulting" class="mega-menu-item block p-4">
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
                                         </a>
-                                        <a href="/services#government" class="mega-menu-item block p-4">
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
                                         </a>
@@ -135,20 +135,70 @@
                             </div>
                         </div>
                     </div>
-                    <a href="/market-areas" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Market Areas</a>
-                    <a href="/team" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Team</a>
-                    <!-- <a href="/insights/" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Market Insights</a> -->
-                    <a href="/contact" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Contact</a>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link active text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
                 </div>
                 
                 <!-- CTA Button -->
                 <div class="hidden md:block">
-                    <a href="/contact" class="inline-flex items-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg">
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
                         Connect with an Appraiser
                     </a>
                 </div>
+                
+                <!-- Mobile menu button -->
+                <div class="md:hidden">
+                    <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
+                        <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                        </div>
+                    </button>
+                </div>
             </div>
         </nav>
+
+        <!-- Mobile Menu -->
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+            
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link active">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+                    
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+
+        <!-- Mobile Menu Overlay -->
+        <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
     </header>
 
     <!-- Hero Section -->
@@ -420,49 +470,61 @@
 
     <!-- Professional Footer -->
     <footer class="bg-black text-white">
-        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-12 mb-12 text-center lg:text-left">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
                 <!-- Company Info -->
                 <div class="lg:col-span-1">
-                    <div class="flex justify-center lg:justify-start items-center gap-3 mb-6">
-                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 w-auto brightness-0 invert">
-                    </div>
-                    <p class="text-gray-300 mb-6 leading-relaxed text-sm">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-6 leading-relaxed">
                         Trusted • Valued • Experienced
                     </p>
-                    <div class="text-gray-300 text-sm space-y-1">
-                        <p class="font-semibold text-white">620A Richmond Street, Suite 203</p>
-                        <p>London, ON N6A 5J9</p>
-                        <p class="mt-3 flex items-center">
-                            <svg class="w-4 h-4 mr-2 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <div class="text-gray-300">
+                        <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
+                        <p class="mb-4">London, ON N6A 5J9</p>
+                        <p class="font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
                             </svg>
                             <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
                         </p>
-                        <p>Toll Free: 866 672 9101</p>
+                        <p>Toll Free: 1-866-672-9101</p>
                         <p>Fax: (519) 672-9321</p>
+                        <p class="mt-4 font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                            </svg>
+                            <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
+                        </p>
                     </div>
                 </div>
                 
                 <!-- Services -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
-                    <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/services#commercial" class="hover:text-white transition-colors duration-200">Commercial Valuation</a></li>
-                        <li><a href="/services#residential" class="hover:text-white transition-colors duration-200">Residential Appraisals</a></li>
-                        <li><a href="/services#litigation" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
-                        <li><a href="/services" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                    <ul class="space-y-3 text-gray-300">
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
+                        <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
                     </ul>
                 </div>
                 
                 <!-- Market Areas -->
                 <div>
-                    <h3 class="text-white font-semibold text-lg mb-6">Market Areas</h3>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Ontario Coverage</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Urban Markets</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Industrial Properties</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Rural & Agricultural</a></li>
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
                     </ul>
                 </div>
                 
@@ -471,9 +533,7 @@
                     <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
-                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">About Us</a></li>
                         <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
-                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">Careers</a></li>
                         <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
                     </ul>
                 </div>
@@ -484,16 +544,31 @@
                 <div class="mb-6">
                     <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
                 </div>
-                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300">
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
                     <span>AIC - Appraisal Institute of Canada</span>
-                    <span>OREA - Ontario Real Estate Association</span>
-                    <span>CREA - Canadian Real Estate Association</span>
+                    <span>RICS - Royal Institution of Chartered Surveyors</span>
+                    <span>AOLE - Association of Ontario Land Economists</span>
+                    <span>IRWA - International Right of Way Association</span>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6">
+                    <span>Data Providers:</span>
+                    <span>CoStar Professional</span>
+                    <span>TRREB - Toronto Regional Real Estate Board</span>
+                </div>
+                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
+                    <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
                 </div>
             </div>
             
             <!-- Copyright -->
             <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
                 <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
             </div>
         </div>
     </footer>

--- a/market-areas/index.html
+++ b/market-areas/index.html
@@ -3,9 +3,11 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Market Areas | Metrix Realty Group | Ontario Province-Wide Coverage</title>
+    <title>Real Estate Appraisal Services Across Ontario | Metrix</title>
+    <meta property="og:title" content="Real Estate Appraisal Services Across Ontario | Metrix">
+    <meta property="og:description" content="Metrix Realty Group provides real estate appraisal services across Ontario. Serving London, Windsor, Kitchener-Waterloo, Hamilton, Niagara, and the GTA.">
     <link rel="icon" type="image/png" href="/favicon.png">
-    <meta name="description" content="Metrix Realty Group provides expert real estate appraisal services across Ontario including Windsor-Essex, Chatham-Kent, London-Middlesex, Kitchener-Waterloo, Hamilton-Burlington, Niagara, and Ottawa regions.">
+    <meta name="description" content="Metrix Realty Group provides real estate appraisal services across Ontario. Serving London, Windsor, Kitchener-Waterloo, Hamilton, Niagara, and the GTA.">
     <link rel="canonical" href="https://metrixrealty.com/market-areas">
     
     <!-- Google Tag Manager -->
@@ -340,12 +342,14 @@
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex items-center justify-between h-16 sm:h-20">
+                <!-- Logo -->
                 <div class="flex-shrink-0">
                     <a href="/">
                         <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
                     </a>
                 </div>
                 
+                <!-- Desktop Navigation -->
                 <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
                     <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
                     <div class="relative group">
@@ -356,23 +360,23 @@
                                 <div>
                                     <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
                                     <div class="space-y-1">
-                                        <a href="/services#commercial" class="mega-menu-item block p-4">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
                                         </a>
-                                        <a href="/services#residential" class="mega-menu-item block p-4">
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
                                         </a>
-                                        <a href="/services#litigation" class="mega-menu-item block p-4">
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
                                         </a>
-                                        <a href="/services#consulting" class="mega-menu-item block p-4">
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
                                         </a>
-                                        <a href="/services#government" class="mega-menu-item block p-4">
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
                                         </a>
@@ -381,12 +385,21 @@
                             </div>
                         </div>
                     </div>
-                    <a href="#" class="nav-link active text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link active text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
                     <a href="/team" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
-                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Insights</a> -->
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
                     <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
                 </div>
                 
+                <!-- CTA Button -->
                 <div class="hidden md:block">
                     <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
                         Connect with an Appraiser
@@ -405,6 +418,37 @@
                 </div>
             </div>
         </nav>
+
+        <!-- Mobile Menu -->
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+            
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link active">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+                    
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+
+        <!-- Mobile Menu Overlay -->
+        <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
     </header>
 
     <main>
@@ -416,7 +460,7 @@
             <div class="relative z-10 max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
                 <span class="inline-block px-4 py-2 bg-white/20 text-white text-sm font-semibold rounded-full uppercase tracking-wide mb-4" data-aos="fade-up" data-aos-duration="800">Service Areas</span>
                 <h1 class="text-4xl sm:text-5xl lg:text-6xl font-bold mb-8 leading-tight" data-aos="fade-up" data-aos-duration="1000">
-                    Serving Ontario Province-Wide
+                    Real Estate Appraisal Services Across Ontario
                 </h1>
                 <p class="text-lg sm:text-xl lg:text-2xl mb-12 opacity-90 max-w-4xl mx-auto leading-relaxed" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="200">
                     Real estate appraisal services across Ontario's diverse markets and communities.
@@ -637,6 +681,7 @@
     <footer class="bg-black text-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
+                <!-- Company Info -->
                 <div class="lg:col-span-1">
                     <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
                     <p class="text-gray-300 mb-6 leading-relaxed">
@@ -662,34 +707,37 @@
                     </div>
                 </div>
                 
+                <!-- Services -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
                     <ul class="space-y-3 text-gray-300">
-                        <li><a href="/services#commercial" class="hover:text-white transition-colors duration-200">Commercial Valuation</a></li>
-                        <li><a href="/services#residential" class="hover:text-white transition-colors duration-200">Residential Appraisals</a></li>
-                        <li><a href="/services#litigation" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
-                        <li><a href="/services#consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
                         <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
                     </ul>
                 </div>
                 
+                <!-- Market Areas -->
                 <div>
-                    <h3 class="text-white font-semibold text-lg mb-6">Market Areas</h3>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London–Middlesex–Elgin (Main Office)</a></li>
-                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor–Essex</a></li>
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Oxford County</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Huron–Perth–Wellington</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Niagara Region</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Halton–Peel</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Full Coverage Map</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
                     </ul>
                 </div>
                 
+                <!-- Company -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
@@ -715,15 +763,21 @@
                     <span>Data Providers:</span>
                     <span>CoStar Professional</span>
                     <span>TRREB - Toronto Regional Real Estate Board</span>
-                    <span>Valcre Cloud Analytics</span>
                 </div>
                 <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
                     <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
                 </div>
             </div>
             
+            <!-- Copyright -->
             <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
                 <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
             </div>
         </div>
     </footer>

--- a/mason-hewitt/index.html
+++ b/mason-hewitt/index.html
@@ -112,17 +112,17 @@
     <!-- Global Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex items-center justify-between h-20">
+            <div class="flex items-center justify-between h-16 sm:h-20">
                 <!-- Logo -->
                 <div class="flex-shrink-0">
                     <a href="/">
-                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
                     </a>
                 </div>
                 
                 <!-- Desktop Navigation -->
-                <div class="hidden md:flex items-center space-x-8">
-                    <a href="/" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Home</a>
+                <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
+                    <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
                     <div class="relative group">
                         <a href="/services" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Services</a>
                         <!-- Mega Menu -->
@@ -131,23 +131,23 @@
                                 <div>
                                     <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
                                     <div class="space-y-1">
-                                        <a href="/services#commercial" class="mega-menu-item block p-4">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
                                         </a>
-                                        <a href="/services#residential" class="mega-menu-item block p-4">
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
                                         </a>
-                                        <a href="/services#litigation" class="mega-menu-item block p-4">
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
                                         </a>
-                                        <a href="/services#consulting" class="mega-menu-item block p-4">
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
                                         </a>
-                                        <a href="/services#government" class="mega-menu-item block p-4">
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
                                         </a>
@@ -156,20 +156,70 @@
                             </div>
                         </div>
                     </div>
-                    <a href="/market-areas" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Market Areas</a>
-                    <a href="/team" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Team</a>
-                    <!-- <a href="/insights/" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Market Insights</a> -->
-                    <a href="/contact" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Contact</a>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link active text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
                 </div>
                 
                 <!-- CTA Button -->
                 <div class="hidden md:block">
-                    <a href="/contact" class="inline-flex items-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-black-dark transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg">
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
                         Connect with an Appraiser
                     </a>
                 </div>
+                
+                <!-- Mobile menu button -->
+                <div class="md:hidden">
+                    <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
+                        <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                        </div>
+                    </button>
+                </div>
             </div>
         </nav>
+
+        <!-- Mobile Menu -->
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+            
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link active">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+                    
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+
+        <!-- Mobile Menu Overlay -->
+        <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
     </header>
 
     <!-- Hero Section -->
@@ -382,49 +432,61 @@
 
     <!-- Professional Footer -->
     <footer class="bg-black text-white">
-        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-12 mb-12 text-center lg:text-left">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
                 <!-- Company Info -->
                 <div class="lg:col-span-1">
-                    <div class="flex justify-center lg:justify-start items-center gap-3 mb-6">
-                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 w-auto brightness-0 invert">
-                    </div>
-                    <p class="text-gray-300 mb-6 leading-relaxed text-sm">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-6 leading-relaxed">
                         Trusted • Valued • Experienced
                     </p>
-                    <div class="text-gray-300 text-sm space-y-1">
-                        <p class="font-semibold text-white">620A Richmond Street, Suite 203</p>
-                        <p>London, ON N6A 5J9</p>
-                        <p class="mt-3 flex items-center">
-                            <svg class="w-4 h-4 mr-2 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <div class="text-gray-300">
+                        <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
+                        <p class="mb-4">London, ON N6A 5J9</p>
+                        <p class="font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
                             </svg>
                             <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
                         </p>
-                        <p>Toll Free: 866 672 9101</p>
+                        <p>Toll Free: 1-866-672-9101</p>
                         <p>Fax: (519) 672-9321</p>
+                        <p class="mt-4 font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                            </svg>
+                            <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
+                        </p>
                     </div>
                 </div>
                 
                 <!-- Services -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
-                    <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/services#commercial" class="hover:text-white transition-colors duration-200">Commercial Valuation</a></li>
-                        <li><a href="/services#residential" class="hover:text-white transition-colors duration-200">Residential Appraisals</a></li>
-                        <li><a href="/services#litigation" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
-                        <li><a href="/services" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                    <ul class="space-y-3 text-gray-300">
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
+                        <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
                     </ul>
                 </div>
                 
                 <!-- Market Areas -->
                 <div>
-                    <h3 class="text-white font-semibold text-lg mb-6">Market Areas</h3>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Ontario Coverage</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Urban Markets</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Industrial Properties</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Rural & Agricultural</a></li>
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
                     </ul>
                 </div>
                 
@@ -433,9 +495,7 @@
                     <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
-                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">About Us</a></li>
                         <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
-                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">Careers</a></li>
                         <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
                     </ul>
                 </div>
@@ -446,16 +506,31 @@
                 <div class="mb-6">
                     <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
                 </div>
-                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300">
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
                     <span>AIC - Appraisal Institute of Canada</span>
-                    <span>OREA - Ontario Real Estate Association</span>
-                    <span>CREA - Canadian Real Estate Association</span>
+                    <span>RICS - Royal Institution of Chartered Surveyors</span>
+                    <span>AOLE - Association of Ontario Land Economists</span>
+                    <span>IRWA - International Right of Way Association</span>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6">
+                    <span>Data Providers:</span>
+                    <span>CoStar Professional</span>
+                    <span>TRREB - Toronto Regional Real Estate Board</span>
+                </div>
+                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
+                    <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
                 </div>
             </div>
             
             <!-- Copyright -->
             <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
                 <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
             </div>
         </div>
     </footer>

--- a/michael-fry/index.html
+++ b/michael-fry/index.html
@@ -88,17 +88,17 @@
     <!-- Global Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex items-center justify-between h-20">
+            <div class="flex items-center justify-between h-16 sm:h-20">
                 <!-- Logo -->
                 <div class="flex-shrink-0">
                     <a href="/">
-                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
                     </a>
                 </div>
                 
                 <!-- Desktop Navigation -->
-                <div class="hidden md:flex items-center space-x-8">
-                    <a href="/" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Home</a>
+                <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
+                    <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
                     <div class="relative group">
                         <a href="/services" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Services</a>
                         <!-- Mega Menu -->
@@ -107,23 +107,23 @@
                                 <div>
                                     <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
                                     <div class="space-y-1">
-                                        <a href="/services#commercial" class="mega-menu-item block p-4">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
                                         </a>
-                                        <a href="/services#residential" class="mega-menu-item block p-4">
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
                                         </a>
-                                        <a href="/services#litigation" class="mega-menu-item block p-4">
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
                                         </a>
-                                        <a href="/services#consulting" class="mega-menu-item block p-4">
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
                                         </a>
-                                        <a href="/services#government" class="mega-menu-item block p-4">
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
                                         </a>
@@ -132,20 +132,70 @@
                             </div>
                         </div>
                     </div>
-                    <a href="/market-areas" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Market Areas</a>
-                    <a href="/team" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Team</a>
-                    <!-- <a href="/insights/" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Market Insights</a> -->
-                    <a href="/contact" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Contact</a>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link active text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
                 </div>
                 
                 <!-- CTA Button -->
                 <div class="hidden md:block">
-                    <a href="/contact" class="inline-flex items-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-black-dark transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg">
-                        Request an Appraisal
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
+                        Connect with an Appraiser
                     </a>
+                </div>
+                
+                <!-- Mobile menu button -->
+                <div class="md:hidden">
+                    <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
+                        <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                        </div>
+                    </button>
                 </div>
             </div>
         </nav>
+
+        <!-- Mobile Menu -->
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+            
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link active">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+                    
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+
+        <!-- Mobile Menu Overlay -->
+        <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
     </header>
 
     <!-- Hero Section -->
@@ -338,49 +388,61 @@
 
     <!-- Professional Footer -->
     <footer class="bg-black text-white">
-        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-12 mb-12 text-center lg:text-left">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
                 <!-- Company Info -->
                 <div class="lg:col-span-1">
-                    <div class="flex justify-center lg:justify-start items-center gap-3 mb-6">
-                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 w-auto brightness-0 invert">
-                    </div>
-                    <p class="text-gray-300 mb-6 leading-relaxed text-sm">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-6 leading-relaxed">
                         Trusted • Valued • Experienced
                     </p>
-                    <div class="text-gray-300 text-sm space-y-1">
-                        <p class="font-semibold text-white">620A Richmond Street, Suite 203</p>
-                        <p>London, ON N6A 5J9</p>
-                        <p class="mt-3 flex items-center">
-                            <svg class="w-4 h-4 mr-2 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <div class="text-gray-300">
+                        <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
+                        <p class="mb-4">London, ON N6A 5J9</p>
+                        <p class="font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
                             </svg>
-                            (519) 672-7550
+                            <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
                         </p>
-                        <p>Toll Free: 866 672 9101</p>
+                        <p>Toll Free: 1-866-672-9101</p>
                         <p>Fax: (519) 672-9321</p>
+                        <p class="mt-4 font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                            </svg>
+                            <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
+                        </p>
                     </div>
                 </div>
                 
                 <!-- Services -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
-                    <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/services#commercial" class="hover:text-white transition-colors duration-200">Commercial Valuation</a></li>
-                        <li><a href="/services#residential" class="hover:text-white transition-colors duration-200">Residential Appraisals</a></li>
-                        <li><a href="/services#litigation" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
-                        <li><a href="/services" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                    <ul class="space-y-3 text-gray-300">
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
+                        <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
                     </ul>
                 </div>
                 
                 <!-- Market Areas -->
                 <div>
-                    <h3 class="text-white font-semibold text-lg mb-6">Market Areas</h3>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Ontario Coverage</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Urban Markets</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Industrial Properties</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Rural & Agricultural</a></li>
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
                     </ul>
                 </div>
                 
@@ -389,9 +451,7 @@
                     <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
-                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">About Us</a></li>
                         <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
-                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">Careers</a></li>
                         <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
                     </ul>
                 </div>
@@ -402,16 +462,31 @@
                 <div class="mb-6">
                     <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
                 </div>
-                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300">
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
                     <span>AIC - Appraisal Institute of Canada</span>
-                    <span>OREA - Ontario Real Estate Association</span>
-                    <span>CREA - Canadian Real Estate Association</span>
+                    <span>RICS - Royal Institution of Chartered Surveyors</span>
+                    <span>AOLE - Association of Ontario Land Economists</span>
+                    <span>IRWA - International Right of Way Association</span>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6">
+                    <span>Data Providers:</span>
+                    <span>CoStar Professional</span>
+                    <span>TRREB - Toronto Regional Real Estate Board</span>
+                </div>
+                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
+                    <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
                 </div>
             </div>
             
             <!-- Copyright -->
             <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
                 <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
             </div>
         </div>
     </footer>

--- a/paula-busch/index.html
+++ b/paula-busch/index.html
@@ -91,17 +91,17 @@
     <!-- Global Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex items-center justify-between h-20">
+            <div class="flex items-center justify-between h-16 sm:h-20">
                 <!-- Logo -->
                 <div class="flex-shrink-0">
                     <a href="/">
-                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
                     </a>
                 </div>
                 
                 <!-- Desktop Navigation -->
-                <div class="hidden md:flex items-center space-x-8">
-                    <a href="/" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Home</a>
+                <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
+                    <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
                     <div class="relative group">
                         <a href="/services" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Services</a>
                         <!-- Mega Menu -->
@@ -110,23 +110,23 @@
                                 <div>
                                     <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
                                     <div class="space-y-1">
-                                        <a href="/services#commercial" class="mega-menu-item block p-4">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
                                         </a>
-                                        <a href="/services#residential" class="mega-menu-item block p-4">
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
                                         </a>
-                                        <a href="/services#litigation" class="mega-menu-item block p-4">
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
                                         </a>
-                                        <a href="/services#consulting" class="mega-menu-item block p-4">
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
                                         </a>
-                                        <a href="/services#government" class="mega-menu-item block p-4">
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
                                         </a>
@@ -135,20 +135,70 @@
                             </div>
                         </div>
                     </div>
-                    <a href="/market-areas" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Market Areas</a>
-                    <a href="/team" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Team</a>
-                    <!-- <a href="/insights/" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Market Insights</a> -->
-                    <a href="/contact" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Contact</a>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link active text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
                 </div>
                 
                 <!-- CTA Button -->
                 <div class="hidden md:block">
-                    <a href="/contact" class="inline-flex items-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-black-dark transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg">
-                        Request an Appraisal
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
+                        Connect with an Appraiser
                     </a>
+                </div>
+                
+                <!-- Mobile menu button -->
+                <div class="md:hidden">
+                    <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
+                        <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                        </div>
+                    </button>
                 </div>
             </div>
         </nav>
+
+        <!-- Mobile Menu -->
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+            
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link active">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+                    
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+
+        <!-- Mobile Menu Overlay -->
+        <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
     </header>
 
     <!-- Hero Section -->
@@ -385,49 +435,61 @@
 
     <!-- Professional Footer -->
     <footer class="bg-black text-white">
-        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-12 mb-12 text-center lg:text-left">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
                 <!-- Company Info -->
                 <div class="lg:col-span-1">
-                    <div class="flex justify-center lg:justify-start items-center gap-3 mb-6">
-                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 w-auto brightness-0 invert">
-                    </div>
-                    <p class="text-gray-300 mb-6 leading-relaxed text-sm">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-6 leading-relaxed">
                         Trusted • Valued • Experienced
                     </p>
-                    <div class="text-gray-300 text-sm space-y-1">
-                        <p class="font-semibold text-white">620A Richmond Street, Suite 203</p>
-                        <p>London, ON N6A 5J9</p>
-                        <p class="mt-3 flex items-center">
-                            <svg class="w-4 h-4 mr-2 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <div class="text-gray-300">
+                        <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
+                        <p class="mb-4">London, ON N6A 5J9</p>
+                        <p class="font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
                             </svg>
-                            (519) 672-7550
+                            <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
                         </p>
-                        <p>Toll Free: 866 672 9101</p>
+                        <p>Toll Free: 1-866-672-9101</p>
                         <p>Fax: (519) 672-9321</p>
+                        <p class="mt-4 font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                            </svg>
+                            <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
+                        </p>
                     </div>
                 </div>
                 
                 <!-- Services -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
-                    <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/services#commercial" class="hover:text-white transition-colors duration-200">Commercial Valuation</a></li>
-                        <li><a href="/services#residential" class="hover:text-white transition-colors duration-200">Residential Appraisals</a></li>
-                        <li><a href="/services#litigation" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
-                        <li><a href="/services" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                    <ul class="space-y-3 text-gray-300">
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
+                        <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
                     </ul>
                 </div>
                 
                 <!-- Market Areas -->
                 <div>
-                    <h3 class="text-white font-semibold text-lg mb-6">Market Areas</h3>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Ontario Coverage</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Urban Markets</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Industrial Properties</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Rural & Agricultural</a></li>
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
                     </ul>
                 </div>
                 
@@ -436,9 +498,7 @@
                     <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
-                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">About Us</a></li>
                         <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
-                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">Careers</a></li>
                         <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
                     </ul>
                 </div>
@@ -449,16 +509,31 @@
                 <div class="mb-6">
                     <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
                 </div>
-                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300">
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
                     <span>AIC - Appraisal Institute of Canada</span>
-                    <span>OREA - Ontario Real Estate Association</span>
-                    <span>CREA - Canadian Real Estate Association</span>
+                    <span>RICS - Royal Institution of Chartered Surveyors</span>
+                    <span>AOLE - Association of Ontario Land Economists</span>
+                    <span>IRWA - International Right of Way Association</span>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6">
+                    <span>Data Providers:</span>
+                    <span>CoStar Professional</span>
+                    <span>TRREB - Toronto Regional Real Estate Board</span>
+                </div>
+                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
+                    <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
                 </div>
             </div>
             
             <!-- Copyright -->
             <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
                 <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
             </div>
         </div>
     </footer>

--- a/privacy-policy/index.html
+++ b/privacy-policy/index.html
@@ -28,23 +28,116 @@
     <!-- End Google Tag Manager (noscript) -->
 
     <!-- Header -->
-    <header class="bg-white shadow-sm">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex justify-between items-center py-6">
-                <div class="flex items-center">
-                    <a href="/" class="flex items-center">
-                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-8 w-auto">
+    <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
+        <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center justify-between h-16 sm:h-20">
+                <!-- Logo -->
+                <div class="flex-shrink-0">
+                    <a href="/">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
                     </a>
                 </div>
-                <nav class="hidden md:flex space-x-8">
-                    <a href="/" class="text-gray-700 hover:text-gray-900">Home</a>
-                    <a href="/services" class="text-gray-700 hover:text-gray-900">Services</a>
-                    <a href="/market-areas" class="text-gray-700 hover:text-gray-900">Market Areas</a>
-                    <a href="/team" class="text-gray-700 hover:text-gray-900">Team</a>
-                    <a href="/contact" class="text-gray-700 hover:text-gray-900">Contact</a>
+                
+                <!-- Desktop Navigation -->
+                <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
+                    <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
+                    <div class="relative group">
+                        <a href="/services" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Services</a>
+                        <!-- Mega Menu -->
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-96 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50 backdrop-blur-sm">
+                            <div class="p-8">
+                                <div>
+                                    <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
+                                    <div class="space-y-1">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
+                                        </a>
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
+                                        </a>
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
+                                        </a>
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
+                                        </a>
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
+                </div>
+                
+                <!-- CTA Button -->
+                <div class="hidden md:block">
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
+                        Connect with an Appraiser
+                    </a>
+                </div>
+                
+                <!-- Mobile menu button -->
+                <div class="md:hidden">
+                    <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
+                        <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                        </div>
+                    </button>
+                </div>
+            </div>
+        </nav>
+
+        <!-- Mobile Menu -->
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+            
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+                    
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
+                    </div>
                 </nav>
             </div>
         </div>
+
+        <!-- Mobile Menu Overlay -->
+        <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
     </header>
 
     <!-- Main Content -->
@@ -92,13 +185,105 @@
     </main>
 
     <!-- Footer -->
-    <footer class="bg-gray-50 border-t">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-            <div class="text-center">
-                <p class="text-gray-500">&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+    <footer class="bg-black text-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
+                <!-- Company Info -->
+                <div class="lg:col-span-1">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-6 leading-relaxed">
+                        Trusted • Valued • Experienced
+                    </p>
+                    <div class="text-gray-300">
+                        <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
+                        <p class="mb-4">London, ON N6A 5J9</p>
+                        <p class="font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
+                            </svg>
+                            <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
+                        </p>
+                        <p>Toll Free: 1-866-672-9101</p>
+                        <p>Fax: (519) 672-9321</p>
+                        <p class="mt-4 font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                            </svg>
+                            <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
+                        </p>
+                    </div>
+                </div>
+                
+                <!-- Services -->
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
+                    <ul class="space-y-3 text-gray-300">
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
+                        <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
+                    </ul>
+                </div>
+                
+                <!-- Market Areas -->
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
+                    </ul>
+                </div>
+                
+                <!-- Company -->
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
+                        <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
+                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
+                    </ul>
+                </div>
+            </div>
+            
+            <!-- Professional Affiliations -->
+            <div class="border-t border-gray-800 pt-8 mb-8 text-center">
+                <div class="mb-6">
+                    <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
+                    <span>AIC - Appraisal Institute of Canada</span>
+                    <span>RICS - Royal Institution of Chartered Surveyors</span>
+                    <span>AOLE - Association of Ontario Land Economists</span>
+                    <span>IRWA - International Right of Way Association</span>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6">
+                    <span>Data Providers:</span>
+                    <span>CoStar Professional</span>
+                    <span>TRREB - Toronto Regional Real Estate Board</span>
+                </div>
+                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
+                    <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
+                </div>
+            </div>
+            
+            <!-- Copyright -->
+            <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
+                <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
                 <div class="mt-4 space-x-4">
-                    <a href="/privacy-policy" class="text-gray-500 hover:text-gray-700">Privacy Policy</a>
-                    <a href="/terms-of-service" class="text-gray-500 hover:text-gray-700">Terms of Service</a>
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
                 </div>
             </div>
         </div>

--- a/roman-virk/index.html
+++ b/roman-virk/index.html
@@ -91,17 +91,17 @@
     <!-- Global Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex items-center justify-between h-20">
+            <div class="flex items-center justify-between h-16 sm:h-20">
                 <!-- Logo -->
                 <div class="flex-shrink-0">
                     <a href="/">
-                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
                     </a>
                 </div>
                 
                 <!-- Desktop Navigation -->
-                <div class="hidden md:flex items-center space-x-8">
-                    <a href="/" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Home</a>
+                <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
+                    <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
                     <div class="relative group">
                         <a href="/services" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Services</a>
                         <!-- Mega Menu -->
@@ -110,23 +110,23 @@
                                 <div>
                                     <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
                                     <div class="space-y-1">
-                                        <a href="/services#commercial" class="mega-menu-item block p-4">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
                                         </a>
-                                        <a href="/services#residential" class="mega-menu-item block p-4">
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
                                         </a>
-                                        <a href="/services#litigation" class="mega-menu-item block p-4">
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
                                         </a>
-                                        <a href="/services#consulting" class="mega-menu-item block p-4">
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
                                         </a>
-                                        <a href="/services#government" class="mega-menu-item block p-4">
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
                                         </a>
@@ -135,19 +135,70 @@
                             </div>
                         </div>
                     </div>
-                    <a href="/market-areas" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Market Areas</a>
-                    <a href="/team" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Team</a>
-                    <a href="/contact" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Contact</a>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link active text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
                 </div>
                 
                 <!-- CTA Button -->
                 <div class="hidden md:block">
-                    <a href="/contact" class="inline-flex items-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-black-dark transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg">
-                        Request an Appraisal
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
+                        Connect with an Appraiser
                     </a>
+                </div>
+                
+                <!-- Mobile menu button -->
+                <div class="md:hidden">
+                    <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
+                        <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                        </div>
+                    </button>
                 </div>
             </div>
         </nav>
+
+        <!-- Mobile Menu -->
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+            
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link active">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+                    
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+
+        <!-- Mobile Menu Overlay -->
+        <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
     </header>
 
     <!-- Hero Section -->
@@ -347,49 +398,61 @@
 
     <!-- Professional Footer -->
     <footer class="bg-black text-white">
-        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-12 mb-12 text-center lg:text-left">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
                 <!-- Company Info -->
                 <div class="lg:col-span-1">
-                    <div class="flex justify-center lg:justify-start items-center gap-3 mb-6">
-                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 w-auto brightness-0 invert">
-                    </div>
-                    <p class="text-gray-300 mb-6 leading-relaxed text-sm">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-6 leading-relaxed">
                         Trusted • Valued • Experienced
                     </p>
-                    <div class="text-gray-300 text-sm space-y-1">
-                        <p class="font-semibold text-white">620A Richmond Street, Suite 203</p>
-                        <p>London, ON N6A 5J9</p>
-                        <p class="mt-3 flex items-center">
-                            <svg class="w-4 h-4 mr-2 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <div class="text-gray-300">
+                        <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
+                        <p class="mb-4">London, ON N6A 5J9</p>
+                        <p class="font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
                             </svg>
                             <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
                         </p>
-                        <p>Toll Free: 866 672 9101</p>
+                        <p>Toll Free: 1-866-672-9101</p>
                         <p>Fax: (519) 672-9321</p>
+                        <p class="mt-4 font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                            </svg>
+                            <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
+                        </p>
                     </div>
                 </div>
                 
                 <!-- Services -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
-                    <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/services#commercial" class="hover:text-white transition-colors duration-200">Commercial Valuation</a></li>
-                        <li><a href="/services#residential" class="hover:text-white transition-colors duration-200">Residential Appraisals</a></li>
-                        <li><a href="/services#litigation" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
-                        <li><a href="/services" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                    <ul class="space-y-3 text-gray-300">
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
+                        <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
                     </ul>
                 </div>
                 
                 <!-- Market Areas -->
                 <div>
-                    <h3 class="text-white font-semibold text-lg mb-6">Market Areas</h3>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Ontario Coverage</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Urban Markets</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Industrial Properties</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Rural & Agricultural</a></li>
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
                     </ul>
                 </div>
                 
@@ -398,9 +461,7 @@
                     <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
-                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">About Us</a></li>
                         <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
-                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">Careers</a></li>
                         <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
                     </ul>
                 </div>
@@ -411,16 +472,31 @@
                 <div class="mb-6">
                     <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
                 </div>
-                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300">
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
                     <span>AIC - Appraisal Institute of Canada</span>
-                    <span>OREA - Ontario Real Estate Association</span>
-                    <span>CREA - Canadian Real Estate Association</span>
+                    <span>RICS - Royal Institution of Chartered Surveyors</span>
+                    <span>AOLE - Association of Ontario Land Economists</span>
+                    <span>IRWA - International Right of Way Association</span>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6">
+                    <span>Data Providers:</span>
+                    <span>CoStar Professional</span>
+                    <span>TRREB - Toronto Regional Real Estate Board</span>
+                </div>
+                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
+                    <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
                 </div>
             </div>
             
             <!-- Copyright -->
             <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
                 <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
             </div>
         </div>
     </footer>

--- a/sam-van-houtte/index.html
+++ b/sam-van-houtte/index.html
@@ -91,17 +91,17 @@
     <!-- Global Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex items-center justify-between h-20">
+            <div class="flex items-center justify-between h-16 sm:h-20">
                 <!-- Logo -->
                 <div class="flex-shrink-0">
                     <a href="/">
-                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
                     </a>
                 </div>
                 
                 <!-- Desktop Navigation -->
-                <div class="hidden md:flex items-center space-x-8">
-                    <a href="/" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Home</a>
+                <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
+                    <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
                     <div class="relative group">
                         <a href="/services" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Services</a>
                         <!-- Mega Menu -->
@@ -110,23 +110,23 @@
                                 <div>
                                     <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
                                     <div class="space-y-1">
-                                        <a href="/services#commercial" class="mega-menu-item block p-4">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
                                         </a>
-                                        <a href="/services#residential" class="mega-menu-item block p-4">
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
                                         </a>
-                                        <a href="/services#litigation" class="mega-menu-item block p-4">
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
                                         </a>
-                                        <a href="/services#consulting" class="mega-menu-item block p-4">
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
                                         </a>
-                                        <a href="/services#government" class="mega-menu-item block p-4">
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
                                         </a>
@@ -135,20 +135,70 @@
                             </div>
                         </div>
                     </div>
-                    <a href="/market-areas" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Market Areas</a>
-                    <a href="/team" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Team</a>
-                    <!-- <a href="/insights/" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Market Insights</a> -->
-                    <a href="/contact" class="text-gray-900 hover:text-gray-600 font-medium transition-colors duration-200">Contact</a>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link active text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
                 </div>
                 
                 <!-- CTA Button -->
                 <div class="hidden md:block">
-                    <a href="/contact" class="inline-flex items-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-black-dark transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg">
-                        Request an Appraisal
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
+                        Connect with an Appraiser
                     </a>
+                </div>
+                
+                <!-- Mobile menu button -->
+                <div class="md:hidden">
+                    <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
+                        <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                        </div>
+                    </button>
                 </div>
             </div>
         </nav>
+
+        <!-- Mobile Menu -->
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+            
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link active">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+                    
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+
+        <!-- Mobile Menu Overlay -->
+        <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
     </header>
 
     <!-- Hero Section -->
@@ -353,49 +403,61 @@
 
     <!-- Professional Footer -->
     <footer class="bg-black text-white">
-        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-12 mb-12 text-center lg:text-left">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
                 <!-- Company Info -->
                 <div class="lg:col-span-1">
-                    <div class="flex justify-center lg:justify-start items-center gap-3 mb-6">
-                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 w-auto brightness-0 invert">
-                    </div>
-                    <p class="text-gray-300 mb-6 leading-relaxed text-sm">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-6 leading-relaxed">
                         Trusted • Valued • Experienced
                     </p>
-                    <div class="text-gray-300 text-sm space-y-1">
-                        <p class="font-semibold text-white">620A Richmond Street, Suite 203</p>
-                        <p>London, ON N6A 5J9</p>
-                        <p class="mt-3 flex items-center">
-                            <svg class="w-4 h-4 mr-2 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <div class="text-gray-300">
+                        <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
+                        <p class="mb-4">London, ON N6A 5J9</p>
+                        <p class="font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
                             </svg>
-                            (519) 672-7550
+                            <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
                         </p>
-                        <p>Toll Free: 866 672 9101</p>
+                        <p>Toll Free: 1-866-672-9101</p>
                         <p>Fax: (519) 672-9321</p>
+                        <p class="mt-4 font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                            </svg>
+                            <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
+                        </p>
                     </div>
                 </div>
                 
                 <!-- Services -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
-                    <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/services#commercial" class="hover:text-white transition-colors duration-200">Commercial Valuation</a></li>
-                        <li><a href="/services#residential" class="hover:text-white transition-colors duration-200">Residential Appraisals</a></li>
-                        <li><a href="/services#litigation" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
-                        <li><a href="/services" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                    <ul class="space-y-3 text-gray-300">
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
+                        <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
                     </ul>
                 </div>
                 
                 <!-- Market Areas -->
                 <div>
-                    <h3 class="text-white font-semibold text-lg mb-6">Market Areas</h3>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Ontario Coverage</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Urban Markets</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Industrial Properties</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Rural & Agricultural</a></li>
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
                     </ul>
                 </div>
                 
@@ -404,9 +466,7 @@
                     <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
-                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">About Us</a></li>
                         <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
-                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">Careers</a></li>
                         <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
                     </ul>
                 </div>
@@ -417,16 +477,31 @@
                 <div class="mb-6">
                     <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
                 </div>
-                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300">
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
                     <span>AIC - Appraisal Institute of Canada</span>
-                    <span>OREA - Ontario Real Estate Association</span>
-                    <span>CREA - Canadian Real Estate Association</span>
+                    <span>RICS - Royal Institution of Chartered Surveyors</span>
+                    <span>AOLE - Association of Ontario Land Economists</span>
+                    <span>IRWA - International Right of Way Association</span>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6">
+                    <span>Data Providers:</span>
+                    <span>CoStar Professional</span>
+                    <span>TRREB - Toronto Regional Real Estate Board</span>
+                </div>
+                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
+                    <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
                 </div>
             </div>
             
             <!-- Copyright -->
             <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
                 <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
             </div>
         </div>
     </footer>

--- a/services/commercial-property-valuations/index.html
+++ b/services/commercial-property-valuations/index.html
@@ -3,15 +3,15 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Commercial Property Valuations Ontario | AACI Certified Appraisers | Metrix Realty</title>
+    <title>Commercial Property Valuations Ontario | Metrix Realty</title>
     <link rel="icon" type="image/png" href="/favicon.png">
-    <meta name="description" content="Precise, lender-approved commercial property valuations by AACI-designated professionals. Office, retail, industrial, and investment properties across Southwestern Ontario. 30+ years experience.">
+    <meta name="description" content="AACI commercial property valuations across Ontario. Expert office, retail, and industrial appraisals. Trusted by lenders and legal professionals.">
     <link rel="canonical" href="https://metrixrealty.com/services/commercial-property-valuations">
     <!-- Open Graph -->
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Metrix Realty Group">
-    <meta property="og:title" content="Commercial Property Valuations Ontario | AACI Certified Appraisers | Metrix Realty">
-    <meta property="og:description" content="Precise, lender-approved commercial property valuations by AACI-designated professionals. Office, retail, industrial, and investment properties across Southwestern Ontario. 30+ years experience.">
+    <meta property="og:title" content="Commercial Property Valuations Ontario | Metrix Realty">
+    <meta property="og:description" content="AACI commercial property valuations across Ontario. Expert office, retail, and industrial appraisals. Trusted by lenders and legal professionals.">
     <meta property="og:url" content="https://metrixrealty.com/services/commercial-property-valuations">
     <meta property="og:image" content="https://metrixrealty.com/assets/images/metrix-realty-logo.png">
     <meta name="twitter:card" content="summary_large_image">
@@ -180,54 +180,73 @@
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex items-center justify-between h-16 sm:h-20">
+                <!-- Logo -->
                 <div class="flex-shrink-0">
-                    <a href="/services">
-                        <img src="../assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
+                    <a href="/">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
                     </a>
                 </div>
+                
+                <!-- Desktop Navigation -->
                 <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
-                    <a href="/services" class="nav-link text-gray-900 font-semibold">Home</a>
+                    <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
                     <div class="relative group">
-                        <a href="/services" class="nav-link active text-gray-900 font-semibold">Services</a>
-                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-96 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                        <a href="/services" class="nav-link active text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Services</a>
+                        <!-- Mega Menu -->
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-96 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50 backdrop-blur-sm">
                             <div class="p-8">
-                                <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
-                                <div class="space-y-1">
-                                    <a href="/services/commercial-property-valuations" class="block p-4 rounded-lg hover:bg-gray-50">
-                                        <div class="font-semibold text-gray-900 mb-1">Commercial Appraisals</div>
-                                        <div class="text-sm text-gray-600">Expert valuations for office, retail, and industrial properties</div>
-                                    </a>
-                                    <a href="/services/residential-property-appraisals" class="block p-4 rounded-lg hover:bg-gray-50">
-                                        <div class="font-semibold text-gray-900 mb-1">Residential Appraisals</div>
-                                        <div class="text-sm text-gray-600">Professional home valuations for mortgages, refinancing, and legal matters</div>
-                                    </a>
-                                    <a href="/services/litigation-support-expert-testimony" class="block p-4 rounded-lg hover:bg-gray-50">
-                                        <div class="font-semibold text-gray-900 mb-1">Litigation Support</div>
-                                        <div class="text-sm text-gray-600">Expert witness testimony and legal valuations</div>
-                                    </a>
-                                    <a href="/services/real-estate-consulting" class="block p-4 rounded-lg hover:bg-gray-50">
-                                        <div class="font-semibold text-gray-900 mb-1">Real Estate Consulting</div>
-                                        <div class="text-sm text-gray-600">Strategic market analysis and investment advisory services</div>
-                                    </a>
-                                    <a href="/services/government-institutional-services" class="block p-4 rounded-lg hover:bg-gray-50">
-                                        <div class="font-semibold text-gray-900 mb-1">Government & Institutional Services</div>
-                                        <div class="text-sm text-gray-600">Specialized services for federal, provincial, and municipal clients</div>
-                                    </a>
+                                <div>
+                                    <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
+                                    <div class="space-y-1">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
+                                        </a>
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
+                                        </a>
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
+                                        </a>
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
+                                        </a>
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
+                                        </a>
+                                    </div>
                                 </div>
                             </div>
                         </div>
                     </div>
-                    <a href="/market-areas" class="nav-link text-gray-900 font-semibold">Market Areas</a>
-                    <a href="/team" class="nav-link text-gray-900 font-semibold">Team</a>
-                    <a href="/contact" class="nav-link text-gray-900 font-semibold">Contact</a>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
                 </div>
+                
+                <!-- CTA Button -->
                 <div class="hidden md:block">
-                    <a href="/contact" class="inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
                         Connect with an Appraiser
                     </a>
                 </div>
+                
+                <!-- Mobile menu button -->
                 <div class="md:hidden">
-                    <button id="mobile-menu-button" class="text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
+                    <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
                         <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
                             <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
                             <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
@@ -237,6 +256,37 @@
                 </div>
             </div>
         </nav>
+
+        <!-- Mobile Menu -->
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+            
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link active">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+                    
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+
+        <!-- Mobile Menu Overlay -->
+        <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
     </header>
 
     <!-- Mobile Menu -->
@@ -251,6 +301,8 @@
                 <a href="/services" class="mobile-nav-link">Home</a>
                 <a href="/services" class="mobile-nav-link active">Services</a>
                 <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
                 <a href="/team" class="mobile-nav-link">Team</a>
                 <a href="/contact" class="mobile-nav-link">Contact</a>
                 <div style="margin-top: 32px;">
@@ -529,61 +581,78 @@
     <footer class="bg-black text-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
+                <!-- Company Info -->
                 <div class="lg:col-span-1">
-                    <img src="../assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
-                    <p class="text-gray-300 mb-6 leading-relaxed">Trusted • Valued • Experienced</p>
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-6 leading-relaxed">
+                        Trusted • Valued • Experienced
+                    </p>
                     <div class="text-gray-300">
                         <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
                         <p class="mb-4">London, ON N6A 5J9</p>
                         <p class="font-semibold text-white flex items-center">
-                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/></svg>
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
+                            </svg>
                             <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
                         </p>
                         <p>Toll Free: 1-866-672-9101</p>
                         <p>Fax: (519) 672-9321</p>
                         <p class="mt-4 font-semibold text-white flex items-center">
-                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                            </svg>
                             <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
                         </p>
                     </div>
                 </div>
+                
+                <!-- Services -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
                     <ul class="space-y-3 text-gray-300">
-                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Valuation</a></li>
-                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisals</a></li>
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
                         <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
                         <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
                         <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
                         <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
                     </ul>
                 </div>
+                
+                <!-- Market Areas -->
                 <div>
-                    <h3 class="text-white font-semibold text-lg mb-6">Market Areas</h3>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">London–Middlesex–Elgin</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Windsor–Essex</a></li>
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Oxford County</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Huron–Perth–Wellington</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Niagara Region</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Halton–Peel</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Full Coverage Map</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
                     </ul>
                 </div>
+                
+                <!-- Company -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
+                        <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
                         <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
                     </ul>
                 </div>
             </div>
+            
+            <!-- Professional Affiliations -->
             <div class="border-t border-gray-800 pt-8 mb-8 text-center">
-                <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
+                <div class="mb-6">
+                    <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
+                </div>
                 <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
                     <span>AIC - Appraisal Institute of Canada</span>
                     <span>RICS - Royal Institution of Chartered Surveyors</span>
@@ -599,8 +668,16 @@
                     <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
                 </div>
             </div>
+            
+            <!-- Copyright -->
             <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
                 <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
             </div>
         </div>
     </footer>

--- a/services/government-institutional-services/index.html
+++ b/services/government-institutional-services/index.html
@@ -3,15 +3,15 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Government & Institutional Appraisal Services Ontario | Municipal Valuations | Metrix Realty</title>
+    <title>Government & Institutional Appraisal Services | Metrix</title>
     <link rel="icon" type="image/png" href="/favicon.png">
-    <meta name="description" content="Confidential, professional advisory services for public sector clients. Expropriation valuations, acquisition and disposition, asset management, and policy support for municipalities, school boards, healthcare institutions, and public agencies across Ontario.">
+    <meta name="description" content="Specialized appraisal services for federal, provincial, and municipal clients in Ontario. AACI-designated professionals with institutional expertise.">
     <link rel="canonical" href="https://metrixrealty.com/services/government-institutional-services">
     <!-- Open Graph -->
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Metrix Realty Group">
-    <meta property="og:title" content="Government &amp; Institutional Appraisal Services Ontario | Municipal Valuations | Metrix Realty">
-    <meta property="og:description" content="Confidential appraisal and advisory services for public sector clients. Expropriation, acquisition, asset management, and policy support for municipalities, school boards, and public agencies across Ontario.">
+    <meta property="og:title" content="Government & Institutional Appraisal Services | Metrix">
+    <meta property="og:description" content="Specialized appraisal services for federal, provincial, and municipal clients in Ontario. AACI-designated professionals with institutional expertise.">
     <meta property="og:url" content="https://metrixrealty.com/services/government-institutional-services">
     <meta property="og:image" content="https://metrixrealty.com/assets/images/metrix-realty-logo.png">
     <meta name="twitter:card" content="summary_large_image">
@@ -156,31 +156,73 @@
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex items-center justify-between h-16 sm:h-20">
-                <div class="flex-shrink-0"><a href="/services"><img src="../assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto"></a></div>
+                <!-- Logo -->
+                <div class="flex-shrink-0">
+                    <a href="/">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
+                    </a>
+                </div>
+                
+                <!-- Desktop Navigation -->
                 <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
-                    <a href="/services" class="nav-link text-gray-900 font-semibold">Home</a>
+                    <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
                     <div class="relative group">
-                        <a href="/services" class="nav-link active text-gray-900 font-semibold">Services</a>
-                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-96 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                        <a href="/services" class="nav-link active text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Services</a>
+                        <!-- Mega Menu -->
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-96 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50 backdrop-blur-sm">
                             <div class="p-8">
-                                <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
-                                <div class="space-y-1">
-                                    <a href="/services/commercial-property-valuations" class="block p-4 rounded-lg hover:bg-gray-50"><div class="font-semibold text-gray-900 mb-1">Commercial Appraisals</div><div class="text-sm text-gray-600">Expert valuations for office, retail, and industrial properties</div></a>
-                                    <a href="/services/residential-property-appraisals" class="block p-4 rounded-lg hover:bg-gray-50"><div class="font-semibold text-gray-900 mb-1">Residential Appraisals</div><div class="text-sm text-gray-600">Professional home valuations for mortgages, refinancing, and legal matters</div></a>
-                                    <a href="/services/litigation-support-expert-testimony" class="block p-4 rounded-lg hover:bg-gray-50"><div class="font-semibold text-gray-900 mb-1">Litigation Support</div><div class="text-sm text-gray-600">Expert witness testimony and legal valuations</div></a>
-                                    <a href="/services/real-estate-consulting" class="block p-4 rounded-lg hover:bg-gray-50"><div class="font-semibold text-gray-900 mb-1">Real Estate Consulting</div><div class="text-sm text-gray-600">Strategic market analysis and investment advisory services</div></a>
-                                    <a href="/services/government-institutional-services" class="block p-4 rounded-lg hover:bg-gray-50"><div class="font-semibold text-gray-900 mb-1">Government and Institutional Appraisal Services</div><div class="text-sm text-gray-600">Specialized services for federal, provincial, and municipal clients</div></a>
+                                <div>
+                                    <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
+                                    <div class="space-y-1">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
+                                        </a>
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
+                                        </a>
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
+                                        </a>
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
+                                        </a>
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
+                                        </a>
+                                    </div>
                                 </div>
                             </div>
                         </div>
                     </div>
-                    <a href="/market-areas" class="nav-link text-gray-900 font-semibold">Market Areas</a>
-                    <a href="/team" class="nav-link text-gray-900 font-semibold">Team</a>
-                    <a href="/contact" class="nav-link text-gray-900 font-semibold">Contact</a>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
                 </div>
-                <div class="hidden md:block"><a href="/contact" class="inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">Discuss Your Project</a></div>
+                
+                <!-- CTA Button -->
+                <div class="hidden md:block">
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
+                        Connect with an Appraiser
+                    </a>
+                </div>
+                
+                <!-- Mobile menu button -->
                 <div class="md:hidden">
-                    <button id="mobile-menu-button" class="text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
+                    <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
                         <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
                             <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
                             <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
@@ -190,6 +232,37 @@
                 </div>
             </div>
         </nav>
+
+        <!-- Mobile Menu -->
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+            
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link active">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+                    
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+
+        <!-- Mobile Menu Overlay -->
+        <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
     </header>
 
     <div id="mobile-menu" class="mobile-menu">
@@ -199,6 +272,8 @@
                 <a href="/services" class="mobile-nav-link">Home</a>
                 <a href="/services" class="mobile-nav-link active">Services</a>
                 <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
                 <a href="/team" class="mobile-nav-link">Team</a>
                 <a href="/contact" class="mobile-nav-link">Contact</a>
                 <div style="margin-top: 32px;"><a href="/contact" class="block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">Discuss Your Project</a></div>
@@ -380,54 +455,104 @@
     <footer class="bg-black text-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
+                <!-- Company Info -->
                 <div class="lg:col-span-1">
-                    <img src="../assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
-                    <p class="text-gray-300 mb-6 leading-relaxed">Trusted • Valued • Experienced</p>
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-6 leading-relaxed">
+                        Trusted • Valued • Experienced
+                    </p>
                     <div class="text-gray-300">
                         <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
                         <p class="mb-4">London, ON N6A 5J9</p>
-                        <p class="font-semibold text-white flex items-center"><svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/></svg><a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a></p>
-                        <p>Toll Free: 1-866-672-9101</p><p>Fax: (519) 672-9321</p>
-                        <p class="mt-4 font-semibold text-white flex items-center"><svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg><a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a></p>
+                        <p class="font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
+                            </svg>
+                            <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
+                        </p>
+                        <p>Toll Free: 1-866-672-9101</p>
+                        <p>Fax: (519) 672-9321</p>
+                        <p class="mt-4 font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                            </svg>
+                            <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
+                        </p>
                     </div>
                 </div>
+                
+                <!-- Services -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
                     <ul class="space-y-3 text-gray-300">
-                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Valuation</a></li>
-                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisals</a></li>
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
                         <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
                         <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
                         <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
                         <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
                     </ul>
                 </div>
+                
+                <!-- Market Areas -->
                 <div>
-                    <h3 class="text-white font-semibold text-lg mb-6">Market Areas</h3>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">London–Middlesex–Elgin</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Windsor–Essex</a></li>
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Full Coverage Map</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
                     </ul>
                 </div>
+                
+                <!-- Company -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
+                        <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
                         <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
                     </ul>
                 </div>
             </div>
+            
+            <!-- Professional Affiliations -->
             <div class="border-t border-gray-800 pt-8 mb-8 text-center">
-                <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
-                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6"><span>AIC - Appraisal Institute of Canada</span><span>RICS - Royal Institution of Chartered Surveyors</span><span>AOLE - Association of Ontario Land Economists</span><span>IRWA - International Right of Way Association</span></div>
-                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6"><span>Data Providers:</span><span>CoStar Professional</span><span>TRREB - Toronto Regional Real Estate Board</span></div>
-                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6"><p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p></div>
+                <div class="mb-6">
+                    <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
+                    <span>AIC - Appraisal Institute of Canada</span>
+                    <span>RICS - Royal Institution of Chartered Surveyors</span>
+                    <span>AOLE - Association of Ontario Land Economists</span>
+                    <span>IRWA - International Right of Way Association</span>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6">
+                    <span>Data Providers:</span>
+                    <span>CoStar Professional</span>
+                    <span>TRREB - Toronto Regional Real Estate Board</span>
+                </div>
+                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
+                    <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
+                </div>
             </div>
-            <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm"><p>&copy; 2025 Metrix Realty Group. All rights reserved.</p></div>
+            
+            <!-- Copyright -->
+            <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
+                <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
+            </div>
         </div>
     </footer>
 

--- a/services/index.html
+++ b/services/index.html
@@ -3,17 +3,17 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>ICI & Commercial Appraisal Services Ontario | Industrial Commercial Investment | Metrix Realty Group</title>
+    <title>Commercial Appraisal Services Ontario | Metrix Realty Group</title>
     <link rel="icon" type="image/png" href="/favicon.png">
-    <meta name="description" content="Metrix Realty Group provides ICI (Industrial, Commercial, Investment) property appraisals, residential valuations, litigation support, and expert witness testimony across Ontario. AACI-designated, lender-recognized. Serving London and Southwestern Ontario since 1995.">
+    <meta name="description" content="AACI-certified ICI appraisal services across Ontario. Commercial, industrial, and investment property valuations for lenders, lawyers, and corporate clients.">
     <meta name="keywords" content="ICI appraisal Ontario, commercial property appraisal London, industrial commercial investment, residential appraisal, litigation support appraiser, expert witness testimony, AACI designated appraiser Ontario, lender recognized appraisal, Metrix Realty Group">
     <meta name="llms-txt" content="Metrix Realty Group is London, Ontario's leading ICI (Industrial, Commercial, Investment) property appraisal firm. Services include commercial appraisals, residential valuations, litigation support, expert witness testimony, and government/institutional appraisals. AACI-designated team, lender-recognized by all major Canadian banks. Founded 1995. For more information see https://metrixrealty.com/llms.txt">
     <link rel="canonical" href="https://metrixrealty.com/services">
     <!-- Open Graph -->
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Metrix Realty Group">
-    <meta property="og:title" content="ICI &amp; Commercial Appraisal Services Ontario | Metrix Realty Group">
-    <meta property="og:description" content="Metrix Realty Group provides ICI property appraisals, residential valuations, litigation support, and expert witness testimony across Ontario. AACI-designated, lender-recognized.">
+    <meta property="og:title" content="Commercial Appraisal Services Ontario | Metrix Realty Group">
+    <meta property="og:description" content="AACI-certified ICI appraisal services across Ontario. Commercial, industrial, and investment property valuations for lenders, lawyers, and corporate clients.">
     <meta property="og:url" content="https://metrixrealty.com/services">
     <meta property="og:image" content="https://metrixrealty.com/assets/images/metrix-realty-logo.png">
     <meta name="twitter:card" content="summary_large_image">
@@ -388,7 +388,7 @@
                         <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
                     </a>
                 </div>
-
+                
                 <!-- Desktop Navigation -->
                 <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
                     <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
@@ -400,23 +400,23 @@
                                 <div>
                                     <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
                                     <div class="space-y-1">
-                                        <a href="/services#commercial" class="mega-menu-item block p-4">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
                                         </a>
-                                        <a href="/services#residential" class="mega-menu-item block p-4">
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
                                         </a>
-                                        <a href="/services#litigation" class="mega-menu-item block p-4">
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
                                         </a>
-                                        <a href="/services#consulting" class="mega-menu-item block p-4">
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
                                         </a>
-                                        <a href="/services#government" class="mega-menu-item block p-4">
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
                                         </a>
@@ -425,19 +425,27 @@
                             </div>
                         </div>
                     </div>
-                    <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
                     <a href="/team" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
-                    <!-- <a href="/insights" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Insights</a> -->
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
                     <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
                 </div>
-
+                
                 <!-- CTA Button -->
                 <div class="hidden md:block">
                     <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
                         Connect with an Appraiser
                     </a>
                 </div>
-
+                
                 <!-- Mobile menu button -->
                 <div class="md:hidden">
                     <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
@@ -450,6 +458,37 @@
                 </div>
             </div>
         </nav>
+
+        <!-- Mobile Menu -->
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+            
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link active">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+                    
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+
+        <!-- Mobile Menu Overlay -->
+        <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
     </header>
 
     <!-- Mobile Menu -->
@@ -465,6 +504,8 @@
                 <a href="/" class="mobile-nav-link">Home</a>
                 <a href="#" class="mobile-nav-link active">Services</a>
                 <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
                 <a href="/team" class="mobile-nav-link">Team</a>
                 <!-- <a href="/insights" class="mobile-nav-link">Market Insights</a> -->
                 <a href="/contact" class="mobile-nav-link">Contact</a>
@@ -494,7 +535,7 @@
                 </div>
 
                 <h1 class="text-4xl sm:text-5xl lg:text-6xl font-bold mb-10 leading-tight" data-aos="fade-up" data-aos-duration="1000">
-                                            Accredited Real Estate Appraisal Services
+                                            Commercial Real Estate Appraisal Services in Ontario
                 </h1>
                 <p class="text-lg sm:text-xl lg:text-2xl mb-16 opacity-90 max-w-4xl mx-auto leading-relaxed" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="200">
                     From commercial properties to residential homes, our AACI and CRA designated professionals deliver precise, reliable valuations that support your most important decisions.
@@ -1104,49 +1145,48 @@
                         </p>
                     </div>
                 </div>
-
+                
                 <!-- Services -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
                     <ul class="space-y-3 text-gray-300">
-                        <li><a href="/services#commercial" class="hover:text-white transition-colors duration-200">Commercial Valuation</a></li>
-                        <li><a href="/services#residential" class="hover:text-white transition-colors duration-200">Residential Appraisals</a></li>
-                        <li><a href="/services#litigation" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
-                        <li><a href="/services#consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
-                        <li><a href="/services#government" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
                         <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
                     </ul>
                 </div>
-
+                
                 <!-- Market Areas -->
                 <div>
-                    <h3 class="text-white font-semibold text-lg mb-6">Market Areas</h3>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">London–Middlesex–Elgin</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Windsor–Essex</a></li>
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Oxford County</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Huron–Perth–Wellington</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Niagara Region</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Halton–Peel</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Full Coverage Map</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
                     </ul>
                 </div>
-
+                
                 <!-- Company -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
-                        <li><a href="/insights" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
+                        <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
                         <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
                     </ul>
                 </div>
             </div>
-
+            
             <!-- Professional Affiliations -->
             <div class="border-t border-gray-800 pt-8 mb-8 text-center">
                 <div class="mb-6">
@@ -1167,10 +1207,16 @@
                     <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
                 </div>
             </div>
-
+            
             <!-- Copyright -->
             <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
                 <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
             </div>
         </div>
     </footer>

--- a/services/litigation-support-expert-testimony/index.html
+++ b/services/litigation-support-expert-testimony/index.html
@@ -3,15 +3,15 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Litigation Support & Expert Witness Testimony | Real Estate Appraisers | Metrix Realty</title>
+    <title>Litigation Support & Expert Testimony Ontario | Metrix</title>
     <link rel="icon" type="image/png" href="/favicon.png">
-    <meta name="description" content="Court-ready valuations and professional expert witness testimony by AACI-designated appraisers. Decades of experience before Ontario courts, the Assessment Review Board, and Ontario Land Tribunal.">
+    <meta name="description" content="AACI-designated appraisers providing litigation support and expert witness testimony for Ontario courts, lawyers, and arbitration proceedings.">
     <link rel="canonical" href="https://metrixrealty.com/services/litigation-support-expert-testimony">
     <!-- Open Graph -->
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Metrix Realty Group">
-    <meta property="og:title" content="Litigation Support &amp; Expert Witness Testimony | Real Estate Appraisers | Metrix Realty">
-    <meta property="og:description" content="Court-ready valuations and professional expert witness testimony by AACI-designated appraisers. Decades of experience before Ontario courts, the Assessment Review Board, and Ontario Land Tribunal.">
+    <meta property="og:title" content="Litigation Support & Expert Testimony Ontario | Metrix">
+    <meta property="og:description" content="AACI-designated appraisers providing litigation support and expert witness testimony for Ontario courts, lawyers, and arbitration proceedings.">
     <meta property="og:url" content="https://metrixrealty.com/services/litigation-support-expert-testimony">
     <meta property="og:image" content="https://metrixrealty.com/assets/images/metrix-realty-logo.png">
     <meta name="twitter:card" content="summary_large_image">
@@ -156,31 +156,73 @@
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex items-center justify-between h-16 sm:h-20">
-                <div class="flex-shrink-0"><a href="/services"><img src="../assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto"></a></div>
+                <!-- Logo -->
+                <div class="flex-shrink-0">
+                    <a href="/">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
+                    </a>
+                </div>
+                
+                <!-- Desktop Navigation -->
                 <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
-                    <a href="/services" class="nav-link text-gray-900 font-semibold">Home</a>
+                    <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
                     <div class="relative group">
-                        <a href="/services" class="nav-link active text-gray-900 font-semibold">Services</a>
-                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-96 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                        <a href="/services" class="nav-link active text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Services</a>
+                        <!-- Mega Menu -->
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-96 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50 backdrop-blur-sm">
                             <div class="p-8">
-                                <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
-                                <div class="space-y-1">
-                                    <a href="/services/commercial-property-valuations" class="block p-4 rounded-lg hover:bg-gray-50"><div class="font-semibold text-gray-900 mb-1">Commercial Appraisals</div><div class="text-sm text-gray-600">Expert valuations for office, retail, and industrial properties</div></a>
-                                    <a href="/services/residential-property-appraisals" class="block p-4 rounded-lg hover:bg-gray-50"><div class="font-semibold text-gray-900 mb-1">Residential Appraisals</div><div class="text-sm text-gray-600">Professional home valuations for mortgages, refinancing, and legal matters</div></a>
-                                    <a href="/services/litigation-support-expert-testimony" class="block p-4 rounded-lg hover:bg-gray-50"><div class="font-semibold text-gray-900 mb-1">Litigation Support</div><div class="text-sm text-gray-600">Expert witness testimony and legal valuations</div></a>
-                                    <a href="/services/real-estate-consulting" class="block p-4 rounded-lg hover:bg-gray-50"><div class="font-semibold text-gray-900 mb-1">Real Estate Consulting</div><div class="text-sm text-gray-600">Strategic market analysis and investment advisory services</div></a>
-                                    <a href="/services/government-institutional-services" class="block p-4 rounded-lg hover:bg-gray-50"><div class="font-semibold text-gray-900 mb-1">Government & Institutional Services</div><div class="text-sm text-gray-600">Specialized services for federal, provincial, and municipal clients</div></a>
+                                <div>
+                                    <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
+                                    <div class="space-y-1">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
+                                        </a>
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
+                                        </a>
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
+                                        </a>
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
+                                        </a>
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
+                                        </a>
+                                    </div>
                                 </div>
                             </div>
                         </div>
                     </div>
-                    <a href="/market-areas" class="nav-link text-gray-900 font-semibold">Market Areas</a>
-                    <a href="/team" class="nav-link text-gray-900 font-semibold">Team</a>
-                    <a href="/contact" class="nav-link text-gray-900 font-semibold">Contact</a>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
                 </div>
-                <div class="hidden md:block"><a href="/contact" class="inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">Connect with an Appraiser</a></div>
+                
+                <!-- CTA Button -->
+                <div class="hidden md:block">
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
+                        Connect with an Appraiser
+                    </a>
+                </div>
+                
+                <!-- Mobile menu button -->
                 <div class="md:hidden">
-                    <button id="mobile-menu-button" class="text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
+                    <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
                         <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
                             <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
                             <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
@@ -190,6 +232,37 @@
                 </div>
             </div>
         </nav>
+
+        <!-- Mobile Menu -->
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+            
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link active">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+                    
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+
+        <!-- Mobile Menu Overlay -->
+        <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
     </header>
 
     <div id="mobile-menu" class="mobile-menu">
@@ -199,6 +272,8 @@
                 <a href="/services" class="mobile-nav-link">Home</a>
                 <a href="/services" class="mobile-nav-link active">Services</a>
                 <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
                 <a href="/team" class="mobile-nav-link">Team</a>
                 <a href="/contact" class="mobile-nav-link">Contact</a>
                 <div style="margin-top: 32px;"><a href="/contact" class="block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">Connect with an Appraiser</a></div>
@@ -378,58 +453,104 @@
     <footer class="bg-black text-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
+                <!-- Company Info -->
                 <div class="lg:col-span-1">
-                    <img src="../assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
-                    <p class="text-gray-300 mb-6 leading-relaxed">Trusted • Valued • Experienced</p>
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-6 leading-relaxed">
+                        Trusted • Valued • Experienced
+                    </p>
                     <div class="text-gray-300">
                         <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
                         <p class="mb-4">London, ON N6A 5J9</p>
-                        <p class="font-semibold text-white flex items-center"><svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/></svg><a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a></p>
-                        <p>Toll Free: 1-866-672-9101</p><p>Fax: (519) 672-9321</p>
-                        <p class="mt-4 font-semibold text-white flex items-center"><svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg><a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a></p>
+                        <p class="font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
+                            </svg>
+                            <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
+                        </p>
+                        <p>Toll Free: 1-866-672-9101</p>
+                        <p>Fax: (519) 672-9321</p>
+                        <p class="mt-4 font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                            </svg>
+                            <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
+                        </p>
                     </div>
                 </div>
+                
+                <!-- Services -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
                     <ul class="space-y-3 text-gray-300">
-                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Valuation</a></li>
-                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisals</a></li>
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
                         <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
                         <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
                         <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
                         <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
                     </ul>
                 </div>
+                
+                <!-- Market Areas -->
                 <div>
-                    <h3 class="text-white font-semibold text-lg mb-6">Market Areas</h3>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">London–Middlesex–Elgin</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Windsor–Essex</a></li>
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Full Coverage Map</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
                     </ul>
                 </div>
+                
+                <!-- Company -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
+                        <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
                         <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
                     </ul>
                 </div>
             </div>
+            
+            <!-- Professional Affiliations -->
             <div class="border-t border-gray-800 pt-8 mb-8 text-center">
-                <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
+                <div class="mb-6">
+                    <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
+                </div>
                 <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
-                    <span>AIC - Appraisal Institute of Canada</span><span>RICS - Royal Institution of Chartered Surveyors</span><span>AOLE - Association of Ontario Land Economists</span><span>IRWA - International Right of Way Association</span>
+                    <span>AIC - Appraisal Institute of Canada</span>
+                    <span>RICS - Royal Institution of Chartered Surveyors</span>
+                    <span>AOLE - Association of Ontario Land Economists</span>
+                    <span>IRWA - International Right of Way Association</span>
                 </div>
                 <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6">
-                    <span>Data Providers:</span><span>CoStar Professional</span><span>TRREB - Toronto Regional Real Estate Board</span>
+                    <span>Data Providers:</span>
+                    <span>CoStar Professional</span>
+                    <span>TRREB - Toronto Regional Real Estate Board</span>
                 </div>
-                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6"><p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p></div>
+                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
+                    <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
+                </div>
             </div>
-            <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm"><p>&copy; 2025 Metrix Realty Group. All rights reserved.</p></div>
+            
+            <!-- Copyright -->
+            <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
+                <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
+            </div>
         </div>
     </footer>
 

--- a/services/real-estate-consulting/index.html
+++ b/services/real-estate-consulting/index.html
@@ -3,15 +3,15 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Real Estate Consulting & Advisory Services Ontario | Market Analysis | Metrix Realty</title>
+    <title>Real Estate Consulting Services Ontario | Metrix Realty</title>
     <link rel="icon" type="image/png" href="/favicon.png">
-    <meta name="description" content="Data-driven real estate consulting by AACI-designated professionals. Feasibility studies, market analysis, investment advisory, and highest & best use studies for developers, investors, and property owners across Southwestern Ontario.">
+    <meta name="description" content="Strategic real estate consulting and advisory services by AACI professionals. Market analysis for investors, developers, and institutions in Ontario.">
     <link rel="canonical" href="https://metrixrealty.com/services/real-estate-consulting">
     <!-- Open Graph -->
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Metrix Realty Group">
-    <meta property="og:title" content="Real Estate Consulting &amp; Advisory Services Ontario | Market Analysis | Metrix Realty">
-    <meta property="og:description" content="Data-driven real estate consulting by AACI-designated professionals. Feasibility studies, market analysis, investment advisory, and highest &amp; best use studies across Southwestern Ontario.">
+    <meta property="og:title" content="Real Estate Consulting Services Ontario | Metrix Realty">
+    <meta property="og:description" content="Strategic real estate consulting and advisory services by AACI professionals. Market analysis for investors, developers, and institutions in Ontario.">
     <meta property="og:url" content="https://metrixrealty.com/services/real-estate-consulting">
     <meta property="og:image" content="https://metrixrealty.com/assets/images/metrix-realty-logo.png">
     <meta name="twitter:card" content="summary_large_image">
@@ -156,31 +156,73 @@
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex items-center justify-between h-16 sm:h-20">
-                <div class="flex-shrink-0"><a href="/services"><img src="../assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto"></a></div>
+                <!-- Logo -->
+                <div class="flex-shrink-0">
+                    <a href="/">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
+                    </a>
+                </div>
+                
+                <!-- Desktop Navigation -->
                 <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
-                    <a href="/services" class="nav-link text-gray-900 font-semibold">Home</a>
+                    <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
                     <div class="relative group">
-                        <a href="/services" class="nav-link active text-gray-900 font-semibold">Services</a>
-                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-96 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                        <a href="/services" class="nav-link active text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Services</a>
+                        <!-- Mega Menu -->
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-96 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50 backdrop-blur-sm">
                             <div class="p-8">
-                                <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
-                                <div class="space-y-1">
-                                    <a href="/services/commercial-property-valuations" class="block p-4 rounded-lg hover:bg-gray-50"><div class="font-semibold text-gray-900 mb-1">Commercial Appraisals</div><div class="text-sm text-gray-600">Expert valuations for office, retail, and industrial properties</div></a>
-                                    <a href="/services/residential-property-appraisals" class="block p-4 rounded-lg hover:bg-gray-50"><div class="font-semibold text-gray-900 mb-1">Residential Appraisals</div><div class="text-sm text-gray-600">Professional home valuations for mortgages, refinancing, and legal matters</div></a>
-                                    <a href="/services/litigation-support-expert-testimony" class="block p-4 rounded-lg hover:bg-gray-50"><div class="font-semibold text-gray-900 mb-1">Litigation Support</div><div class="text-sm text-gray-600">Expert witness testimony and legal valuations</div></a>
-                                    <a href="/services/real-estate-consulting" class="block p-4 rounded-lg hover:bg-gray-50"><div class="font-semibold text-gray-900 mb-1">Real Estate Consulting</div><div class="text-sm text-gray-600">Strategic market analysis and investment advisory services</div></a>
-                                    <a href="/services/government-institutional-services" class="block p-4 rounded-lg hover:bg-gray-50"><div class="font-semibold text-gray-900 mb-1">Government & Institutional Services</div><div class="text-sm text-gray-600">Specialized services for federal, provincial, and municipal clients</div></a>
+                                <div>
+                                    <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
+                                    <div class="space-y-1">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
+                                        </a>
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
+                                        </a>
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
+                                        </a>
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
+                                        </a>
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
+                                        </a>
+                                    </div>
                                 </div>
                             </div>
                         </div>
                     </div>
-                    <a href="/market-areas" class="nav-link text-gray-900 font-semibold">Market Areas</a>
-                    <a href="/team" class="nav-link text-gray-900 font-semibold">Team</a>
-                    <a href="/contact" class="nav-link text-gray-900 font-semibold">Contact</a>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
                 </div>
-                <div class="hidden md:block"><a href="/contact" class="inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">Connect with an Appraiser</a></div>
+                
+                <!-- CTA Button -->
+                <div class="hidden md:block">
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
+                        Connect with an Appraiser
+                    </a>
+                </div>
+                
+                <!-- Mobile menu button -->
                 <div class="md:hidden">
-                    <button id="mobile-menu-button" class="text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
+                    <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
                         <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
                             <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
                             <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
@@ -190,6 +232,37 @@
                 </div>
             </div>
         </nav>
+
+        <!-- Mobile Menu -->
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+            
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link active">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+                    
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+
+        <!-- Mobile Menu Overlay -->
+        <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
     </header>
 
     <div id="mobile-menu" class="mobile-menu">
@@ -199,6 +272,8 @@
                 <a href="/services" class="mobile-nav-link">Home</a>
                 <a href="/services" class="mobile-nav-link active">Services</a>
                 <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
                 <a href="/team" class="mobile-nav-link">Team</a>
                 <a href="/contact" class="mobile-nav-link">Contact</a>
                 <div style="margin-top: 32px;"><a href="/contact" class="block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">Connect with an Appraiser</a></div>
@@ -367,54 +442,104 @@
     <footer class="bg-black text-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
+                <!-- Company Info -->
                 <div class="lg:col-span-1">
-                    <img src="../assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
-                    <p class="text-gray-300 mb-6 leading-relaxed">Trusted • Valued • Experienced</p>
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-6 leading-relaxed">
+                        Trusted • Valued • Experienced
+                    </p>
                     <div class="text-gray-300">
                         <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
                         <p class="mb-4">London, ON N6A 5J9</p>
-                        <p class="font-semibold text-white flex items-center"><svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/></svg><a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a></p>
-                        <p>Toll Free: 1-866-672-9101</p><p>Fax: (519) 672-9321</p>
-                        <p class="mt-4 font-semibold text-white flex items-center"><svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg><a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a></p>
+                        <p class="font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
+                            </svg>
+                            <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
+                        </p>
+                        <p>Toll Free: 1-866-672-9101</p>
+                        <p>Fax: (519) 672-9321</p>
+                        <p class="mt-4 font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                            </svg>
+                            <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
+                        </p>
                     </div>
                 </div>
+                
+                <!-- Services -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
                     <ul class="space-y-3 text-gray-300">
-                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Valuation</a></li>
-                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisals</a></li>
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
                         <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
                         <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
                         <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
                         <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
                     </ul>
                 </div>
+                
+                <!-- Market Areas -->
                 <div>
-                    <h3 class="text-white font-semibold text-lg mb-6">Market Areas</h3>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">London–Middlesex–Elgin</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Windsor–Essex</a></li>
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Full Coverage Map</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
                     </ul>
                 </div>
+                
+                <!-- Company -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
+                        <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
                         <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
                     </ul>
                 </div>
             </div>
+            
+            <!-- Professional Affiliations -->
             <div class="border-t border-gray-800 pt-8 mb-8 text-center">
-                <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
-                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6"><span>AIC - Appraisal Institute of Canada</span><span>RICS - Royal Institution of Chartered Surveyors</span><span>AOLE - Association of Ontario Land Economists</span><span>IRWA - International Right of Way Association</span></div>
-                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6"><span>Data Providers:</span><span>CoStar Professional</span><span>TRREB - Toronto Regional Real Estate Board</span></div>
-                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6"><p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p></div>
+                <div class="mb-6">
+                    <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
+                    <span>AIC - Appraisal Institute of Canada</span>
+                    <span>RICS - Royal Institution of Chartered Surveyors</span>
+                    <span>AOLE - Association of Ontario Land Economists</span>
+                    <span>IRWA - International Right of Way Association</span>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6">
+                    <span>Data Providers:</span>
+                    <span>CoStar Professional</span>
+                    <span>TRREB - Toronto Regional Real Estate Board</span>
+                </div>
+                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
+                    <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
+                </div>
             </div>
-            <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm"><p>&copy; 2025 Metrix Realty Group. All rights reserved.</p></div>
+            
+            <!-- Copyright -->
+            <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
+                <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
+            </div>
         </div>
     </footer>
 

--- a/services/residential-property-appraisals/index.html
+++ b/services/residential-property-appraisals/index.html
@@ -3,15 +3,15 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Residential Property Appraisals Ontario | AACI & CRA Certified | Metrix Realty</title>
+    <title>Residential Property Appraisals Ontario | Metrix Realty</title>
     <link rel="icon" type="image/png" href="/favicon.png">
-    <meta name="description" content="Accurate, lender-approved home valuations by AACI and CRA designated appraisers. Mortgage financing, estate planning, divorce proceedings, and property tax appeals across Southwestern Ontario.">
+    <meta name="description" content="AACI and CRA-certified residential appraisals across Ontario. Home valuations for mortgage financing, estate planning, divorce proceedings, and MPAC appeals.">
     <link rel="canonical" href="https://metrixrealty.com/services/residential-property-appraisals">
     <!-- Open Graph -->
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Metrix Realty Group">
-    <meta property="og:title" content="Residential Property Appraisals Ontario | AACI &amp; CRA Certified | Metrix Realty">
-    <meta property="og:description" content="Accurate, lender-approved home valuations by AACI and CRA designated appraisers. Mortgage financing, estate planning, divorce proceedings, and property tax appeals across Southwestern Ontario.">
+    <meta property="og:title" content="Residential Property Appraisals Ontario | Metrix Realty">
+    <meta property="og:description" content="AACI and CRA-certified residential appraisals across Ontario. Home valuations for mortgage financing, estate planning, divorce proceedings, and MPAC appeals.">
     <meta property="og:url" content="https://metrixrealty.com/services/residential-property-appraisals">
     <meta property="og:image" content="https://metrixrealty.com/assets/images/metrix-realty-logo.png">
     <meta name="twitter:card" content="summary_large_image">
@@ -167,37 +167,73 @@
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex items-center justify-between h-16 sm:h-20">
+                <!-- Logo -->
                 <div class="flex-shrink-0">
-                    <a href="/services">
-                        <img src="../assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
+                    <a href="/">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
                     </a>
                 </div>
+                
+                <!-- Desktop Navigation -->
                 <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
-                    <a href="/services" class="nav-link text-gray-900 font-semibold">Home</a>
+                    <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
                     <div class="relative group">
-                        <a href="/services" class="nav-link active text-gray-900 font-semibold">Services</a>
-                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-96 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                        <a href="/services" class="nav-link active text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Services</a>
+                        <!-- Mega Menu -->
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-96 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50 backdrop-blur-sm">
                             <div class="p-8">
-                                <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
-                                <div class="space-y-1">
-                                    <a href="/services/commercial-property-valuations" class="block p-4 rounded-lg hover:bg-gray-50"><div class="font-semibold text-gray-900 mb-1">Commercial Appraisals</div><div class="text-sm text-gray-600">Expert valuations for office, retail, and industrial properties</div></a>
-                                    <a href="/services/residential-property-appraisals" class="block p-4 rounded-lg hover:bg-gray-50"><div class="font-semibold text-gray-900 mb-1">Residential Appraisals</div><div class="text-sm text-gray-600">Professional home valuations for mortgages, refinancing, and legal matters</div></a>
-                                    <a href="/services/litigation-support-expert-testimony" class="block p-4 rounded-lg hover:bg-gray-50"><div class="font-semibold text-gray-900 mb-1">Litigation Support</div><div class="text-sm text-gray-600">Expert witness testimony and legal valuations</div></a>
-                                    <a href="/services/real-estate-consulting" class="block p-4 rounded-lg hover:bg-gray-50"><div class="font-semibold text-gray-900 mb-1">Real Estate Consulting</div><div class="text-sm text-gray-600">Strategic market analysis and investment advisory services</div></a>
-                                    <a href="/services/government-institutional-services" class="block p-4 rounded-lg hover:bg-gray-50"><div class="font-semibold text-gray-900 mb-1">Government & Institutional Services</div><div class="text-sm text-gray-600">Specialized services for federal, provincial, and municipal clients</div></a>
+                                <div>
+                                    <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
+                                    <div class="space-y-1">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
+                                        </a>
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
+                                        </a>
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
+                                        </a>
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
+                                        </a>
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
+                                        </a>
+                                    </div>
                                 </div>
                             </div>
                         </div>
                     </div>
-                    <a href="/market-areas" class="nav-link text-gray-900 font-semibold">Market Areas</a>
-                    <a href="/team" class="nav-link text-gray-900 font-semibold">Team</a>
-                    <a href="/contact" class="nav-link text-gray-900 font-semibold">Contact</a>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
                 </div>
+                
+                <!-- CTA Button -->
                 <div class="hidden md:block">
-                    <a href="/contact" class="inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">Connect with an Appraiser</a>
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
+                        Connect with an Appraiser
+                    </a>
                 </div>
+                
+                <!-- Mobile menu button -->
                 <div class="md:hidden">
-                    <button id="mobile-menu-button" class="text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
+                    <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
                         <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
                             <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
                             <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
@@ -207,6 +243,37 @@
                 </div>
             </div>
         </nav>
+
+        <!-- Mobile Menu -->
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+            
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link active">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+                    
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+
+        <!-- Mobile Menu Overlay -->
+        <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
     </header>
 
     <div id="mobile-menu" class="mobile-menu">
@@ -218,6 +285,8 @@
                 <a href="/services" class="mobile-nav-link">Home</a>
                 <a href="/services" class="mobile-nav-link active">Services</a>
                 <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
                 <a href="/team" class="mobile-nav-link">Team</a>
                 <a href="/contact" class="mobile-nav-link">Contact</a>
                 <div style="margin-top: 32px;"><a href="/contact" class="block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">Connect with an Appraiser</a></div>
@@ -422,54 +491,78 @@
     <footer class="bg-black text-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
+                <!-- Company Info -->
                 <div class="lg:col-span-1">
-                    <img src="../assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
-                    <p class="text-gray-300 mb-6 leading-relaxed">Trusted • Valued • Experienced</p>
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-6 leading-relaxed">
+                        Trusted • Valued • Experienced
+                    </p>
                     <div class="text-gray-300">
                         <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
                         <p class="mb-4">London, ON N6A 5J9</p>
-                        <p class="font-semibold text-white flex items-center"><svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/></svg><a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a></p>
-                        <p>Toll Free: 1-866-672-9101</p><p>Fax: (519) 672-9321</p>
-                        <p class="mt-4 font-semibold text-white flex items-center"><svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg><a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a></p>
+                        <p class="font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
+                            </svg>
+                            <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
+                        </p>
+                        <p>Toll Free: 1-866-672-9101</p>
+                        <p>Fax: (519) 672-9321</p>
+                        <p class="mt-4 font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                            </svg>
+                            <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
+                        </p>
                     </div>
                 </div>
+                
+                <!-- Services -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
                     <ul class="space-y-3 text-gray-300">
-                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Valuation</a></li>
-                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisals</a></li>
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
                         <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
                         <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
                         <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
                         <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
                     </ul>
                 </div>
+                
+                <!-- Market Areas -->
                 <div>
-                    <h3 class="text-white font-semibold text-lg mb-6">Market Areas</h3>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">London–Middlesex–Elgin</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Windsor–Essex</a></li>
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Oxford County</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Huron–Perth–Wellington</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Niagara Region</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Halton–Peel</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Full Coverage Map</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
                     </ul>
                 </div>
+                
+                <!-- Company -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
+                        <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
                         <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
                     </ul>
                 </div>
             </div>
+            
+            <!-- Professional Affiliations -->
             <div class="border-t border-gray-800 pt-8 mb-8 text-center">
-                <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
+                <div class="mb-6">
+                    <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
+                </div>
                 <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
                     <span>AIC - Appraisal Institute of Canada</span>
                     <span>RICS - Royal Institution of Chartered Surveyors</span>
@@ -477,14 +570,24 @@
                     <span>IRWA - International Right of Way Association</span>
                 </div>
                 <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6">
-                    <span>Data Providers:</span><span>CoStar Professional</span><span>TRREB - Toronto Regional Real Estate Board</span>
+                    <span>Data Providers:</span>
+                    <span>CoStar Professional</span>
+                    <span>TRREB - Toronto Regional Real Estate Board</span>
                 </div>
                 <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
                     <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
                 </div>
             </div>
+            
+            <!-- Copyright -->
             <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
                 <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
             </div>
         </div>
     </footer>

--- a/team/index.html
+++ b/team/index.html
@@ -3,7 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Our Expert Team | Metrix Realty Group | AACI Designated Appraisers</title>
+    <title>AACI Certified Appraisers | Metrix Realty Group Team</title>
+    <meta property="og:title" content="AACI Certified Appraisers | Metrix Realty Group Team">
+    <meta property="og:description" content="Meet our team of AACI-designated real estate appraisers and valuation experts serving Southwestern Ontario with over 25 years of combined experience.">
     <link rel="icon" type="image/png" href="/favicon.png">
     <meta name="description" content="Meet our team of AACI-designated real estate appraisers and valuation experts serving Southwestern Ontario with over 25 years of combined experience.">
     <link rel="canonical" href="https://metrixrealty.com/team">
@@ -265,23 +267,23 @@
                                 <div>
                                     <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
                                     <div class="space-y-1">
-                                        <a href="/services#commercial" class="mega-menu-item block p-4">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
                                         </a>
-                                        <a href="/services#residential" class="mega-menu-item block p-4">
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
                                         </a>
-                                        <a href="/services#litigation" class="mega-menu-item block p-4">
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
                                         </a>
-                                        <a href="/services#consulting" class="mega-menu-item block p-4">
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
                                         </a>
-                                        <a href="/services#government" class="mega-menu-item block p-4">
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
                                             <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
                                             <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
                                         </a>
@@ -290,9 +292,17 @@
                             </div>
                         </div>
                     </div>
-                    <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
-                    <a href="#" class="nav-link active text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
-                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Insights</a> -->
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link active text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
                     <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
                 </div>
                 
@@ -305,8 +315,8 @@
                 
                 <!-- Mobile menu button -->
                 <div class="md:hidden">
-                    <button id="mobile-menu-button" class="hamburger touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
-                        <div class="w-6 h-6 flex flex-col justify-center space-y-1">
+                    <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
+                        <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
                             <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
                             <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
                             <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
@@ -315,6 +325,37 @@
                 </div>
             </div>
         </nav>
+
+        <!-- Mobile Menu -->
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+            
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link active">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+                    
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+
+        <!-- Mobile Menu Overlay -->
+        <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
     </header>
 
     <!-- Mobile Menu -->
@@ -330,6 +371,8 @@
                 <a href="/" class="mobile-nav-link">Home</a>
                 <a href="/services" class="mobile-nav-link">Services</a>
                 <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
                 <a href="#" class="mobile-nav-link active">Team</a>
                 <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
                 <a href="/contact" class="mobile-nav-link">Contact</a>
@@ -359,7 +402,7 @@
                 </div>
                 
                 <h1 class="text-4xl sm:text-5xl lg:text-6xl font-bold mb-8 leading-tight" data-aos="fade-up" data-aos-duration="1000">
-                    Meet Our Team of Professionals
+                    Meet Our AACI-Certified Appraisers
                 </h1>
                 <p class="text-lg sm:text-xl lg:text-2xl mb-12 opacity-90 max-w-4xl mx-auto leading-relaxed" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="200">
                     Our accredited professionals bring decades of combined experience in real estate valuation across Southwestern Ontario.
@@ -866,29 +909,29 @@
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
                     <ul class="space-y-3 text-gray-300">
-                        <li><a href="/services#commercial" class="hover:text-white transition-colors duration-200">Commercial Valuation</a></li>
-                        <li><a href="/services#residential" class="hover:text-white transition-colors duration-200">Residential Appraisals</a></li>
-                        <li><a href="/services#litigation" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
-                        <li><a href="/services#consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
                         <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
                     </ul>
                 </div>
                 
                 <!-- Market Areas -->
                 <div>
-                    <h3 class="text-white font-semibold text-lg mb-6">Market Areas</h3>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">London–Middlesex–Elgin</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Windsor–Essex</a></li>
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
                         <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Oxford County</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Huron–Perth–Wellington</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Niagara Region</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Halton–Peel</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Full Coverage Map</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
                     </ul>
                 </div>
                 
@@ -927,6 +970,12 @@
             <!-- Copyright -->
             <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
                 <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
             </div>
         </div>
     </footer>

--- a/terms-of-service/index.html
+++ b/terms-of-service/index.html
@@ -28,23 +28,116 @@
     <!-- End Google Tag Manager (noscript) -->
 
     <!-- Header -->
-    <header class="bg-white shadow-sm">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex justify-between items-center py-6">
-                <div class="flex items-center">
-                    <a href="/" class="flex items-center">
-                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-8 w-auto">
+    <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
+        <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center justify-between h-16 sm:h-20">
+                <!-- Logo -->
+                <div class="flex-shrink-0">
+                    <a href="/">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
                     </a>
                 </div>
-                <nav class="hidden md:flex space-x-8">
-                    <a href="/" class="text-gray-700 hover:text-gray-900">Home</a>
-                    <a href="/services" class="text-gray-700 hover:text-gray-900">Services</a>
-                    <a href="/market-areas" class="text-gray-700 hover:text-gray-900">Market Areas</a>
-                    <a href="/team" class="text-gray-700 hover:text-gray-900">Team</a>
-                    <a href="/contact" class="text-gray-700 hover:text-gray-900">Contact</a>
+                
+                <!-- Desktop Navigation -->
+                <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
+                    <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
+                    <div class="relative group">
+                        <a href="/services" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Services</a>
+                        <!-- Mega Menu -->
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-96 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50 backdrop-blur-sm">
+                            <div class="p-8">
+                                <div>
+                                    <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
+                                    <div class="space-y-1">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
+                                        </a>
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
+                                        </a>
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
+                                        </a>
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
+                                        </a>
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
+                </div>
+                
+                <!-- CTA Button -->
+                <div class="hidden md:block">
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
+                        Connect with an Appraiser
+                    </a>
+                </div>
+                
+                <!-- Mobile menu button -->
+                <div class="md:hidden">
+                    <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
+                        <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                        </div>
+                    </button>
+                </div>
+            </div>
+        </nav>
+
+        <!-- Mobile Menu -->
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+            
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+                    
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
+                    </div>
                 </nav>
             </div>
         </div>
+
+        <!-- Mobile Menu Overlay -->
+        <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
     </header>
 
     <!-- Main Content -->
@@ -91,13 +184,105 @@
     </main>
 
     <!-- Footer -->
-    <footer class="bg-gray-50 border-t">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-            <div class="text-center">
-                <p class="text-gray-500">&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+    <footer class="bg-black text-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
+                <!-- Company Info -->
+                <div class="lg:col-span-1">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-6 leading-relaxed">
+                        Trusted • Valued • Experienced
+                    </p>
+                    <div class="text-gray-300">
+                        <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
+                        <p class="mb-4">London, ON N6A 5J9</p>
+                        <p class="font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
+                            </svg>
+                            <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
+                        </p>
+                        <p>Toll Free: 1-866-672-9101</p>
+                        <p>Fax: (519) 672-9321</p>
+                        <p class="mt-4 font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                            </svg>
+                            <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
+                        </p>
+                    </div>
+                </div>
+                
+                <!-- Services -->
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
+                    <ul class="space-y-3 text-gray-300">
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
+                        <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
+                    </ul>
+                </div>
+                
+                <!-- Market Areas -->
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
+                    </ul>
+                </div>
+                
+                <!-- Company -->
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
+                        <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
+                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
+                    </ul>
+                </div>
+            </div>
+            
+            <!-- Professional Affiliations -->
+            <div class="border-t border-gray-800 pt-8 mb-8 text-center">
+                <div class="mb-6">
+                    <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
+                    <span>AIC - Appraisal Institute of Canada</span>
+                    <span>RICS - Royal Institution of Chartered Surveyors</span>
+                    <span>AOLE - Association of Ontario Land Economists</span>
+                    <span>IRWA - International Right of Way Association</span>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6">
+                    <span>Data Providers:</span>
+                    <span>CoStar Professional</span>
+                    <span>TRREB - Toronto Regional Real Estate Board</span>
+                </div>
+                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
+                    <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
+                </div>
+            </div>
+            
+            <!-- Copyright -->
+            <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
+                <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
                 <div class="mt-4 space-x-4">
-                    <a href="/privacy-policy" class="text-gray-500 hover:text-gray-700">Privacy Policy</a>
-                    <a href="/terms-of-service" class="text-gray-500 hover:text-gray-700">Terms of Service</a>
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
                 </div>
             </div>
         </div>

--- a/windsor/index.html
+++ b/windsor/index.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Commercial Real Estate Appraiser Windsor Ontario | Property Valuation Services | Metrix Realty</title>
-    <meta name="description" content="Windsor Ontario's trusted real estate appraisers. AACI-designated professionals providing commercial, industrial & litigation appraisals. 2557 Dougall Ave office. Call (519) 672-7550.">
+    <title>Real Estate Appraiser Windsor Ontario | Metrix Realty</title>
+    <meta name="description" content="Real estate appraisers in Windsor, Ontario serving Essex County. AACI-designated professionals for commercial, industrial, and litigation appraisals.">
     <meta name="keywords" content="commercial real estate appraiser Windsor Ontario, ICI appraisal Windsor, property appraisal Windsor ON, commercial appraiser Windsor Essex, AACI appraiser Windsor, industrial property valuation Windsor-Essex, litigation appraisal Windsor, Metrix Realty Group Windsor">
     <meta name="robots" content="index, follow">
     <meta name="llms-txt" content="Metrix Realty Group's Windsor office provides ICI (Industrial, Commercial, Investment) property appraisals across Windsor-Essex County. Part of Southwestern Ontario's leading appraisal firm, founded in 1995 and headquartered in London, Ontario. AACI-designated appraisers delivering lender-recognized commercial valuations. For more information see https://metrixrealty.com/llms.txt">
@@ -26,8 +26,8 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://metrixrealty.com/windsor/">
-    <meta property="og:title" content="Commercial Real Estate Appraiser Windsor Ontario | Metrix Realty Group">
-    <meta property="og:description" content="Windsor Ontario's trusted real estate appraisers. AACI-designated professionals providing commercial, industrial & litigation appraisals in Windsor-Essex.">
+    <meta property="og:title" content="Real Estate Appraiser Windsor Ontario | Metrix Realty">
+    <meta property="og:description" content="Real estate appraisers in Windsor, Ontario serving Essex County. AACI-designated professionals for commercial, industrial, and litigation appraisals.">
     <meta property="og:image" content="https://metrixrealty.com/assets/images/metrix-realty-logo.png">
 
     <!-- Twitter -->
@@ -411,29 +411,73 @@
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex items-center justify-between h-16 sm:h-20">
+                <!-- Logo -->
                 <div class="flex-shrink-0">
                     <a href="/">
-                        <img src="../assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
                     </a>
                 </div>
                 
+                <!-- Desktop Navigation -->
                 <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
-                    <a href="/" class="nav-link text-gray-900 font-semibold">Home</a>
-                    <a href="/services" class="nav-link text-gray-900 font-semibold">Services</a>
-                    <a href="/market-areas" class="nav-link active text-gray-900 font-semibold">Market Areas</a>
-                    <a href="/team" class="nav-link text-gray-900 font-semibold">Team</a>
-                    <a href="/contact" class="nav-link text-gray-900 font-semibold">Contact</a>
+                    <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
+                    <div class="relative group">
+                        <a href="/services" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Services</a>
+                        <!-- Mega Menu -->
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-96 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50 backdrop-blur-sm">
+                            <div class="p-8">
+                                <div>
+                                    <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
+                                    <div class="space-y-1">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
+                                        </a>
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
+                                        </a>
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
+                                        </a>
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
+                                        </a>
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link active text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
                 </div>
                 
+                <!-- CTA Button -->
                 <div class="hidden md:block">
-                    <a href="/contact" class="inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
                         Connect with an Appraiser
                     </a>
                 </div>
                 
                 <!-- Mobile menu button -->
                 <div class="md:hidden">
-                    <button id="mobile-menu-button" class="text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
+                    <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
                         <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
                             <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
                             <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
@@ -443,6 +487,37 @@
                 </div>
             </div>
         </nav>
+
+        <!-- Mobile Menu -->
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+            
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link active">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+                    
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+
+        <!-- Mobile Menu Overlay -->
+        <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
     </header>
 
     <main>
@@ -856,15 +931,15 @@
     <footer class="bg-black text-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
+                <!-- Company Info -->
                 <div class="lg:col-span-1">
-                    <img src="../assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
                     <p class="text-gray-300 mb-6 leading-relaxed">
                         Trusted • Valued • Experienced
                     </p>
                     <div class="text-gray-300">
-                        <p class="font-semibold text-white mb-2">Windsor Office</p>
-                        <p>2557 Dougall Ave #6</p>
-                        <p class="mb-4">Windsor, ON N8X 1T5</p>
+                        <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
+                        <p class="mb-4">London, ON N6A 5J9</p>
                         <p class="font-semibold text-white flex items-center">
                             <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
@@ -872,47 +947,87 @@
                             <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
                         </p>
                         <p>Toll Free: 1-866-672-9101</p>
+                        <p>Fax: (519) 672-9321</p>
+                        <p class="mt-4 font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                            </svg>
+                            <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
+                        </p>
                     </div>
                 </div>
                 
+                <!-- Services -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
                     <ul class="space-y-3 text-gray-300">
                         <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
-                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Industrial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
                         <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
                         <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
                     </ul>
                 </div>
                 
+                <!-- Market Areas -->
                 <div>
-                    <h3 class="text-white font-semibold text-lg mb-6">Locations</h3>
-                    <ul class="space-y-3 text-gray-300">
-                        <li><a href="../london/" class="hover:text-white transition-colors duration-200">London (Main Office)</a></li>
-                        <li><a href="../windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Market Areas</a></li>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
                     </ul>
                 </div>
                 
+                <!-- Company -->
                 <div>
                     <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
-                    <ul class="space-y-3 text-gray-300">
+                    <ul class="space-y-2 text-gray-300 text-sm">
                         <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
+                        <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
                         <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
                     </ul>
                 </div>
             </div>
             
+            <!-- Professional Affiliations -->
             <div class="border-t border-gray-800 pt-8 mb-8 text-center">
+                <div class="mb-6">
+                    <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
+                </div>
                 <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
                     <span>AIC - Appraisal Institute of Canada</span>
                     <span>RICS - Royal Institution of Chartered Surveyors</span>
                     <span>AOLE - Association of Ontario Land Economists</span>
+                    <span>IRWA - International Right of Way Association</span>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6">
+                    <span>Data Providers:</span>
+                    <span>CoStar Professional</span>
+                    <span>TRREB - Toronto Regional Real Estate Board</span>
+                </div>
+                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
+                    <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
                 </div>
             </div>
             
+            <!-- Copyright -->
             <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
                 <p>&copy; 2025 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
             </div>
         </div>
     </footer>
@@ -930,6 +1045,8 @@
                 <a href="/" class="mobile-nav-link">Home</a>
                 <a href="/services" class="mobile-nav-link">Services</a>
                 <a href="/market-areas" class="mobile-nav-link active">Market Areas</a>
+                <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
                 <a href="/team" class="mobile-nav-link">Team</a>
                 <a href="/contact" class="mobile-nav-link">Contact</a>
                 


### PR DESCRIPTION
## Summary

- **Market Areas nav dropdown** — London and Windsor added as hover dropdown on desktop, indented sub-links on mobile, across all 38 live pages. Directly addresses the link equity gap (/london/ and /windsor/ had the lowest inbound link count on the site and were not navigable from the main nav)
- **Header/footer standardisation** — canonical homepage header and footer pushed to all 38 live pages. Fixes: missing legal footer links (Accessibility, LLMs.txt, Privacy Policy, Terms) on most pages, inconsistent nav classes, stale footer layouts, and relative image paths
- **Title tags** — all 16 affected pages trimmed to 51–59 chars with primary keyword first (was up to 100 chars on some pages)
- **Meta descriptions** — all pages now 141–157 chars; 3 pages had stub descriptions (15–38 chars), 11 were over 160 chars
- **H1 fixes** — 4 pages updated: `/services` (added "commercial" signal), `/market-areas` (keyword-aligned), `/team` (added AACI signal), `/london/residential-appraisal` (changed to "Home Appraisal" to match primary keyword)
- **OG tags** — og:title and og:description synced to updated values across all 17 core pages; 3 pages (market-areas, team, contact) were missing OG tags entirely

## Test plan

- [ ] Verify Market Areas hover dropdown renders on desktop homepage
- [ ] Verify London and Windsor sub-links appear in mobile menu
- [ ] Confirm active nav state is correct on team, services, london, and contact pages
- [ ] Confirm footer legal links (Privacy Policy, Terms, Accessibility, LLMs.txt) appear on team bio and service pages
- [ ] Spot-check title and meta on homepage, /london/, /windsor/ in browser source

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Site-wide on-page SEO and nav improvements. Added London/Windsor to the nav, rolled out a sticky header/footer, and optimized titles, meta, OG, and H1s to improve internal linking and metadata quality across 38 pages.

- **New Features**
  - Added Market Areas dropdown on desktop with links to London and Windsor.
  - Added indented London/Windsor sub-links in the mobile menu.
  - Fixed active nav states on team, services, London, and contact pages.

- **Refactors**
  - Standardized a fixed, accessible header and canonical footer across all pages; restored legal footer links, corrected nav classes, updated mega‑menu service links to real routes, and fixed image paths.
  - Trimmed and rewrote title tags (51–59 chars) and meta descriptions (141–157 chars) with primary keywords first.
  - Synced og:title and og:description on 17 core pages and added missing OG tags (e.g., team, market-areas, contact).
  - Updated H1s on services, market-areas, team, and London residential appraisal to match target keywords.

<sup>Written for commit 9aae22d169d5b4b282be0ba53943d5704823dfb5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

