### PR TITLE
Fix: HTML in title tags and CUSPAP footer links sitewide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vercel
+session-notes.md

--- a/404.html
+++ b/404.html
@@ -267,7 +267,7 @@
                     <span>TRREB - Toronto Regional Real Estate Board</span>
                 </div>
                 <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
-                    <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
+                    <p>Reports completed in compliance with <a href="https://www.aicanada.ca/about-aic/cuspap/" target="_blank" rel="noopener noreferrer">CUSPAP</a> (Canadian Uniform Standards of Professional Appraisal Practice)</p>
                 </div>
             </div>
             

--- a/index.html
+++ b/index.html
@@ -1573,7 +1573,7 @@
                     <span>TRREB - Toronto Regional Real Estate Board</span>
                 </div>
                 <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
-                    <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
+                    <p>Reports completed in compliance with <a href="https://www.aicanada.ca/about-aic/cuspap/" target="_blank" rel="noopener noreferrer">CUSPAP</a> (Canadian Uniform Standards of Professional Appraisal Practice)</p>
                 </div>
             </div>
             

--- a/insights/what-is-aaci-designation.html
+++ b/insights/what-is-aaci-designation.html
@@ -1,0 +1,747 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>What Is the AACI Designation? | Metrix Realty Group</title>
+    <link rel="icon" type="image/png" href="/favicon.png">
+    <meta name="description" content="AACI stands for Accredited Appraiser Canadian Institute — Canada's senior appraisal credential. Learn how it differs from CRA and why lenders require it.">
+    <link rel="canonical" href="https://metrixrealty.com/insights/what-is-aaci-designation.html">
+
+    <!-- Open Graph Meta Tags -->
+    <meta property="og:title" content="What Is the AACI Designation? | Metrix Realty Group">
+    <meta property="og:description" content="AACI stands for Accredited Appraiser Canadian Institute — Canada's senior appraisal credential. Learn how it differs from CRA and why lenders require it.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://metrixrealty.com/insights/what-is-aaci-designation.html">
+    <meta property="og:image" content="https://metrixrealty.com/assets/images/metrix-realty-team.webp">
+    <meta property="article:published_time" content="2026-05-27">
+    <meta property="article:author" content="Dan Van Houtte">
+
+    <!-- Twitter Card Meta Tags -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="robots" content="noindex, nofollow">
+    <meta name="twitter:title" content="What Is the AACI Designation?">
+    <meta name="twitter:description" content="AACI (Accredited Appraiser Canadian Institute) explained: education, experience, exam, continuing education, and why lenders require it.">
+    <meta name="twitter:image" content="https://metrixrealty.com/assets/images/metrix-realty-team.webp">
+
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    <!-- End Google Tag Manager -->
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">
+
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        'metrix-blue': '#233c75',
+                        'metrix-blue-light': '#3d5a9e',
+                        'metrix-blue-dark': '#1a2d5a',
+                        'metrix-green': '#3faa4d',
+                    },
+                    fontFamily: {
+                        'inter': ['Inter', 'sans-serif'],
+                    }
+                }
+            }
+        }
+    </script>
+
+    <style>
+        body { font-family: 'Inter', sans-serif; }
+
+        .article-content { font-size: 1.125rem; line-height: 1.8; color: #374151; }
+        .article-content h2 { font-size: 2rem; font-weight: 700; color: #1f2937; margin-top: 3rem; margin-bottom: 1.5rem; line-height: 1.3; }
+        .article-content h3 { font-size: 1.5rem; font-weight: 600; color: #1f2937; margin-top: 2.5rem; margin-bottom: 1rem; }
+        .article-content p { margin-bottom: 1.5rem; }
+        .article-content ul, .article-content ol { margin-bottom: 1.5rem; padding-left: 2rem; }
+        .article-content ul { list-style-type: disc; list-style-position: inside; }
+        .article-content ol { list-style-type: decimal; list-style-position: inside; }
+        .article-content li { margin-bottom: 0.75rem; padding-left: 0.5rem; }
+        .article-content strong { font-weight: 600; color: #1f2937; }
+        .article-content a { color: #233c75; text-decoration: underline; }
+        .article-content a:hover { color: #1a2d5a; }
+
+        .article-content table { width: 100%; border-collapse: collapse; margin: 2rem 0; font-size: 0.95rem; }
+        .article-content th { background: #233c75; color: white; padding: 0.75rem 1rem; text-align: left; font-weight: 600; }
+        .article-content td { padding: 0.75rem 1rem; border-bottom: 1px solid #e5e7eb; vertical-align: top; }
+        .article-content tr:nth-child(even) td { background: #f9fafb; }
+
+        .callout-box { background: linear-gradient(135deg, #233c75 0%, #1a2d5a 100%); color: white; padding: 2rem; border-radius: 1rem; margin: 2.5rem 0; }
+        .callout-box h2, .callout-box h3 { color: white !important; margin-top: 0 !important; }
+        .callout-box strong { color: inherit !important; }
+        .callout-box p { margin-bottom: 0; }
+
+        .stat-highlight { background: #f0f9ff; border-left: 4px solid #3faa4d; padding: 1.5rem; margin: 2rem 0; border-radius: 0.5rem; }
+
+        .period-box, .callout-box, .stat-highlight, .bias-box, h1, h2, h3, h4, h5, h6 { list-style: none !important; }
+
+        .mobile-menu { position: fixed; top: 0; right: 0; height: 100vh; width: 320px; background: #ffffff; box-shadow: -10px 0 25px rgba(0,0,0,0.15); z-index: 99999; transform: translateX(100%); transition: transform 0.3s ease; }
+        .mobile-menu.open { transform: translateX(0); }
+        .overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.5); backdrop-filter: blur(4px); z-index: 99998; opacity: 0; visibility: hidden; transition: opacity 0.3s ease, visibility 0.3s ease; }
+        .overlay.active { opacity: 1; visibility: visible; }
+        .share-button { transition: all 0.2s ease; }
+        .share-button:hover { transform: translateY(-2px); }
+        .nav-link { position: relative; transition: all 0.3s cubic-bezier(0.4,0,0.2,1); }
+        .nav-link::after { content: ''; position: absolute; bottom: -2px; left: 0; width: 0; height: 2px; background: linear-gradient(90deg, #233c75, #1a2d5a); transition: width 0.3s ease; }
+        .nav-link:hover::after { width: 100%; }
+        .nav-link:hover { color: #233c75; }
+        .mega-menu-item { transition: all 0.3s ease; border-radius: 8px; }
+        .mega-menu-item:hover { background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%); transform: translateX(4px); }
+        .mobile-menu-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 99998; opacity: 0; visibility: hidden; transition: opacity 0.3s ease, visibility 0.3s ease; }
+        .mobile-menu-overlay.open { opacity: 1; visibility: visible; }
+        .mobile-menu-close { background: none; border: none; padding: 12px; cursor: pointer; color: #6b7280; border-radius: 6px; transition: all 0.2s ease; }
+        .mobile-menu-close:hover { background: #f3f4f6; color: #374151; }
+        .mobile-menu-content { padding: 24px; padding-top: 80px; height: 100%; overflow-y: auto; }
+        .mobile-nav { display: flex; flex-direction: column; gap: 8px; }
+        .mobile-nav-link { display: block; padding: 16px; color: #374151; font-weight: 500; font-size: 18px; text-decoration: none; border-radius: 8px; transition: all 0.2s ease; }
+        .mobile-nav-link:hover { color: #233c75; background: #f8fafc; }
+    </style>
+
+    <!-- Article Schema -->
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "What Is the AACI Designation?",
+        "description": "AACI stands for Accredited Appraiser Canadian Institute — Canada's senior appraisal credential. Learn how it differs from CRA and why lenders require it.",
+        "image": "https://metrixrealty.com/assets/images/metrix-realty-team.webp",
+        "datePublished": "2026-05-27",
+        "dateModified": "2026-05-27",
+        "author": {
+            "@type": "Person",
+            "name": "Dan Van Houtte",
+            "jobTitle": "MRICS AACI PLE",
+            "url": "https://metrixrealty.com/team"
+        },
+        "publisher": {
+            "@type": "Organization",
+            "name": "Metrix Realty Group",
+            "logo": {
+                "@type": "ImageObject",
+                "url": "https://metrixrealty.com/assets/images/metrix-realty-logo.png"
+            }
+        },
+        "mainEntityOfPage": {
+            "@type": "WebPage",
+            "@id": "https://metrixrealty.com/insights/what-is-aaci-designation.html"
+        },
+        "keywords": "AACI designation, Accredited Appraiser Canadian Institute, AACI appraiser Canada, AIC designation Canada, AACI vs CRA",
+        "articleSection": "Appraisal Credentials",
+        "wordCount": 2000
+    }
+    </script>
+
+    <!-- FAQPage Schema -->
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+            {
+                "@type": "Question",
+                "name": "What does AACI stand for?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "AACI stands for Accredited Appraiser Canadian Institute. It is the senior professional designation granted by the Appraisal Institute of Canada (AIC) and authorizes the holder to appraise all property types, including commercial, industrial, multi-family, agricultural, and residential."
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "How long does it take to earn the AACI designation?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "The average candidate takes 3 to 5 years to complete the education, experience, and assessment requirements for the AACI designation. Candidates have up to 10 years from the date they become a Candidate Member to complete all requirements."
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "What is the difference between an AACI and a CRA appraiser?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Both designations are granted by the Appraisal Institute of Canada. The CRA (Canadian Residential Appraiser) designation is limited to residential properties with up to four self-contained family housing units. The AACI designation covers all property types, including commercial, industrial, multi-family, agricultural, land, and special-use properties. AACI holders must also complete a minimum of two years of applied experience, versus one year for CRA candidates."
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "Why do lenders require AACI-designated appraisers?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Lenders rely on AACI-designated appraisers because their reports are independent, professionally prepared, and completed under the Canadian Uniform Standards of Professional Appraisal Practice (CUSPAP). For commercial and complex properties, lenders and mortgage underwriters typically require an AACI-designated appraiser to support sound credit decisions and manage portfolio risk."
+                }
+            }
+        ]
+    }
+    </script>
+
+    <!-- BreadcrumbList Schema -->
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+            {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://metrixrealty.com/"},
+            {"@type": "ListItem", "position": 2, "name": "Insights", "item": "https://metrixrealty.com/insights/"},
+            {"@type": "ListItem", "position": 3, "name": "What Is the AACI Designation?", "item": "https://metrixrealty.com/insights/what-is-aaci-designation.html"}
+        ]
+    }
+    </script>
+</head>
+<body class="bg-white">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+
+    <div class="overlay" id="overlay"></div>
+
+    <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
+        <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center justify-between h-16 sm:h-20">
+                <!-- Logo -->
+                <div class="flex-shrink-0">
+                    <a href="/">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
+                    </a>
+                </div>
+
+                <!-- Desktop Navigation -->
+                <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
+                    <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
+                    <div class="relative group">
+                        <a href="/services" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Services</a>
+                        <!-- Mega Menu -->
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-96 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50 backdrop-blur-sm">
+                            <div class="p-8">
+                                <div>
+                                    <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
+                                    <div class="space-y-1">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
+                                        </a>
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
+                                        </a>
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
+                                        </a>
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
+                                        </a>
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
+                </div>
+
+                <!-- CTA Button -->
+                <div class="hidden md:block">
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
+                        Connect with an Appraiser
+                    </a>
+                </div>
+
+                <!-- Mobile menu button -->
+                <div class="md:hidden">
+                    <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
+                        <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                        </div>
+                    </button>
+                </div>
+            </div>
+        </nav>
+
+        <!-- Mobile Menu -->
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+
+        <!-- Mobile Menu Overlay -->
+        <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
+    </header>
+
+    <div class="h-16 sm:h-20"></div>
+
+    <!-- Breadcrumb -->
+    <div class="bg-gray-50 border-b">
+        <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+            <nav class="flex text-sm" aria-label="Breadcrumb">
+                <ol class="inline-flex items-center space-x-2">
+                    <li><a href="/" class="text-gray-500 hover:text-metrix-blue">Home</a></li>
+                    <li><span class="text-gray-400">/</span></li>
+                    <li><a href="/insights/" class="text-gray-500 hover:text-metrix-blue">Insights</a></li>
+                    <li><span class="text-gray-400">/</span></li>
+                    <li><span class="text-gray-700">What Is the AACI Designation</span></li>
+                </ol>
+            </nav>
+        </div>
+    </div>
+
+    <!-- Article -->
+    <article class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <header class="mb-12">
+            <div class="mb-6">
+                <span class="inline-block px-4 py-2 bg-metrix-blue/10 text-metrix-blue text-sm font-semibold rounded-full">
+                    Appraisal Credentials
+                </span>
+            </div>
+            <h1 class="text-4xl md:text-5xl font-bold text-gray-900 mb-6 leading-tight">
+                What Is the AACI Designation?
+            </h1>
+            <div class="flex flex-wrap items-center gap-4 text-gray-600 mb-8">
+                <div class="flex items-center">
+                    <svg class="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M4 4a2 2 0 012-2h8a2 2 0 012 2v12a2 2 0 01-2 2H6a2 2 0 01-2-2V4z" clip-rule="evenodd"></path></svg>
+                    <a href="/team" class="font-medium hover:text-metrix-blue transition-colors">Dan Van Houtte, MRICS AACI PLE</a>
+                </div>
+                <div class="flex items-center">
+                    <svg class="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z" clip-rule="evenodd"></path></svg>
+                    <time datetime="2026-05-27">May 27, 2026</time>
+                </div>
+                <div class="flex items-center">
+                    <svg class="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clip-rule="evenodd"></path></svg>
+                    <span>9 min read</span>
+                </div>
+            </div>
+            <p class="text-xl text-gray-600 leading-relaxed border-l-4 border-metrix-blue pl-6 py-2">
+                AACI stands for Accredited Appraiser Canadian Institute. It is the senior professional designation granted by the Appraisal Institute of Canada, and it authorizes the holder to appraise any property type in Canada — commercial, industrial, multi-family, agricultural, land, or residential.
+            </p>
+            <div class="flex items-center gap-3 mt-8 pt-8 border-t">
+                <span class="text-sm font-medium text-gray-700">Share:</span>
+                <button onclick="shareArticle('twitter')" class="share-button p-2 bg-gray-100 hover:bg-blue-400 hover:text-white rounded-lg transition-colors">
+                    <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M23 3a10.9 10.9 0 01-3.14 1.53 4.48 4.48 0 00-7.86 3v1A10.66 10.66 0 013 4s-4 9 5 13a11.64 11.64 0 01-7 2c9 5 20 0 20-11.5a4.5 4.5 0 00-.08-.83A7.72 7.72 0 0023 3z"></path></svg>
+                </button>
+                <button onclick="shareArticle('linkedin')" class="share-button p-2 bg-gray-100 hover:bg-blue-600 hover:text-white rounded-lg transition-colors">
+                    <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
+                </button>
+                <button onclick="shareArticle('facebook')" class="share-button p-2 bg-gray-100 hover:bg-blue-700 hover:text-white rounded-lg transition-colors">
+                    <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>
+                </button>
+            </div>
+        </header>
+
+        <!-- Article Content -->
+        <div class="article-content">
+
+            <p>If you are hiring an appraiser in Canada for a commercial mortgage, a litigation file, an estate matter, or a complex property valuation, you will likely encounter the letters AACI after an appraiser's name. Understanding what those letters mean — and what they require — helps you know whether the appraiser you are considering is qualified for the assignment.</p>
+
+            <p>This article explains what the AACI designation is, how appraisers earn it, how it compares to the CRA designation, and why lenders and legal professionals routinely specify AACI-designated appraisers for their files.</p>
+
+            <div class="callout-box">
+                <h2 style="font-size:1.5rem; margin-bottom:0.75rem;">Quick Answer</h2>
+                <p>AACI stands for Accredited Appraiser Canadian Institute. It is granted by the <a href="https://www.aicanada.ca/designation/aaci/" target="_blank" rel="noopener" style="color:#7dd3fc;">Appraisal Institute of Canada (AIC)</a> and is the designation required to appraise commercial, industrial, multi-family, agricultural, and all other property types in Canada. Earning the AACI designation requires a university degree, a structured education program, at least two years of supervised applied experience, work product reviews, a written exam, and a Professional Competency Interview.</p>
+            </div>
+
+            <h2>What AACI Stands For</h2>
+
+            <p>AACI is the abbreviation for <strong>Accredited Appraiser Canadian Institute</strong>. The designation is issued by the Appraisal Institute of Canada (AIC), which is Canada's leading real property valuation association with more than 5,000 members across the country.</p>
+
+            <p>The AIC also grants the <strong>P. App.</strong> (Professional Appraiser) certification mark alongside the AACI designation. Members who hold the AACI designation are bound by the <a href="/insights/what-is-cuspap.html" class="text-metrix-blue hover:underline"><strong>Canadian Uniform Standards of Professional Appraisal Practice (CUSPAP)</strong></a>, which govern scope of work, reporting, ethics, and professional conduct for all AIC-designated appraisers in Canada.</p>
+
+            <p>When you see "AACI" after an appraiser's name, it tells you that the person has satisfied the AIC's full education, experience, examination, and competency requirements — and that they are authorized to complete appraisal assignments on any property type.</p>
+
+            <h2>What Property Types an AACI Can Appraise</h2>
+
+            <p>The AACI designation authorizes the holder to undertake valuation and consulting assignments on any real property, including:</p>
+
+            <ul>
+                <li>Commercial properties (office, retail, industrial, hospitality)</li>
+                <li>Multi-family residential (apartment buildings, mixed-use)</li>
+                <li>Agricultural land and farm properties</li>
+                <li>Vacant land and development sites</li>
+                <li>Special-use and institutional properties</li>
+                <li>Residential properties of any size</li>
+            </ul>
+
+            <p>This breadth is what distinguishes the AACI from the CRA designation. A CRA-designated appraiser is limited to residential properties with up to four self-contained family housing units or individual undeveloped residential dwelling sites. For anything beyond that, the AACI designation is required.</p>
+
+            <h2>How to Earn the AACI Designation</h2>
+
+            <p>The path to the AACI designation is structured around five requirements: an admission standard, education, supervised work experience, work product reviews, and a final competency assessment. The AIC allows up to 10 years to complete all requirements from the date a candidate becomes a Candidate Member, though most candidates complete the process in 3 to 5 years.</p>
+
+            <h3>1. University Degree</h3>
+
+            <p>A university degree is required before a candidate can sit the AACI Applied Experience Exam. Candidates with a business or commerce degree from a Canadian university can pursue the AACI designation through the University of British Columbia's Post-Graduate Certificate in Real Property Valuation (PGCV) program — an accelerated pathway consisting of six courses and a guided case study.</p>
+
+            <p>Candidates without a commerce or business background complete the full AIC education program, which includes core appraisal courses covering valuation theory, methodology, income-producing properties, and professional practice. The AIC also recognizes equivalent education credentials from other universities through approved pathways.</p>
+
+            <h3>2. Applied Experience Program (AEP)</h3>
+
+            <p>Classroom education alone does not qualify an appraiser. Candidates must complete a minimum of <strong>two years of supervised applied experience</strong> in the valuation industry before they can write the AACI Applied Experience Exam. This is the Applied Experience Program (AEP).</p>
+
+            <p>The AEP is designed to ensure that every candidate develops practical competency in the application of the First Principles of Value in a professional setting. It includes self-paced webinars, minimum work experience hours, and opportunities to specialize experience in specific property types or market areas. Candidates must work under the supervision of a designated AIC member throughout this period.</p>
+
+            <h3>3. Work Product Reviews</h3>
+
+            <p>Before sitting the exam, candidates must submit work products — actual appraisal reports — for review by designated AIC members. The Work Product Review (WPR) process provides in-depth feedback on CUSPAP compliance, report quality, and best practices. The first two submissions result in guidance and counsel. The third submission must comply fully with CUSPAP standards or a resubmission is required within 30 days.</p>
+
+            <p>The WPR process is designed as a learning exercise that helps candidates understand professional standards before they face the exam and the Professional Competency Interview.</p>
+
+            <h3>4. Applied Experience Exam</h3>
+
+            <p>Once the education requirement and two years of applied experience are satisfied, candidates write the AACI Applied Experience Written Exam. This exam assesses the candidate's understanding of the First Principles of Value as they relate to experiential knowledge — not just theory, but how valuation principles are applied to real assignments in a professional context.</p>
+
+            <h3>5. Professional Competency Interview (PCI)</h3>
+
+            <p>The final step is the Professional Competency Interview. This is a structured assessment that evaluates whether the candidate has mastered the full set of competencies the AIC expects from its AACI-designated members. Passing the PCI is the last gate before the designation is granted.</p>
+
+            <div class="stat-highlight">
+                <p style="margin-bottom:0;"><strong>By the numbers:</strong> The Appraisal Institute of Canada has more than 5,000 members across Canada and around the world. The AIC was established in 1938 and works through 10 provincial affiliated associations to grant the AACI and CRA designations. In Ontario, the provincial affiliate is AIC Ontario.</p>
+            </div>
+
+            <h2>Continuing Education Requirements</h2>
+
+            <p>Holding the AACI designation is not a one-time achievement. Designated members must maintain active standing through the AIC's Continuing Professional Development (CPD) program.</p>
+
+            <p>The requirement is <strong>24 CPD credits in each two-year cycle</strong>. Of those 24 credits, seven must come from the AIC's mandatory Professional Practice Seminar. The remaining 17 are discretionary and can be earned through industry-related education, training, seminars, webinars, or approved courses from AIC education partners such as UBC.</p>
+
+            <p>Failure to complete the required CPD credits within the two-year cycle results in a suspension of membership and a fine. This ongoing requirement ensures that AACI-designated appraisers stay current with changes to CUSPAP, market conditions, valuation methodology, and professional practice standards.</p>
+
+            <h2>AACI vs CRA vs Unlicensed: A Comparison</h2>
+
+            <table>
+                <thead>
+                    <tr>
+                        <th>Credential</th>
+                        <th>AACI</th>
+                        <th>CRA</th>
+                        <th>No AIC Designation</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td><strong>Full name</strong></td>
+                        <td>Accredited Appraiser Canadian Institute</td>
+                        <td>Canadian Residential Appraiser</td>
+                        <td>No professional designation</td>
+                    </tr>
+                    <tr>
+                        <td><strong>Granting body</strong></td>
+                        <td>Appraisal Institute of Canada</td>
+                        <td>Appraisal Institute of Canada</td>
+                        <td>N/A</td>
+                    </tr>
+                    <tr>
+                        <td><strong>Property types</strong></td>
+                        <td>All property types: commercial, industrial, multi-family, agricultural, land, residential</td>
+                        <td>Residential only — up to four self-contained family housing units or individual undeveloped residential sites</td>
+                        <td>Not authorized to provide CUSPAP-compliant appraisals</td>
+                    </tr>
+                    <tr>
+                        <td><strong>Education required</strong></td>
+                        <td>University degree plus AIC/UBC appraisal program</td>
+                        <td>University degree plus AIC/UBC residential appraisal program</td>
+                        <td>No standard</td>
+                    </tr>
+                    <tr>
+                        <td><strong>Experience required</strong></td>
+                        <td>Minimum 2 years supervised applied experience</td>
+                        <td>Minimum 1 year supervised applied experience</td>
+                        <td>No standard</td>
+                    </tr>
+                    <tr>
+                        <td><strong>Exam required</strong></td>
+                        <td>Applied Experience Exam + Professional Competency Interview</td>
+                        <td>Applied Experience Exam + Professional Competency Interview</td>
+                        <td>No standard</td>
+                    </tr>
+                    <tr>
+                        <td><strong>Ongoing CPD</strong></td>
+                        <td>24 credits per two-year cycle</td>
+                        <td>24 credits per two-year cycle</td>
+                        <td>No requirement</td>
+                    </tr>
+                    <tr>
+                        <td><strong>Accepted for commercial lending?</strong></td>
+                        <td>Yes — required by most lenders for commercial files</td>
+                        <td>For eligible residential properties only</td>
+                        <td>Generally not accepted by institutional lenders</td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <h2>Why Lenders Require AACI-Designated Appraisers</h2>
+
+            <p>When a bank, credit union, mortgage investment corporation, or institutional lender orders an appraisal for a commercial or complex property, they typically specify that the report must be prepared by an AACI-designated appraiser. There are practical reasons for this requirement.</p>
+
+            <p><strong>Independence.</strong> An AACI-designated appraiser provides an independent value opinion. They do not advocate for a number — they develop and report market evidence. Lenders need that independence to make credit decisions without relying on a valuation that may have been influenced by the transaction.</p>
+
+            <p><strong>CUSPAP compliance.</strong> Reports prepared by AIC-designated appraisers must comply with the Canadian Uniform Standards of Professional Appraisal Practice. CUSPAP sets out requirements for scope of work, client and user identification, intended use, effective date, assumptions, and report content. A CUSPAP-compliant report gives lenders and their underwriters a standardized, auditable document.</p>
+
+            <p><strong>Scope of practice.</strong> For commercial mortgage files, the AACI designation is the only AIC credential that authorizes the appraiser to work on the property types involved — office buildings, retail plazas, industrial facilities, multi-family apartment buildings, development land, and mixed-use assets. A CRA-designated appraiser is not authorized to complete those assignments.</p>
+
+            <p><strong>Professional accountability.</strong> AIC-designated members are subject to a complaint and discipline process administered through the AIC and its provincial affiliates. If a report does not meet professional standards, there is a mechanism to address the issue. That accountability matters to lenders who rely on appraisals to support large credit decisions.</p>
+
+            <p>For these reasons, major Canadian banks, CMHC, credit unions, and private lenders routinely specify AACI-designated appraisers for commercial and complex property assignments. The <a href="https://www.aicanada.ca/need-an-appraiser/for-mortgage-professionals/" target="_blank" rel="noopener">AIC's mortgage industry page</a> describes how mortgage brokers, lenders, insurers, servicers, and investors engage AIC-designated appraisers to support sound credit decisions and portfolio risk management.</p>
+
+            <h2>AACI Designation and Legal or Litigation Use</h2>
+
+            <p>Beyond lending, AACI-designated appraisers are routinely engaged for legal matters where an independent, professionally prepared value opinion is required. Metrix provides <a href="/services/litigation-support-expert-testimony" class="text-metrix-blue hover:underline">litigation support and expert witness services</a> for a range of legal contexts. These include:</p>
+
+            <ul>
+                <li>Estate and date-of-death valuations for probate or tax purposes</li>
+                <li>Matrimonial and family-law property division matters</li>
+                <li>Expropriation and partial-taking compensation</li>
+                <li>Property tax assessment appeals</li>
+                <li>Commercial litigation and expert witness testimony</li>
+                <li>Partnership disputes and corporate transactions</li>
+            </ul>
+
+            <p>In these contexts, the AACI designation signals to the court, the opposing party, and the instructing lawyer that the appraiser has met a defined national standard — not that they simply hold themselves out as an expert. Courts in Canada have accepted AIC-designated appraisers as qualified expert witnesses in property valuation matters. The designation, the CUSPAP framework, and the underlying methodology all contribute to a report that can withstand scrutiny.</p>
+
+            <h2>How to Find an AACI Appraiser in Ontario</h2>
+
+            <p>The Appraisal Institute of Canada maintains a national directory of designated members. In Ontario, the provincial affiliate is <a href="https://aicontario.ca" target="_blank" rel="noopener noreferrer" class="text-metrix-blue hover:underline"><strong>AIC Ontario (aicontario.ca)</strong></a>, which also maintains a member directory. You can search for AACI appraisers in Ontario by name, location, or property type specialization.</p>
+
+            <p>When selecting an AACI appraiser for a specific assignment, look beyond the designation itself. Consider whether the appraiser has direct experience with the property type, geographic market, and intended use of the report. An AACI designation confirms that the person meets the AIC's baseline education and experience requirements — it does not guarantee expertise in every property type or market.</p>
+
+            <p>For commercial and ICI (industrial, commercial, investment) properties in London, Windsor, and Southwestern Ontario, ask the firm about their experience with the specific property type involved — office, retail plaza, industrial, multi-family, development land, or special use — and whether they have completed assignments for similar intended uses, such as lender financing, litigation support, or government and institutional work.</p>
+
+            <h2>AACI Appraisers at Metrix Realty Group</h2>
+
+            <p>Metrix Realty Group, founded in London, Ontario in 1995, is led by <a href="/team" class="text-metrix-blue hover:underline"><strong>Dan Van Houtte MRICS AACI PLE</strong></a>, who also holds the MRICS designation from the Royal Institution of Chartered Surveyors and the PLE (Property and Land Economist) designation from the Association of Ontario Land Economists. Sam Van Houtte AACI and Roman Virk AACI are also designated members of the <a href="/team" class="text-metrix-blue hover:underline">Metrix appraisal team</a>.</p>
+
+            <p>The firm's AACI-designated appraisers complete assignments across commercial, industrial, multi-family, agricultural, and residential property types throughout Southwestern Ontario. In London, the firm handles all property types including single-family residential. In Windsor-Essex, the team focuses on commercial, industrial, multi-family, and litigation support assignments. All reports are prepared in compliance with CUSPAP.</p>
+
+            <p>Review the firm's <a href="/services">appraisal and consulting services</a> to understand the range of assignments Metrix handles. If you have a specific valuation requirement, <a href="/contact">contact Metrix</a> to discuss the property, the intended use, and the timeline before placing the order.</p>
+
+            <h2>FAQs</h2>
+
+            <h3>What Does AACI Stand For?</h3>
+            <p>AACI stands for Accredited Appraiser Canadian Institute. It is the senior professional designation granted by the Appraisal Institute of Canada and authorizes the holder to appraise all property types, including commercial, industrial, multi-family, agricultural, and residential.</p>
+
+            <h3>How Long Does It Take to Earn the AACI Designation?</h3>
+            <p>The average candidate takes 3 to 5 years to complete the education, experience, and assessment requirements. Candidates have up to 10 years from the date they become a Candidate Member to finish all requirements.</p>
+
+            <h3>What Is the Difference Between an AACI and a CRA Appraiser?</h3>
+            <p>Both designations are granted by the Appraisal Institute of Canada. The CRA (Canadian Residential Appraiser) is limited to residential properties with up to four self-contained family housing units. The AACI covers all property types. AACI candidates must also complete a minimum of two years of applied experience, compared to one year for CRA candidates.</p>
+
+            <h3>Why Do Lenders Require AACI-Designated Appraisers?</h3>
+            <p>Lenders require AACI-designated appraisers because their reports are independent, professionally prepared, and completed under the Canadian Uniform Standards of Professional Appraisal Practice (CUSPAP). For commercial and complex properties, the AACI designation is the only AIC credential that authorizes the appraiser to complete those assignments. The independence, methodology, and professional accountability that come with the designation support the lender's credit decision and risk management process.</p>
+
+        </div>
+
+        <!-- Related Articles -->
+        <div class="mt-16 pt-12 border-t">
+            <h2 class="text-3xl font-bold text-gray-900 mb-8">Continue Reading</h2>
+            <div class="grid md:grid-cols-2 gap-8">
+                <a href="appraisal-vs-realtor-cma-ontario.html" class="group">
+                    <div class="bg-white border border-gray-200 rounded-xl p-6 hover:border-metrix-blue transition-colors">
+                        <span class="inline-block px-3 py-1 bg-metrix-blue/10 text-metrix-blue text-xs font-semibold rounded-full mb-3">Appraisal Fundamentals</span>
+                        <h3 class="text-xl font-bold text-gray-900 mb-2 group-hover:text-metrix-blue transition-colors">Appraisal vs Realtor CMA: What Is the Difference in Ontario?</h3>
+                        <p class="text-gray-600 mb-3">They can both discuss property value, but they are not built for the same decision. Here is how to know which one you need.</p>
+                        <span class="text-metrix-blue font-semibold inline-flex items-center">
+                            Read article
+                            <svg class="w-4 h-4 ml-1 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>
+                        </span>
+                    </div>
+                </a>
+                <a href="bank-appraisal-vs-private-appraisal-ontario.html" class="group">
+                    <div class="bg-white border border-gray-200 rounded-xl p-6 hover:border-metrix-blue transition-colors">
+                        <span class="inline-block px-3 py-1 bg-metrix-blue/10 text-metrix-blue text-xs font-semibold rounded-full mb-3">Appraisal Fundamentals</span>
+                        <h3 class="text-xl font-bold text-gray-900 mb-2 group-hover:text-metrix-blue transition-colors">Bank Appraisal vs Private Appraisal: Which Report Do You Need?</h3>
+                        <p class="text-gray-600 mb-3">The property may be the same, but the authorized client, authorized use, and report access may be different.</p>
+                        <span class="text-metrix-blue font-semibold inline-flex items-center">
+                            Read article
+                            <svg class="w-4 h-4 ml-1 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>
+                        </span>
+                    </div>
+                </a>
+            </div>
+        </div>
+
+        <!-- CTA -->
+        <div class="mt-16 bg-gradient-to-r from-metrix-blue to-metrix-blue-dark rounded-2xl p-8 md:p-12 text-white text-center">
+            <h2 class="text-3xl font-bold mb-4">Work With AACI-Designated Appraisers</h2>
+            <p class="text-xl text-gray-200 mb-6 max-w-2xl mx-auto">
+                Metrix Realty Group's team includes <a href="https://www.aicanada.ca/designation/aaci/" target="_blank" rel="noopener noreferrer" class="text-white underline hover:text-gray-200">AACI-designated appraisers</a> with decades of experience across commercial, industrial, multi-family, and residential properties throughout Southwestern Ontario — including London and Windsor-Essex.
+            </p>
+            <a href="/contact" class="inline-block bg-white text-metrix-blue px-8 py-4 rounded-lg font-semibold hover:bg-gray-100 transition-colors">
+                Schedule Your Consultation
+            </a>
+        </div>
+    </article>
+
+    <!-- Footer -->
+    <footer class="bg-black text-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
+                <!-- Company Info -->
+                <div class="lg:col-span-1">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-6 leading-relaxed">
+                        Trusted • Valued • Experienced
+                    </p>
+                    <div class="text-gray-300">
+                        <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
+                        <p class="mb-4">London, ON N6A 5J9</p>
+                        <p class="font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
+                            </svg>
+                            <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
+                        </p>
+                        <p>Toll Free: 1-866-672-9101</p>
+                        <p>Fax: (519) 672-9321</p>
+                        <p class="mt-4 font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                            </svg>
+                            <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
+                        </p>
+                    </div>
+                </div>
+
+                <!-- Services -->
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
+                    <ul class="space-y-3 text-gray-300">
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
+                        <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
+                    </ul>
+                </div>
+
+                <!-- Market Areas -->
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
+                    </ul>
+                </div>
+
+                <!-- Company -->
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
+                        <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
+                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
+                    </ul>
+                </div>
+            </div>
+
+            <!-- Professional Affiliations -->
+            <div class="border-t border-gray-800 pt-8 mb-8 text-center">
+                <div class="mb-6">
+                    <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
+                    <span>AIC - <a href="https://www.aicanada.ca/" target="_blank" rel="noopener noreferrer">Appraisal Institute of Canada</a></span>
+                    <span>RICS - Royal Institution of Chartered Surveyors</span>
+                    <span>AOLE - Association of Ontario Land Economists</span>
+                    <span>IRWA - International Right of Way Association</span>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6">
+                    <span>Data Providers:</span>
+                    <span>CoStar Professional</span>
+                    <span>TRREB - Toronto Regional Real Estate Board</span>
+                </div>
+                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
+                    <p>Reports completed in compliance with <a href="https://www.aicanada.ca/about-aic/cuspap/" target="_blank" rel="noopener noreferrer">CUSPAP</a> (Canadian Uniform Standards of Professional Appraisal Practice)</p>
+                </div>
+            </div>
+
+            <!-- Copyright -->
+            <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
+                <p>&copy; 2026 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script>
+        const mobileMenuButton = document.getElementById('mobile-menu-button');
+        const mobileMenu = document.getElementById('mobile-menu');
+        const mobileMenuOverlay = document.getElementById('mobile-menu-overlay');
+        const mobileMenuClose = document.getElementById('mobile-menu-close');
+
+        function openMobileMenu() { mobileMenu.classList.add('open'); if (mobileMenuOverlay) mobileMenuOverlay.classList.add('open'); }
+        function closeMobileMenu() { mobileMenu.classList.remove('open'); if (mobileMenuOverlay) mobileMenuOverlay.classList.remove('open'); }
+
+        if (mobileMenuButton) mobileMenuButton.addEventListener('click', function(e) { e.preventDefault(); mobileMenu.classList.contains('open') ? closeMobileMenu() : openMobileMenu(); });
+        if (mobileMenuClose) mobileMenuClose.addEventListener('click', function(e) { e.preventDefault(); closeMobileMenu(); });
+        if (mobileMenuOverlay) mobileMenuOverlay.addEventListener('click', closeMobileMenu);
+        document.addEventListener('keydown', function(e) { if (e.key === 'Escape') closeMobileMenu(); });
+        mobileMenu?.querySelectorAll('a').forEach(link => link.addEventListener('click', closeMobileMenu));
+
+        function shareArticle(platform) {
+            const url = encodeURIComponent(window.location.href);
+            const title = encodeURIComponent(document.title);
+            const urls = { twitter: `https://twitter.com/intent/tweet?url=${url}&text=${title}`, linkedin: `https://www.linkedin.com/sharing/share-offsite/?url=${url}`, facebook: `https://www.facebook.com/sharer/sharer.php?u=${url}` };
+            if (urls[platform]) window.open(urls[platform], '_blank', 'width=600,height=400');
+        }
+    </script>
+
+    <script src="../assets/js/analytics-tracking.js"></script>
+</body>
+</html>

--- a/insights/what-is-cuspap.html
+++ b/insights/what-is-cuspap.html
@@ -1,0 +1,790 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>What Is CUSPAP? (2024 Edition) | Metrix Realty Group</title>
+    <link rel="icon" type="image/png" href="/favicon.png">
+    <meta name="description" content="CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice) governs every AIC appraisal in Canada. Learn what the 2024 edition requires and why it matters.">
+    <link rel="canonical" href="https://metrixrealty.com/insights/what-is-cuspap.html">
+
+    <!-- Open Graph Meta Tags -->
+    <meta property="og:title" content="What Is CUSPAP? (2024 Edition) | Metrix Realty Group">
+    <meta property="og:description" content="CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice) governs every AIC appraisal in Canada. Learn what the 2024 edition requires and why it matters.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://metrixrealty.com/insights/what-is-cuspap.html">
+    <meta property="og:image" content="https://metrixrealty.com/assets/images/metrix-realty-team.webp">
+    <meta property="article:published_time" content="2026-05-27">
+    <meta property="article:author" content="Dan Van Houtte">
+
+    <!-- Twitter Card Meta Tags -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="robots" content="noindex, nofollow">
+    <meta name="twitter:title" content="What Is CUSPAP? (2024 Edition)">
+    <meta name="twitter:description" content="CUSPAP governs every appraisal assignment completed by AIC members in Canada. Here is what the 2024 standards require and why they matter to clients.">
+    <meta name="twitter:image" content="https://metrixrealty.com/assets/images/metrix-realty-team.webp">
+
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    <!-- End Google Tag Manager -->
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">
+
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        'metrix-blue': '#233c75',
+                        'metrix-blue-light': '#3d5a9e',
+                        'metrix-blue-dark': '#1a2d5a',
+                        'metrix-green': '#3faa4d',
+                    },
+                    fontFamily: {
+                        'inter': ['Inter', 'sans-serif'],
+                    }
+                }
+            }
+        }
+    </script>
+
+    <style>
+        body { font-family: 'Inter', sans-serif; }
+
+        .article-content { font-size: 1.125rem; line-height: 1.8; color: #374151; }
+        .article-content h2 { font-size: 2rem; font-weight: 700; color: #1f2937; margin-top: 3rem; margin-bottom: 1.5rem; line-height: 1.3; }
+        .article-content h3 { font-size: 1.5rem; font-weight: 600; color: #1f2937; margin-top: 2.5rem; margin-bottom: 1rem; }
+        .article-content p { margin-bottom: 1.5rem; }
+        .article-content ul, .article-content ol { margin-bottom: 1.5rem; padding-left: 2rem; }
+        .article-content ul { list-style-type: disc; list-style-position: inside; }
+        .article-content ol { list-style-type: decimal; list-style-position: inside; }
+        .article-content li { margin-bottom: 0.75rem; padding-left: 0.5rem; }
+        .article-content strong { font-weight: 600; color: #1f2937; }
+        .article-content a { color: #233c75; text-decoration: underline; }
+        .article-content a:hover { color: #1a2d5a; }
+
+        .article-content table { width: 100%; border-collapse: collapse; margin: 2rem 0; font-size: 0.95rem; }
+        .article-content th { background: #233c75; color: white; padding: 0.75rem 1rem; text-align: left; font-weight: 600; }
+        .article-content td { padding: 0.75rem 1rem; border-bottom: 1px solid #e5e7eb; vertical-align: top; }
+        .article-content tr:nth-child(even) td { background: #f9fafb; }
+
+        .callout-box { background: linear-gradient(135deg, #233c75 0%, #1a2d5a 100%); color: white; padding: 2rem; border-radius: 1rem; margin: 2.5rem 0; }
+        .callout-box h2, .callout-box h3 { color: white !important; margin-top: 0 !important; }
+        .callout-box strong { color: inherit !important; }
+        .callout-box p { margin-bottom: 0; }
+
+        .stat-highlight { background: #f0f9ff; border-left: 4px solid #3faa4d; padding: 1.5rem; margin: 2rem 0; border-radius: 0.5rem; }
+
+        .period-box, .callout-box, .stat-highlight, .bias-box, h1, h2, h3, h4, h5, h6 { list-style: none !important; }
+
+        .mobile-menu { position: fixed; top: 0; right: 0; height: 100vh; width: 320px; background: #ffffff; box-shadow: -10px 0 25px rgba(0,0,0,0.15); z-index: 99999; transform: translateX(100%); transition: transform 0.3s ease; }
+        .mobile-menu.open { transform: translateX(0); }
+        .overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.5); backdrop-filter: blur(4px); z-index: 99998; opacity: 0; visibility: hidden; transition: opacity 0.3s ease, visibility 0.3s ease; }
+        .overlay.active { opacity: 1; visibility: visible; }
+        .share-button { transition: all 0.2s ease; }
+        .share-button:hover { transform: translateY(-2px); }
+        .nav-link { position: relative; transition: all 0.3s cubic-bezier(0.4,0,0.2,1); }
+        .nav-link::after { content: ''; position: absolute; bottom: -2px; left: 0; width: 0; height: 2px; background: linear-gradient(90deg, #233c75, #1a2d5a); transition: width 0.3s ease; }
+        .nav-link:hover::after { width: 100%; }
+        .nav-link:hover { color: #233c75; }
+        .mega-menu-item { transition: all 0.3s ease; border-radius: 8px; }
+        .mega-menu-item:hover { background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%); transform: translateX(4px); }
+        .mobile-menu-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 99998; opacity: 0; visibility: hidden; transition: opacity 0.3s ease, visibility 0.3s ease; }
+        .mobile-menu-overlay.open { opacity: 1; visibility: visible; }
+        .mobile-menu-close { background: none; border: none; padding: 12px; cursor: pointer; color: #6b7280; border-radius: 6px; transition: all 0.2s ease; }
+        .mobile-menu-close:hover { background: #f3f4f6; color: #374151; }
+        .mobile-menu-content { padding: 24px; padding-top: 80px; height: 100%; overflow-y: auto; }
+        .mobile-nav { display: flex; flex-direction: column; gap: 8px; }
+        .mobile-nav-link { display: block; padding: 16px; color: #374151; font-weight: 500; font-size: 18px; text-decoration: none; border-radius: 8px; transition: all 0.2s ease; }
+        .mobile-nav-link:hover { color: #233c75; background: #f8fafc; }
+    </style>
+
+    <!-- Article Schema -->
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "What Is CUSPAP? (2024 Edition)",
+        "description": "CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice) governs every AIC appraisal in Canada. Learn what the 2024 edition requires and why it matters.",
+        "image": "https://metrixrealty.com/assets/images/metrix-realty-team.webp",
+        "datePublished": "2026-05-27",
+        "dateModified": "2026-05-27",
+        "author": {
+            "@type": "Person",
+            "name": "Dan Van Houtte",
+            "jobTitle": "MRICS AACI PLE",
+            "url": "https://metrixrealty.com/team"
+        },
+        "publisher": {
+            "@type": "Organization",
+            "name": "Metrix Realty Group",
+            "logo": {
+                "@type": "ImageObject",
+                "url": "https://metrixrealty.com/assets/images/metrix-realty-logo.png"
+            }
+        },
+        "mainEntityOfPage": {
+            "@type": "WebPage",
+            "@id": "https://metrixrealty.com/insights/what-is-cuspap.html"
+        },
+        "keywords": "CUSPAP, Canadian Uniform Standards of Professional Appraisal Practice, CUSPAP appraisal, appraisal standards Canada, AIC appraisal standards, AACI CUSPAP",
+        "articleSection": "Appraisal Standards",
+        "wordCount": 1850
+    }
+    </script>
+
+    <!-- FAQPage Schema -->
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+            {
+                "@type": "Question",
+                "name": "What does CUSPAP stand for?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "CUSPAP stands for Canadian Uniform Standards of Professional Appraisal Practice. It is the mandatory professional standard published by the Appraisal Institute of Canada (AIC) that governs how all AIC members must conduct, develop, and communicate appraisal assignments."
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "Does CUSPAP apply to all appraisers in Canada?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "CUSPAP applies to all members of the Appraisal Institute of Canada (AIC), including AACI-designated, CRA-designated, and Candidate members. It applies to every professional services assignment they complete — real property appraisals, reviews, consulting, reserve fund studies, and machinery and equipment appraisals. Non-members are not bound by CUSPAP, which is one reason clients should confirm their appraiser holds an AIC designation."
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "What happens if an appraiser violates CUSPAP?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "The AIC can investigate a formal complaint against any member alleged to have violated CUSPAP. Depending on the finding, sanctions can include a written warning, formal written criticism, suspension of membership, suspension of co-signing privileges, or permanent expulsion from the Institute. A case summary is published on the AIC's public website for twelve months following a disciplinary outcome."
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "Do lenders require CUSPAP-compliant appraisals?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Major lenders and financial institutions in Canada generally require appraisal reports completed by AIC members in compliance with CUSPAP. The AACI and CRA designations signal to lenders that the appraiser is bound by these standards. Reports prepared by non-members or non-designated individuals are typically not accepted by institutional lenders."
+                }
+            }
+        ]
+    }
+    </script>
+
+    <!-- BreadcrumbList Schema -->
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+            {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://metrixrealty.com/"},
+            {"@type": "ListItem", "position": 2, "name": "Insights", "item": "https://metrixrealty.com/insights/"},
+            {"@type": "ListItem", "position": 3, "name": "What Is CUSPAP? (2024 Edition)", "item": "https://metrixrealty.com/insights/what-is-cuspap.html"}
+        ]
+    }
+    </script>
+</head>
+<body class="bg-white">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+
+    <div class="overlay" id="overlay"></div>
+
+    <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
+        <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center justify-between h-16 sm:h-20">
+                <!-- Logo -->
+                <div class="flex-shrink-0">
+                    <a href="/">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
+                    </a>
+                </div>
+
+                <!-- Desktop Navigation -->
+                <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
+                    <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
+                    <div class="relative group">
+                        <a href="/services" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Services</a>
+                        <!-- Mega Menu -->
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-96 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50 backdrop-blur-sm">
+                            <div class="p-8">
+                                <div>
+                                    <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal & Consulting Services</h4>
+                                    <div class="space-y-1">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
+                                        </a>
+                                        <a href="/services/residential-property-appraisals" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Residential Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Professional home valuations for mortgages, refinancing, estate planning, and legal matters.</div>
+                                        </a>
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
+                                        </a>
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
+                                        </a>
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government & Institutional Services</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <!-- <a href="/insights/" class="nav-link text-gray-900 font-semibold">Market Insights</a> -->
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
+                </div>
+
+                <!-- CTA Button -->
+                <div class="hidden md:block">
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
+                        Connect with an Appraiser
+                    </a>
+                </div>
+
+                <!-- Mobile menu button -->
+                <div class="md:hidden">
+                    <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
+                        <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                        </div>
+                    </button>
+                </div>
+            </div>
+        </nav>
+
+        <!-- Mobile Menu -->
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link">Team</a>
+                    <!-- <a href="/insights/" class="mobile-nav-link">Market Insights</a> -->
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+
+        <!-- Mobile Menu Overlay -->
+        <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
+    </header>
+
+    <div class="h-16 sm:h-20"></div>
+
+    <!-- Breadcrumb -->
+    <div class="bg-gray-50 border-b">
+        <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+            <nav class="flex text-sm" aria-label="Breadcrumb">
+                <ol class="inline-flex items-center space-x-2">
+                    <li><a href="/" class="text-gray-500 hover:text-metrix-blue">Home</a></li>
+                    <li><span class="text-gray-400">/</span></li>
+                    <li><a href="/insights/" class="text-gray-500 hover:text-metrix-blue">Insights</a></li>
+                    <li><span class="text-gray-400">/</span></li>
+                    <li><span class="text-gray-700">What Is CUSPAP (2024 Edition)</span></li>
+                </ol>
+            </nav>
+        </div>
+    </div>
+
+    <!-- Article -->
+    <article class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <header class="mb-12">
+            <div class="mb-6">
+                <span class="inline-block px-4 py-2 bg-metrix-blue/10 text-metrix-blue text-sm font-semibold rounded-full">
+                    Appraisal Standards
+                </span>
+            </div>
+            <h1 class="text-4xl md:text-5xl font-bold text-gray-900 mb-6 leading-tight">
+                What Is CUSPAP? Canada's 2024 Appraisal Standards Explained
+            </h1>
+            <div class="flex flex-wrap items-center gap-4 text-gray-600 mb-8">
+                <div class="flex items-center">
+                    <svg class="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M4 4a2 2 0 012-2h8a2 2 0 012 2v12a2 2 0 01-2 2H6a2 2 0 01-2-2V4z" clip-rule="evenodd"></path></svg>
+                    <a href="/team" class="font-medium hover:text-metrix-blue transition-colors">Dan Van Houtte, MRICS AACI PLE</a>
+                </div>
+                <div class="flex items-center">
+                    <svg class="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z" clip-rule="evenodd"></path></svg>
+                    <time datetime="2026-05-27">May 27, 2026</time>
+                </div>
+                <div class="flex items-center">
+                    <svg class="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clip-rule="evenodd"></path></svg>
+                    <span>9 min read</span>
+                </div>
+            </div>
+            <p class="text-xl text-gray-600 leading-relaxed border-l-4 border-metrix-blue pl-6 py-2">
+                CUSPAP is the mandatory professional standard that governs every appraisal assignment completed by a member of the Appraisal Institute of Canada. If you have ever ordered an appraisal for a mortgage, estate, legal proceeding, or commercial property decision, CUSPAP is the framework that sets out what the appraiser was required to do.
+            </p>
+            <div class="flex items-center gap-3 mt-8 pt-8 border-t">
+                <span class="text-sm font-medium text-gray-700">Share:</span>
+                <button onclick="shareArticle('twitter')" class="share-button p-2 bg-gray-100 hover:bg-blue-400 hover:text-white rounded-lg transition-colors">
+                    <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M23 3a10.9 10.9 0 01-3.14 1.53 4.48 4.48 0 00-7.86 3v1A10.66 10.66 0 013 4s-4 9 5 13a11.64 11.64 0 01-7 2c9 5 20 0 20-11.5a4.5 4.5 0 00-.08-.83A7.72 7.72 0 0023 3z"></path></svg>
+                </button>
+                <button onclick="shareArticle('linkedin')" class="share-button p-2 bg-gray-100 hover:bg-blue-600 hover:text-white rounded-lg transition-colors">
+                    <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
+                </button>
+                <button onclick="shareArticle('facebook')" class="share-button p-2 bg-gray-100 hover:bg-blue-700 hover:text-white rounded-lg transition-colors">
+                    <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>
+                </button>
+            </div>
+        </header>
+
+        <!-- Article Content -->
+        <div class="article-content">
+
+            <p>CUSPAP stands for <strong>Canadian Uniform Standards of Professional Appraisal Practice</strong>. Published by the <a href="https://www.aicanada.ca/about-aic/cuspap/" target="_blank" rel="noopener">Appraisal Institute of Canada (AIC)</a>, CUSPAP sets out the minimum mandatory requirements for how AIC members must develop, document, and communicate professional appraisal services. The standards apply to residential appraisals, commercial appraisals, appraisal reviews, consulting assignments, reserve fund studies, and machinery and equipment appraisals. The current version in effect for all AIC members is CUSPAP 2024, which was published by the AIC and supersedes all prior editions.</p>
+
+            <p>CUSPAP exists for a straightforward reason: to protect the public. When a lender, lawyer, estate trustee, or business owner relies on an appraisal report to make a significant decision, they need confidence that the appraiser followed a consistent, rigorous standard. CUSPAP provides that assurance. Without it, there would be no common benchmark for what a credible appraisal report must contain, how conflicts of interest must be handled, or what an appraiser is required to disclose.</p>
+
+            <div class="callout-box">
+                <h2 style="font-size:1.5rem; margin-bottom:0.75rem;">Quick Answer</h2>
+                <p>CUSPAP — Canadian Uniform Standards of Professional Appraisal Practice — is the mandatory professional standard published by the Appraisal Institute of Canada. It applies to all AIC members and governs every type of appraisal assignment they complete. Compliance is not optional. A report that does not meet CUSPAP requirements is not an AIC-compliant appraisal, and it may not be accepted by lenders, courts, or other institutional users.</p>
+            </div>
+
+            <h2>Who Does CUSPAP Apply To?</h2>
+
+            <p>CUSPAP applies to all members of the Appraisal Institute of Canada. That includes:</p>
+
+            <ul>
+                <li><strong>AACI-designated members</strong> — Accredited Appraisers Canadian Institute, who are qualified for all property types including commercial, industrial, multi-family, land, and complex residential assignments.</li>
+                <li><strong>CRA-designated members</strong> — Canadian Residential Appraisers, who are qualified for residential properties with up to four self-contained units.</li>
+                <li><strong>Candidate members</strong> — Individuals working toward their AIC designation under the supervision of a designated member.</li>
+            </ul>
+
+            <p>Retired, student, associate, or honorary members cannot perform appraisal services. Non-members are not bound by CUSPAP at all — which is one of the most important reasons to verify your appraiser's AIC membership status before ordering a report.</p>
+
+            <p>CUSPAP compliance is compulsory for every professional services assignment. An AIC member cannot opt out of CUSPAP requirements based on the type of client, the size of the fee, or the format of the report.</p>
+
+            <h2>The Eight Standards Within CUSPAP</h2>
+
+            <p>CUSPAP is organized into eight major standards, each governing a specific type of professional service. Every standard contains Rules — which are mandatory minimum requirements — and Comments, which clarify and interpret what those rules require in practice.</p>
+
+            <ol>
+                <li><strong>Ethics Standard</strong> — Governs professional conduct, conflicts of interest, confidentiality, competency, and the appraiser's obligation to act with integrity and objectivity in all assignments.</li>
+                <li><strong>Reporting Standard</strong> — Applies to every report type across every assignment. Sets out the minimum content every report must contain, regardless of the service being provided.</li>
+                <li><strong>Real Property Appraisal Standard</strong> — Covers the development and communication of value opinions for residential and commercial real property, including all residential form, concise narrative, and comprehensive narrative reports.</li>
+                <li><strong>Review Standard</strong> — Addresses assignments where an appraiser reviews and critiques the work of another appraiser, providing an opinion of quality, adequacy, or compliance.</li>
+                <li><strong>Consulting Standard</strong> — Governs advisory and analytical services related to real property, where the appraiser's role is broader than producing a value opinion.</li>
+                <li><strong>Reserve Fund Study Standard</strong> — Applies to capital reserve planning for condominium corporations and other shared-interest communities.</li>
+                <li><strong>Machinery and Equipment Appraisal Standard</strong> — Governs valuations of industrial equipment and other non-real-property assets.</li>
+                <li><strong>Mass Appraisal Standard</strong> — Applies to large-scale valuation assignments, such as municipal property assessment work.</li>
+            </ol>
+
+            <p>Each standard defines the scope of work required for that assignment type, the mandatory content the report must include, and the level of analysis expected to produce a credible result.</p>
+
+            <h2>The Ethics Standard: What It Requires</h2>
+
+            <p>The Ethics Standard is the foundation of CUSPAP. It governs how appraisers conduct themselves before, during, and after every assignment.</p>
+
+            <p>Under the Ethics Standard, AIC members must:</p>
+
+            <ul>
+                <li>Act with integrity, objectivity, and impartiality in every assignment.</li>
+                <li>Disclose any conflicts of interest in writing before accepting an assignment.</li>
+                <li>Refuse to accept contingent compensation arrangements — that is, fees structured to depend on reaching a particular value conclusion.</li>
+                <li>Maintain client confidentiality except as required by law or professional investigation.</li>
+                <li>Maintain a work file for every assignment, containing all data and analysis used to support the report's conclusions.</li>
+                <li>Cooperate fully with any AIC professional practice investigation.</li>
+                <li>Comply with continuing professional development requirements.</li>
+                <li>Decline any assignment for which they lack the necessary competency.</li>
+            </ul>
+
+            <p>The Ethics Standard also explicitly prohibits misleading reports, false advertising, fraudulent conduct, and any behavior that would bring the profession into disrepute. The standard does not treat carelessness or negligent practice as acceptable simply because no measurable harm resulted — a violation is a violation regardless of outcome.</p>
+
+            <h2>Competency: What an Appraiser Must Demonstrate</h2>
+
+            <p>CUSPAP requires that every appraiser possess sufficient knowledge, skill, and experience to complete the specific assignment they have accepted. This is not a general credential — it applies to each individual assignment.</p>
+
+            <p>If an appraiser lacks competency for a particular assignment, CUSPAP requires them to disclose that deficiency in writing and take steps to address it before proceeding. That might mean additional study, working alongside a qualified specialist, or retaining a subject-matter expert and disclosing their involvement in the report.</p>
+
+            <p>For geographic assignments — where an appraiser is asked to value property in a market they do not regularly work in — CUSPAP requires them to develop a working understanding of local market conditions. Geographic unfamiliarity is not grounds to produce a lower-quality analysis.</p>
+
+            <p>The competency requirement is especially relevant for commercial and complex property appraisals. Only AACI-designated members are qualified to sign appraisal reports for commercial, industrial, multi-family, land, and special-use properties. Understanding the <a href="/insights/what-is-aaci-designation.html" class="text-metrix-blue hover:underline">AACI designation and what it requires</a> gives clients a clearer picture of what they are getting when they hire a fully designated commercial appraiser.</p>
+
+            <h2>What a CUSPAP-Compliant Appraisal Report Must Include</h2>
+
+            <p>The Reporting Standard specifies a minimum set of content requirements that every report must meet, regardless of property type or assignment scope. A report that omits any of these elements does not comply with CUSPAP.</p>
+
+            <p>Every CUSPAP-compliant appraisal report must identify:</p>
+
+            <ul>
+                <li>The <strong>authorized client</strong> and <strong>authorized users</strong> — by name. Vague references such as "the client" are not acceptable.</li>
+                <li>The <strong>authorized use</strong> of the report — the specific purpose for which the value opinion was prepared.</li>
+                <li>The <strong>effective date</strong> of the value opinion and the date the report was prepared.</li>
+                <li>The <strong>scope of work</strong> — what was inspected, what research was conducted, and what analysis was performed.</li>
+                <li>All <strong>assumptions and limiting conditions</strong> that affect the analysis or the value conclusion.</li>
+                <li>The <strong>relevant value definition</strong> being applied (e.g., market value, value in use, insurable value).</li>
+                <li>A signed <strong>certification</strong> in which the appraiser accepts responsibility for the report's contents.</li>
+            </ul>
+
+            <p>The report must also contain sufficient analysis for a reasonable appraiser reading the report to understand how the value conclusion was reached. CUSPAP recognizes three report formats: the residential form report, the short narrative, and the full narrative. A letter of opinion is not an accepted format under CUSPAP.</p>
+
+            <h2>CUSPAP-Compliant vs Non-Compliant: What the Difference Looks Like</h2>
+
+            <table>
+                <thead>
+                    <tr>
+                        <th>Characteristic</th>
+                        <th>CUSPAP-Compliant Report</th>
+                        <th>Non-Compliant Report</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td><strong>Appraiser credentials</strong></td>
+                        <td>Signed by an active AIC-designated member (AACI or CRA).</td>
+                        <td>Signed by a non-member, unlicensed individual, or person without the applicable designation for the property type.</td>
+                    </tr>
+                    <tr>
+                        <td><strong>Authorized use</strong></td>
+                        <td>Clearly states the specific purpose the report was prepared for and who the authorized users are.</td>
+                        <td>Uses vague language or omits the intended use and user identification entirely.</td>
+                    </tr>
+                    <tr>
+                        <td><strong>Effective date</strong></td>
+                        <td>States a specific date as of which the value opinion applies.</td>
+                        <td>Value opinion is undated or the effective date is unclear.</td>
+                    </tr>
+                    <tr>
+                        <td><strong>Scope of work</strong></td>
+                        <td>Describes the inspection, research, and analysis conducted for this specific assignment.</td>
+                        <td>Scope is absent, generic, or inconsistent with the analysis contained in the report.</td>
+                    </tr>
+                    <tr>
+                        <td><strong>Conflict of interest</strong></td>
+                        <td>Disclosed in writing before accepting the assignment, or confirmed not to exist.</td>
+                        <td>Not addressed. Appraiser may have a financial or personal interest in the outcome.</td>
+                    </tr>
+                    <tr>
+                        <td><strong>Fee arrangement</strong></td>
+                        <td>Fixed or hourly fee. Not contingent on the value reached.</td>
+                        <td>Fee is contingent on a specific value conclusion or outcome.</td>
+                    </tr>
+                    <tr>
+                        <td><strong>Lender acceptance</strong></td>
+                        <td>Accepted by major Canadian lenders and financial institutions.</td>
+                        <td>Typically rejected by institutional lenders and government bodies.</td>
+                    </tr>
+                    <tr>
+                        <td><strong>Professional accountability</strong></td>
+                        <td>Appraiser subject to AIC discipline process if standards are not met.</td>
+                        <td>No professional body with jurisdiction over the practitioner's conduct.</td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <h2>What Happens When an Appraiser Violates CUSPAP?</h2>
+
+            <p>The AIC operates a formal complaint resolution process. Any party — client, lender, lawyer, or member of the public — can file a formal complaint against an AIC member alleged to have violated CUSPAP, the AIC's bylaws, or its Professional Liability Insurance Program requirements.</p>
+
+            <p>Depending on the findings of the investigation, the AIC can impose the following sanctions:</p>
+
+            <ul>
+                <li>A written warning.</li>
+                <li>A formal written expression of criticism and professional disapproval.</li>
+                <li>Suspension of AIC membership.</li>
+                <li>Suspension of the member's co-signing privileges.</li>
+                <li>Permanent expulsion from the Appraisal Institute of Canada.</li>
+            </ul>
+
+            <p>Following a disciplinary outcome, a case summary is published on the public section of the AIC website for twelve months. This transparency is part of the AIC's self-regulatory mandate and serves as a deterrent against professional misconduct.</p>
+
+            <p>Beyond professional sanctions, CUSPAP violations can expose an appraiser to civil liability if a client suffers financial harm because of a non-compliant or misleading report. The AIC's mandatory Professional Liability Insurance Program may deny coverage for claims arising from deliberate misconduct or acts that contravene CUSPAP.</p>
+
+            <div class="stat-highlight">
+                <p style="margin-bottom:0;"><strong>Why this matters to clients:</strong> The fact that an appraiser is subject to professional discipline creates accountability that informal valuation opinions do not carry. If you receive a CUSPAP-compliant report and the analysis is later found to be deficient, there is a regulated mechanism for addressing that. A report from a non-member has no equivalent recourse.</p>
+            </div>
+
+            <h2>Why Clients Should Care Whether Their Appraiser Follows CUSPAP</h2>
+
+            <p>For lenders, lawyers, accountants, estate trustees, and business owners, CUSPAP compliance is not a formality — it is a substantive quality signal.</p>
+
+            <p><strong>For lenders and financial institutions:</strong> Major Canadian banks and institutional lenders require appraisal reports completed by AIC members in compliance with CUSPAP. A report from a non-designated practitioner will typically be rejected outright, regardless of the property's actual value. This means that ordering an appraisal from someone who is not an AIC member can delay a financing transaction and require a second report to be commissioned.</p>
+
+            <p><strong>For lawyers and estate trustees:</strong> CUSPAP-compliant reports provide a documented chain of analysis that can withstand scrutiny in legal proceedings, estate administration, matrimonial disputes, and tax matters. Courts expect that appraisal evidence presented by an AIC-designated appraiser will have been developed in accordance with CUSPAP. A non-compliant report is more easily challenged on procedural grounds, independent of the value conclusion itself.</p>
+
+            <p><strong>For commercial property owners and investors:</strong> When a value opinion will support a financing decision, a sale, a partnership dispute, or a tax appeal, the report needs to be defensible. CUSPAP's requirements around scope of work, assumption disclosure, and analysis documentation provide a structural framework that makes a commercial appraisal report credible and reviewable.</p>
+
+            <p><strong>For all clients:</strong> CUSPAP prohibits contingent fee arrangements for appraisal assignments. This means your appraiser cannot structure their fee to depend on reaching a specific value conclusion. That prohibition protects you from a form of conflict of interest that can compromise the entire appraisal process. Review <a href="/services">Metrix's appraisal services</a> to understand the range of assignments where this independence matters most.</p>
+
+            <h2>CUSPAP vs. USPAP: What Is the Difference?</h2>
+
+            <p>Canadian and American real estate markets share many investment participants, and clients with cross-border exposure sometimes ask whether CUSPAP is equivalent to USPAP — the Uniform Standards of Professional Appraisal Practice used in the United States. The two standards serve the same general purpose but are separate documents issued by separate organizations with no mutual recognition agreement.</p>
+
+            <table>
+                <thead>
+                    <tr>
+                        <th>Feature</th>
+                        <th>CUSPAP (Canada)</th>
+                        <th>USPAP (United States)</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td><strong>Governing body</strong></td>
+                        <td>Appraisal Institute of Canada (AIC)</td>
+                        <td>The Appraisal Foundation</td>
+                    </tr>
+                    <tr>
+                        <td><strong>Jurisdiction</strong></td>
+                        <td>Canada — mandatory for all AIC members</td>
+                        <td>United States — adopted by state law in most states</td>
+                    </tr>
+                    <tr>
+                        <td><strong>Designation structure</strong></td>
+                        <td>AACI (all property types), CRA (residential)</td>
+                        <td>MAI (commercial), SRA (residential)</td>
+                    </tr>
+                    <tr>
+                        <td><strong>Current edition</strong></td>
+                        <td>CUSPAP 2024</td>
+                        <td>USPAP 2024–2025</td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <p>An appraiser holding a USPAP-compliant credential from the U.S. is not automatically qualified to complete appraisals in Canada under CUSPAP, and vice versa. Canadian lenders, courts, and government bodies require CUSPAP compliance from AIC-designated appraisers — a U.S.-trained appraiser working under USPAP would need to become an AIC member and comply with CUSPAP to produce reports accepted in Canada.</p>
+
+            <h2>How Metrix Realty Group Delivers CUSPAP-Compliant Reports</h2>
+
+            <p>Metrix Realty Group has been providing independent appraisal and valuation services across London, Windsor, and Southwestern Ontario since 1995. Every report produced by Metrix is completed by an AACI-designated appraiser in full compliance with CUSPAP.</p>
+
+            <p>The AACI designation — Accredited Appraiser Canadian Institute — is the highest designation issued by the AIC and qualifies the holder to appraise all property types, including commercial, industrial, multi-family, land, and special-use assets. Metrix appraisers carry this designation because the majority of the firm's work involves commercial and complex property assignments that require it.</p>
+
+            <p>Metrix reports are accepted by all major Canadian lenders, financial institutions, and government bodies. Each report identifies the authorized client and authorized users, states a specific effective date, describes the scope of work conducted, discloses all assumptions and limiting conditions, and is signed by a designated member who accepts professional responsibility for the analysis and conclusions.</p>
+
+            <p>The firm's work spans commercial mortgage financing, estate and date-of-death valuations, litigation support and expert testimony, property tax appeals, expropriation matters, and strategic consulting for business owners and investors. Whether the assignment involves a multi-tenant retail plaza, an industrial facility, agricultural land, or a complex residential property, the same CUSPAP framework governs how the work is done.</p>
+
+            <p>If you have questions about whether a specific assignment requires a CUSPAP-compliant report, or if you need to understand what a properly scoped appraisal involves for your situation, <a href="/contact">contact Metrix</a> directly. Explaining the decision the value needs to support is the best starting point for any appraisal inquiry.</p>
+
+            <h2>FAQs</h2>
+
+            <h3>What Does CUSPAP Stand For?</h3>
+            <p>CUSPAP stands for Canadian Uniform Standards of Professional Appraisal Practice. It is the mandatory professional standard published by the Appraisal Institute of Canada (AIC) that governs how all AIC members must conduct, develop, and communicate appraisal assignments.</p>
+
+            <h3>Does CUSPAP Apply to All Appraisers in Canada?</h3>
+            <p>CUSPAP applies to all members of the Appraisal Institute of Canada, including AACI-designated, CRA-designated, and Candidate members. It covers every professional services assignment they complete. Non-members are not bound by CUSPAP, which is one reason clients should confirm their appraiser holds an active AIC designation.</p>
+
+            <h3>What Happens If an Appraiser Violates CUSPAP?</h3>
+            <p>The AIC can investigate formal complaints and impose sanctions ranging from a written warning to permanent expulsion from the Institute. Sanctions also include suspension of membership and suspension of co-signing privileges. A case summary is published on the AIC's public website for twelve months following any disciplinary outcome.</p>
+
+            <h3>Do Lenders Require CUSPAP-Compliant Appraisals?</h3>
+            <p>Major lenders and financial institutions in Canada generally require appraisal reports completed by AIC members in compliance with CUSPAP. The AACI and CRA designations signal to lenders that the appraiser is bound by these standards. Reports prepared by non-members are typically not accepted for institutional lending purposes.</p>
+
+        </div>
+
+        <!-- Related Articles -->
+        <div class="mt-16 pt-12 border-t">
+            <h2 class="text-3xl font-bold text-gray-900 mb-8">Continue Reading</h2>
+            <div class="grid md:grid-cols-2 gap-8">
+                <a href="appraisal-vs-realtor-cma-ontario.html" class="group">
+                    <div class="bg-white border border-gray-200 rounded-xl p-6 hover:border-metrix-blue transition-colors">
+                        <span class="inline-block px-3 py-1 bg-metrix-blue/10 text-metrix-blue text-xs font-semibold rounded-full mb-3">Appraisal Fundamentals</span>
+                        <h3 class="text-xl font-bold text-gray-900 mb-2 group-hover:text-metrix-blue transition-colors">Appraisal vs Realtor CMA: What Is the Difference in Ontario?</h3>
+                        <p class="text-gray-600 mb-3">The property may be the same, but the purpose, users, and report scope are different. Here is how to choose the right tool for your decision.</p>
+                        <span class="text-metrix-blue font-semibold inline-flex items-center">
+                            Read article
+                            <svg class="w-4 h-4 ml-1 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>
+                        </span>
+                    </div>
+                </a>
+                <a href="what-is-aaci-designation.html" class="group">
+                    <div class="bg-white border border-gray-200 rounded-xl p-6 hover:border-metrix-blue transition-colors">
+                        <span class="inline-block px-3 py-1 bg-metrix-blue/10 text-metrix-blue text-xs font-semibold rounded-full mb-3">Appraisal Standards</span>
+                        <h3 class="text-xl font-bold text-gray-900 mb-2 group-hover:text-metrix-blue transition-colors">What Is the AACI Designation? Canada's Highest Appraisal Credential Explained</h3>
+                        <p class="text-gray-600 mb-3">The AACI designation from the Appraisal Institute of Canada qualifies an appraiser for all property types. Here is what it requires and why it matters.</p>
+                        <span class="text-metrix-blue font-semibold inline-flex items-center">
+                            Read article
+                            <svg class="w-4 h-4 ml-1 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>
+                        </span>
+                    </div>
+                </a>
+            </div>
+        </div>
+
+        <!-- CTA -->
+        <div class="mt-16 bg-gradient-to-r from-metrix-blue to-metrix-blue-dark rounded-2xl p-8 md:p-12 text-white text-center">
+            <h2 class="text-3xl font-bold mb-4">Need a CUSPAP-Compliant Appraisal?</h2>
+            <p class="text-xl text-gray-200 mb-6 max-w-2xl mx-auto">
+                Every Metrix report is produced by <a href="https://www.aicanada.ca/designation/aaci/" target="_blank" rel="noopener noreferrer" class="text-white underline hover:text-gray-200">AACI</a>-designated appraisers in full compliance with CUSPAP — accepted by all major lenders and defensible in any professional setting.
+            </p>
+            <a href="/contact" class="inline-block bg-white text-metrix-blue px-8 py-4 rounded-lg font-semibold hover:bg-gray-100 transition-colors">
+                Schedule Your Consultation
+            </a>
+        </div>
+    </article>
+
+    <!-- Footer -->
+    <footer class="bg-black text-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
+                <!-- Company Info -->
+                <div class="lg:col-span-1">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-6 leading-relaxed">
+                        Trusted • Valued • Experienced
+                    </p>
+                    <div class="text-gray-300">
+                        <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
+                        <p class="mb-4">London, ON N6A 5J9</p>
+                        <p class="font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
+                            </svg>
+                            <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
+                        </p>
+                        <p>Toll Free: 1-866-672-9101</p>
+                        <p>Fax: (519) 672-9321</p>
+                        <p class="mt-4 font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                            </svg>
+                            <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
+                        </p>
+                    </div>
+                </div>
+
+                <!-- Services -->
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
+                    <ul class="space-y-3 text-gray-300">
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government & Institutional</a></li>
+                        <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
+                    </ul>
+                </div>
+
+                <!-- Market Areas -->
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
+                    </ul>
+                </div>
+
+                <!-- Company -->
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
+                        <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
+                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
+                    </ul>
+                </div>
+            </div>
+
+            <!-- Professional Affiliations -->
+            <div class="border-t border-gray-800 pt-8 mb-8 text-center">
+                <div class="mb-6">
+                    <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
+                    <span>AIC - <a href="https://www.aicanada.ca/" target="_blank" rel="noopener noreferrer">Appraisal Institute of Canada</a></span>
+                    <span>RICS - Royal Institution of Chartered Surveyors</span>
+                    <span>AOLE - Association of Ontario Land Economists</span>
+                    <span>IRWA - International Right of Way Association</span>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6">
+                    <span>Data Providers:</span>
+                    <span>CoStar Professional</span>
+                    <span>TRREB - Toronto Regional Real Estate Board</span>
+                </div>
+                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
+                    <p>Reports completed in compliance with <a href="https://www.aicanada.ca/about-aic/cuspap/" target="_blank" rel="noopener noreferrer">CUSPAP</a> (Canadian Uniform Standards of Professional Appraisal Practice)</p>
+                </div>
+            </div>
+
+            <!-- Copyright -->
+            <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
+                <p>&copy; 2026 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script>
+        const mobileMenuButton = document.getElementById('mobile-menu-button');
+        const mobileMenu = document.getElementById('mobile-menu');
+        const mobileMenuOverlay = document.getElementById('mobile-menu-overlay');
+        const mobileMenuClose = document.getElementById('mobile-menu-close');
+
+        function openMobileMenu() { mobileMenu.classList.add('open'); if (mobileMenuOverlay) mobileMenuOverlay.classList.add('open'); }
+        function closeMobileMenu() { mobileMenu.classList.remove('open'); if (mobileMenuOverlay) mobileMenuOverlay.classList.remove('open'); }
+
+        if (mobileMenuButton) mobileMenuButton.addEventListener('click', function(e) { e.preventDefault(); mobileMenu.classList.contains('open') ? closeMobileMenu() : openMobileMenu(); });
+        if (mobileMenuClose) mobileMenuClose.addEventListener('click', function(e) { e.preventDefault(); closeMobileMenu(); });
+        if (mobileMenuOverlay) mobileMenuOverlay.addEventListener('click', closeMobileMenu);
+        document.addEventListener('keydown', function(e) { if (e.key === 'Escape') closeMobileMenu(); });
+        mobileMenu?.querySelectorAll('a').forEach(link => link.addEventListener('click', closeMobileMenu));
+
+        function shareArticle(platform) {
+            const url = encodeURIComponent(window.location.href);
+            const title = encodeURIComponent(document.title);
+            const urls = { twitter: `https://twitter.com/intent/tweet?url=${url}&text=${title}`, linkedin: `https://www.linkedin.com/sharing/share-offsite/?url=${url}`, facebook: `https://www.facebook.com/sharer/sharer.php?u=${url}` };
+            if (urls[platform]) window.open(urls[platform], '_blank', 'width=600,height=400');
+        }
+    </script>
+
+    <script src="../assets/js/analytics-tracking.js"></script>
+</body>
+</html>

--- a/llms.txt
+++ b/llms.txt
@@ -98,3 +98,13 @@ Metrix Realty Group's appraisers are experienced expert witnesses who regularly 
 
 **What areas does Metrix Realty Group serve?**
 Metrix Realty Group serves all of Southwestern Ontario from offices in London and Windsor. Their primary service area includes London, St. Thomas, Woodstock, Stratford, Sarnia, Chatham-Kent, Windsor, and the counties of Middlesex, Elgin, Oxford, Perth, Huron, Lambton, and Essex. They also accept specialized assignments across all of Ontario.
+
+## Insights & Educational Resources
+
+**What Is the AACI Designation?**
+URL: https://metrixrealty.com/insights/what-is-aaci-designation.html
+AACI (Accredited Appraiser Canadian Institute) is the senior real property appraisal designation issued by the Appraisal Institute of Canada, qualifying the holder to appraise all property types. This article explains what the designation requires, how it differs from the CRA designation, and why lenders and courts require AACI-designated appraisers for commercial and complex property assignments. Written by Dan Van Houtte, MRICS AACI PLE.
+
+**What Is CUSPAP? (2024 Edition)**
+URL: https://metrixrealty.com/insights/what-is-cuspap.html
+CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice) is the mandatory standard published by the Appraisal Institute of Canada that governs how all AIC members must conduct and communicate appraisal assignments. The 2024 edition is the current version in effect. This article covers who CUSPAP applies to, what a compliant report must include, the Ethics and Competency Standards, and how CUSPAP differs from USPAP (the U.S. equivalent). Written by Dan Van Houtte, MRICS AACI PLE.

--- a/london/commercial-appraisal/index.html
+++ b/london/commercial-appraisal/index.html
@@ -600,7 +600,7 @@
                     <span>TRREB - Toronto Regional Real Estate Board</span>
                 </div>
                 <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
-                    <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
+                    <p>Reports completed in compliance with <a href="https://www.aicanada.ca/about-aic/cuspap/" target="_blank" rel="noopener noreferrer">CUSPAP</a> (Canadian Uniform Standards of Professional Appraisal Practice)</p>
                 </div>
             </div>
             

--- a/london/industrial-appraisal/index.html
+++ b/london/industrial-appraisal/index.html
@@ -483,7 +483,7 @@
                     <span>TRREB - Toronto Regional Real Estate Board</span>
                 </div>
                 <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
-                    <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
+                    <p>Reports completed in compliance with <a href="https://www.aicanada.ca/about-aic/cuspap/" target="_blank" rel="noopener noreferrer">CUSPAP</a> (Canadian Uniform Standards of Professional Appraisal Practice)</p>
                 </div>
             </div>
             

--- a/london/residential-appraisal/index.html
+++ b/london/residential-appraisal/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Home Appraisal London Ontario | <a href="https://www.aicanada.ca/designation/aaci/" target="_blank" rel="noopener noreferrer">AACI</a> Certified | Metrix</title>
+    <title>Home Appraisal London Ontario | AACI Certified | Metrix</title>
     <link rel="icon" type="image/png" href="/favicon.png">
     <meta name="description" content="Home appraisals in London, Ontario by AACI and CRA-designated professionals. Expert residential valuations for mortgages, estates, and legal matters.">
     <link rel="canonical" href="https://metrixrealty.com/london/residential-appraisal">
@@ -287,7 +287,7 @@
             <div class="max-w-4xl" data-aos="fade-up">
                 <p class="text-metrix-green font-semibold text-sm uppercase tracking-wider mb-3">London, Ontario</p>
                 <h1 class="text-3xl sm:text-4xl lg:text-5xl font-bold mb-6 leading-tight">Home Appraisal Services in London, Ontario</h1>
-                <p class="text-lg sm:text-xl text-white/85 mb-8 leading-relaxed max-w-3xl">Accurate, lender-approved home valuations by AACI and CRA designated appraisers. Mortgage financing, refinancing, estate settlement, divorce proceedings, and <a href="https://www.mpac.ca/" target="_blank" rel="noopener noreferrer">MPAC</a> property tax appeals across London and Middlesex County.</p>
+                <p class="text-lg sm:text-xl text-white/85 mb-8 leading-relaxed max-w-3xl">Accurate, lender-approved home valuations by <a href="https://www.aicanada.ca/designation/aaci/" target="_blank" rel="noopener noreferrer">AACI</a> and CRA designated appraisers. Mortgage financing, refinancing, estate settlement, divorce proceedings, and <a href="https://www.mpac.ca/" target="_blank" rel="noopener noreferrer">MPAC</a> property tax appeals across London and Middlesex County.</p>
                 <div class="flex flex-col sm:flex-row gap-4">
                     <a href="/contact" class="inline-flex items-center justify-center px-8 py-4 bg-white text-metrix-blue font-semibold rounded-lg hover:bg-gray-100 transition-colors text-lg">
                         Request a Quote
@@ -503,7 +503,7 @@
                     <span>TRREB - Toronto Regional Real Estate Board</span>
                 </div>
                 <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
-                    <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
+                    <p>Reports completed in compliance with <a href="https://www.aicanada.ca/about-aic/cuspap/" target="_blank" rel="noopener noreferrer">CUSPAP</a> (Canadian Uniform Standards of Professional Appraisal Practice)</p>
                 </div>
             </div>
             

--- a/roman-virk/index.html
+++ b/roman-virk/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <link rel="canonical" href="https://metrixrealty.com/roman-virk">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Roman Virk | <a href="https://www.aicanada.ca/designation/aaci/" target="_blank" rel="noopener noreferrer">AACI</a> Designated Appraiser | Metrix Realty Group</title>
+    <title>Roman Virk | AACI Designated Appraiser | Metrix Realty Group</title>
     <link rel="icon" type="image/png" href="/favicon.png">
     <meta name="description" content="Meet Roman Virk, AACI Designated Appraiser at Metrix Realty Group. BMOS, AACI with expertise in commercial and residential valuations.">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -297,7 +297,7 @@
                     <div class="flex items-start justify-between mb-4">
                             <div>
                             <h4 class="text-xl font-bold text-gray-600 mb-2">Metrix Realty Group, London ON</h4>
-                            <p class="text-lg font-semibold text-gray-900 mb-2">P. App., AACI Designated Appraiser</p>
+                            <p class="text-lg font-semibold text-gray-900 mb-2">P. App., <a href="https://www.aicanada.ca/designation/aaci/" target="_blank" rel="noopener noreferrer">AACI</a> Designated Appraiser</p>
                             <p class="text-gray-600">2025 - Present</p>
                         </div>
                     </div>

--- a/services/commercial-property-valuations/index.html
+++ b/services/commercial-property-valuations/index.html
@@ -687,7 +687,7 @@
                     <span>TRREB - Toronto Regional Real Estate Board</span>
                 </div>
                 <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
-                    <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
+                    <p>Reports completed in compliance with <a href="https://www.aicanada.ca/about-aic/cuspap/" target="_blank" rel="noopener noreferrer">CUSPAP</a> (Canadian Uniform Standards of Professional Appraisal Practice)</p>
                 </div>
             </div>
             

--- a/services/residential-property-appraisals/index.html
+++ b/services/residential-property-appraisals/index.html
@@ -597,7 +597,7 @@
                     <span>TRREB - Toronto Regional Real Estate Board</span>
                 </div>
                 <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
-                    <p>Reports completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice)</p>
+                    <p>Reports completed in compliance with <a href="https://www.aicanada.ca/about-aic/cuspap/" target="_blank" rel="noopener noreferrer">CUSPAP</a> (Canadian Uniform Standards of Professional Appraisal Practice)</p>
                 </div>
             </div>
             

--- a/suzanne-de-jong/index.html
+++ b/suzanne-de-jong/index.html
@@ -490,6 +490,9 @@
                     <span>OREA - Ontario Real Estate Association</span>
                     <span>CREA - Canadian Real Estate Association</span>
                 </div>
+                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
+                    <p>Reports completed in compliance with <a href="https://www.aicanada.ca/about-aic/cuspap/" target="_blank" rel="noopener noreferrer">CUSPAP</a> (Canadian Uniform Standards of Professional Appraisal Practice)</p>
+                </div>
             </div>
             
             <!-- Copyright -->

--- a/team/index.html
+++ b/team/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title><a href="https://www.aicanada.ca/designation/aaci/" target="_blank" rel="noopener noreferrer">AACI</a> Certified Appraisers | Metrix Realty Group Team</title>
+    <title>AACI Certified Appraisers | Metrix Realty Group Team</title>
     <meta property="og:title" content="AACI Certified Appraisers | Metrix Realty Group Team">
     <meta property="og:description" content="Meet our team of AACI-designated real estate appraisers and valuation experts serving Southwestern Ontario with over 25 years of combined experience.">
     <link rel="icon" type="image/png" href="/favicon.png">
@@ -402,7 +402,7 @@
                 </div>
                 
                 <h1 class="text-4xl sm:text-5xl lg:text-6xl font-bold mb-8 leading-tight" data-aos="fade-up" data-aos-duration="1000">
-                    Meet Our AACI-Certified Appraisers
+                    Meet Our <a href="https://www.aicanada.ca/designation/aaci/" target="_blank" rel="noopener noreferrer">AACI</a>-Certified Appraisers
                 </h1>
                 <p class="text-lg sm:text-xl lg:text-2xl mb-12 opacity-90 max-w-4xl mx-auto leading-relaxed" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="200">
                     Our accredited professionals bring decades of combined experience in real estate valuation across Southwestern Ontario.

--- a/tyler-munn/index.html
+++ b/tyler-munn/index.html
@@ -409,6 +409,9 @@
                     <span>OREA - Ontario Real Estate Association</span>
                     <span>CREA - Canadian Real Estate Association</span>
                 </div>
+                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
+                    <p>Reports completed in compliance with <a href="https://www.aicanada.ca/about-aic/cuspap/" target="_blank" rel="noopener noreferrer">CUSPAP</a> (Canadian Uniform Standards of Professional Appraisal Practice)</p>
+                </div>
             </div>
             
             <!-- Copyright -->

--- a/windsor/commercial-appraisal/index.html
+++ b/windsor/commercial-appraisal/index.html
@@ -1,0 +1,660 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Commercial Appraisal Windsor Ontario | Metrix Realty</title>
+    <link rel="icon" type="image/png" href="/favicon.png">
+    <meta name="description" content="AACI-designated commercial appraisers in Windsor-Essex. Office, retail, industrial, and multi-family valuations accepted by all major lenders.">
+    <meta name="keywords" content="commercial appraisal Windsor Ontario, commercial appraiser Windsor, ICI appraisal Windsor Essex, AACI appraiser Windsor, office appraisal Windsor, retail appraisal Windsor">
+    <link rel="canonical" href="https://metrixrealty.com/windsor/commercial-appraisal">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Metrix Realty Group">
+    <meta property="og:title" content="Commercial Appraisal Windsor Ontario | Metrix Realty">
+    <meta property="og:description" content="AACI-designated commercial appraisers in Windsor-Essex. Office, retail, industrial, and multi-family valuations accepted by all major lenders.">
+    <meta property="og:url" content="https://metrixrealty.com/windsor/commercial-appraisal">
+    <meta property="og:image" content="https://metrixrealty.com/assets/images/metrix-realty-logo.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="robots" content="noindex, nofollow">
+
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
+    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: { 'metrix-blue': '#233c75', 'metrix-blue-light': '#3d5a9e', 'metrix-blue-dark': '#1a2d5a', 'metrix-green': '#3faa4d' },
+                    fontFamily: { 'inter': ['Inter', 'sans-serif'] }
+                }
+            }
+        }
+    </script>
+    <style>
+        .bg-hero { background: linear-gradient(135deg, #233c75 0%, #1a2d5a 70%, #3faa4d 100%); }
+        .hamburger-line { transition: all 0.3s ease; }
+        .hamburger.open .hamburger-line:nth-child(1) { transform: rotate(45deg) translate(5px, 5px); }
+        .hamburger.open .hamburger-line:nth-child(2) { opacity: 0; }
+        .hamburger.open .hamburger-line:nth-child(3) { transform: rotate(-45deg) translate(7px, -6px); }
+        .mobile-menu { position: fixed; top: 0; right: 0; height: 100vh; width: 320px; background: #ffffff !important; box-shadow: -10px 0 25px rgba(0,0,0,0.15); z-index: 99999 !important; transform: translateX(100%); transition: transform 0.4s cubic-bezier(0.25,0.46,0.45,0.94); border-left: 1px solid #e5e7eb; }
+        .mobile-menu.open { transform: translateX(0); }
+        .mobile-menu-close { position: absolute; top: 24px; right: 24px; background: none; border: none; padding: 8px; cursor: pointer; color: #9ca3af; border-radius: 8px; transition: all 0.2s ease; }
+        .mobile-menu-close:hover { background: #f3f4f6; color: #374151; }
+        .mobile-menu-content { padding: 80px 32px 32px; height: 100%; overflow-y: auto; }
+        .mobile-nav { display: flex; flex-direction: column; gap: 8px; }
+        .mobile-nav-link { display: block; padding: 16px 0; color: #374151; font-weight: 500; font-size: 18px; text-decoration: none; border-bottom: 1px solid #f3f4f6; transition: all 0.2s ease; }
+        .mobile-nav-link:hover { color: #233c75; background: #f8fafc; padding-left: 16px; border-radius: 8px; border-bottom: 1px solid transparent; }
+        .mobile-nav-link.active { color: #233c75; font-weight: 600; }
+        .mobile-menu-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 99998 !important; opacity: 0; visibility: hidden; transition: all 0.3s ease; }
+        .mobile-menu-overlay.show { opacity: 1; visibility: visible; }
+        body.menu-open { overflow: hidden; }
+        .nav-link { position: relative; transition: all 0.3s cubic-bezier(0.4,0,0.2,1); }
+        .nav-link::after { content: ''; position: absolute; bottom: -2px; left: 0; width: 0; height: 2px; background: linear-gradient(90deg,#1a202c,#2d3748); transition: width 0.3s cubic-bezier(0.4,0,0.2,1); }
+        .nav-link:hover::after { width: 100%; }
+        .nav-link:hover { color: #1a202c; transform: translateY(-1px); }
+        .nav-link.active { color: #1a202c; font-weight: 600; }
+        .nav-link.active::after { width: 100%; }
+        .mega-menu-item { display: block; border-radius: 12px; transition: all 0.2s ease; }
+        .mega-menu-item:hover { background: #f8fafc; }
+        .mega-menu-item:hover .mega-menu-title { color: #233c75; }
+        .btn-primary { position: relative; overflow: hidden; transition: all 0.3s cubic-bezier(0.4,0,0.2,1); }
+        .btn-primary:hover { transform: translateY(-2px); box-shadow: 0 10px 25px rgba(26,32,44,0.25); }
+        .touch-target { min-height: 44px; min-width: 44px; }
+    </style>
+
+    <!-- Structured Data -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "ProfessionalService",
+      "name": "Metrix Realty Group – Commercial Appraisal Windsor Ontario",
+      "url": "https://metrixrealty.com/windsor/commercial-appraisal",
+      "description": "AACI-designated commercial real estate appraisers in Windsor-Essex. Office, retail, industrial, and multi-family valuations accepted by all major Canadian lenders.",
+      "telephone": "+1-519-672-7550",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "2557 Dougall Ave #6",
+        "addressLocality": "Windsor",
+        "addressRegion": "ON",
+        "postalCode": "N8X 1T5",
+        "addressCountry": "CA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 42.3149,
+        "longitude": -83.0364
+      },
+      "areaServed": { "@type": "City", "name": "Windsor", "containedInPlace": { "@type": "AdministrativeArea", "name": "Ontario" } },
+      "hasCredential": ["AACI", "CUSPAP", "RICS"],
+      "parentOrganization": { "@type": "Organization", "name": "Metrix Realty Group", "url": "https://metrixrealty.com" }
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://metrixrealty.com/"},
+        {"@type": "ListItem", "position": 2, "name": "Windsor", "item": "https://metrixrealty.com/windsor/"},
+        {"@type": "ListItem", "position": 3, "name": "Commercial Appraisal", "item": "https://metrixrealty.com/windsor/commercial-appraisal"}
+      ]
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "Who provides commercial appraisals in Windsor, Ontario?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Metrix Realty Group provides commercial appraisals in Windsor, Ontario through its Windsor office at 2557 Dougall Ave #6. Founded in 1995 with over 50,000 appraisal files completed, Metrix is one of Southwestern Ontario's most experienced commercial appraisal firms with AACI-designated appraisers serving Windsor-Essex and all of Essex County."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "What commercial property types are appraised in Windsor-Essex?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Metrix Realty appraises all commercial property types in Windsor-Essex including office buildings, retail plazas and shopping centres, multi-tenant commercial properties, mixed-use developments, and special purpose properties. Windsor's commercial market is shaped by the automotive sector, the Windsor-Detroit border crossing, and the growing Gordie Howe International Bridge logistics corridor."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Are commercial appraisals from Metrix Realty accepted by Windsor lenders?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Yes. Metrix Realty's AACI-designated appraisers produce CUSPAP-compliant reports accepted by all major Canadian financial institutions including chartered banks, credit unions, CMHC, and private lenders for commercial mortgage financing, refinancing, and construction loans in Windsor, Essex County, and throughout Southwestern Ontario."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "What is the Windsor-Essex commercial real estate market like in 2026?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "The Windsor-Essex commercial real estate market in 2026 reflects strong industrial demand driven by the automotive manufacturing sector (Stellantis, Ford supply chain), ongoing logistics growth near the Gordie Howe International Bridge, and Essex County's agricultural and food processing industries. Office and retail markets are tighter than London with generally less vacancy. Commercial investment cap rates have adjusted from 2021–2022 lows in line with broader Ontario market trends."
+          }
+        }
+      ]
+    }
+    </script>
+</head>
+<body class="font-inter">
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+
+    <!-- Global Header -->
+    <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
+        <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center justify-between h-16 sm:h-20">
+                <!-- Logo -->
+                <div class="flex-shrink-0">
+                    <a href="/">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
+                    </a>
+                </div>
+
+                <!-- Desktop Navigation -->
+                <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
+                    <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
+                    <div class="relative group">
+                        <a href="/services" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Services</a>
+                        <!-- Mega Menu -->
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-96 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50 backdrop-blur-sm">
+                            <div class="p-8">
+                                <div>
+                                    <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal &amp; Consulting Services</h4>
+                                    <div class="space-y-1">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
+                                        </a>
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
+                                        </a>
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
+                                        </a>
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government &amp; Institutional Services</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link active text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
+                </div>
+
+                <!-- CTA Button -->
+                <div class="hidden md:block">
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
+                        Connect with an Appraiser
+                    </a>
+                </div>
+
+                <!-- Mobile menu button -->
+                <div class="md:hidden">
+                    <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
+                        <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                        </div>
+                    </button>
+                </div>
+            </div>
+        </nav>
+
+        <!-- Mobile Menu -->
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link active">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link">Team</a>
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+
+        <!-- Mobile Menu Overlay -->
+        <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
+    </header>
+
+    <!-- Hero -->
+    <section class="bg-hero pt-20 sm:pt-24 pb-16 sm:pb-20 text-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <nav class="text-sm mb-6 text-white/70" aria-label="Breadcrumb">
+                <ol class="flex flex-wrap gap-1 items-center">
+                    <li><a href="/" class="hover:text-white transition-colors">Home</a></li>
+                    <li class="text-white/40 mx-1">/</li>
+                    <li><a href="/windsor/" class="hover:text-white transition-colors">Windsor</a></li>
+                    <li class="text-white/40 mx-1">/</li>
+                    <li class="text-white">Commercial Appraisal</li>
+                </ol>
+            </nav>
+            <div class="max-w-4xl" data-aos="fade-up">
+                <p class="text-metrix-green font-semibold text-sm uppercase tracking-wider mb-3">Windsor, Ontario</p>
+                <h1 class="text-3xl sm:text-4xl lg:text-5xl font-bold mb-6 leading-tight">Commercial Appraisal in Windsor, Ontario</h1>
+                <p class="text-lg sm:text-xl text-white/85 mb-8 leading-relaxed max-w-3xl">Lender-approved commercial property valuations by <a href="https://www.aicanada.ca/designation/aaci/" target="_blank" rel="noopener noreferrer" class="underline hover:text-white">AACI</a>-designated appraisers serving Windsor-Essex and all of Essex County. Over 30 years and 50,000+ files completed across Southwestern Ontario.</p>
+                <div class="flex flex-col sm:flex-row gap-4">
+                    <a href="/contact" class="inline-flex items-center justify-center px-8 py-4 bg-white text-metrix-blue font-semibold rounded-lg hover:bg-gray-100 transition-colors text-lg">
+                        Request a Quote
+                        <svg class="w-5 h-5 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"/></svg>
+                    </a>
+                    <a href="tel:519-672-7550" class="inline-flex items-center justify-center px-8 py-4 bg-transparent text-white font-semibold rounded-lg border-2 border-white hover:bg-white hover:text-metrix-blue transition-colors text-lg">
+                        (519) 672-7550
+                    </a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- When You Need Us -->
+    <section class="py-16 sm:py-20 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="max-w-3xl mx-auto text-center mb-12" data-aos="fade-up">
+                <h2 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-4">When Is a Commercial Appraisal Required in Windsor?</h2>
+                <p class="text-gray-600 text-lg">Commercial appraisals in Windsor-Essex are required across a wide range of situations — from lender financing and investment decisions to legal proceedings and insurance coverage.</p>
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6" data-aos="fade-up" data-aos-delay="100">
+                <div class="p-6 rounded-xl border border-gray-200 hover:border-metrix-blue hover:shadow-md transition-all">
+                    <h3 class="font-semibold text-gray-900 mb-2">Financing &amp; Refinancing</h3>
+                    <p class="text-gray-600 text-sm">Lender-approved appraisals for commercial mortgage applications, refinancing, and construction financing. Accepted by all major Canadian financial institutions operating in Windsor-Essex.</p>
+                </div>
+                <div class="p-6 rounded-xl border border-gray-200 hover:border-metrix-blue hover:shadow-md transition-all">
+                    <h3 class="font-semibold text-gray-900 mb-2">Acquisition &amp; Disposition</h3>
+                    <p class="text-gray-600 text-sm">Independent market value opinions to support the purchase or sale of commercial properties across Windsor, LaSalle, Tecumseh, Amherstburg, and Essex County.</p>
+                </div>
+                <div class="p-6 rounded-xl border border-gray-200 hover:border-metrix-blue hover:shadow-md transition-all">
+                    <h3 class="font-semibold text-gray-900 mb-2">Portfolio Management</h3>
+                    <p class="text-gray-600 text-sm">Periodic portfolio valuations for institutional investors, REITs, and property managers requiring accurate asset values for reporting and strategic planning.</p>
+                </div>
+                <div class="p-6 rounded-xl border border-gray-200 hover:border-metrix-blue hover:shadow-md transition-all">
+                    <h3 class="font-semibold text-gray-900 mb-2">Financial Reporting &amp; Tax</h3>
+                    <p class="text-gray-600 text-sm">Valuations for IFRS financial reporting, capital gains calculations, CRA compliance, and property tax assessment appeals before the <a href="https://tribunalsontario.ca/arb/" target="_blank" rel="noopener noreferrer" class="text-metrix-blue hover:underline">Assessment Review Board</a>.</p>
+                </div>
+                <div class="p-6 rounded-xl border border-gray-200 hover:border-metrix-blue hover:shadow-md transition-all">
+                    <h3 class="font-semibold text-gray-900 mb-2">Insurance Purposes</h3>
+                    <p class="text-gray-600 text-sm">Replacement cost and market value assessments for insurance coverage determination and claims support on commercial and industrial properties in Windsor-Essex.</p>
+                </div>
+                <div class="p-6 rounded-xl border border-gray-200 hover:border-metrix-blue hover:shadow-md transition-all">
+                    <h3 class="font-semibold text-gray-900 mb-2">Legal &amp; Partnership Disputes</h3>
+                    <p class="text-gray-600 text-sm">Court-ready valuations for litigation, partnership buyouts, shareholder disputes, and expropriation proceedings in Windsor-Essex with experienced expert witness testimony.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Property Types -->
+    <section class="py-16 sm:py-20 bg-gray-50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="max-w-3xl mx-auto text-center mb-12" data-aos="fade-up">
+                <h2 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-4">Commercial Property Types We Appraise in Windsor</h2>
+                <p class="text-gray-600 text-lg">Our AACI-designated appraisers cover all commercial property types across Windsor-Essex County and the surrounding region.</p>
+            </div>
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6" data-aos="fade-up" data-aos-delay="100">
+                <div class="bg-white p-6 rounded-xl shadow-sm">
+                    <h3 class="font-semibold text-gray-900 mb-2">Office Buildings</h3>
+                    <p class="text-gray-600 text-sm">Multi-tenant office complexes, corporate headquarters, professional buildings, and medical office facilities across Windsor and the Essex County region.</p>
+                </div>
+                <div class="bg-white p-6 rounded-xl shadow-sm">
+                    <h3 class="font-semibold text-gray-900 mb-2">Retail &amp; Shopping Centres</h3>
+                    <p class="text-gray-600 text-sm">Strip malls, retail plazas, anchored shopping centres, standalone retail, and mixed-use retail in Windsor, Tecumseh, LaSalle, and throughout Essex County.</p>
+                </div>
+                <div class="bg-white p-6 rounded-xl shadow-sm">
+                    <h3 class="font-semibold text-gray-900 mb-2">Multi-Tenant Commercial</h3>
+                    <p class="text-gray-600 text-sm">Multi-tenant commercial properties with diverse tenancy mixes, including automotive supply chain tenants and border-adjacent commercial uses unique to Windsor's economy.</p>
+                </div>
+                <div class="bg-white p-6 rounded-xl shadow-sm">
+                    <h3 class="font-semibold text-gray-900 mb-2">Multi-Family Investment</h3>
+                    <p class="text-gray-600 text-sm">Apartment buildings (5+ units), rental complexes, and multi-family investment properties for CMHC financing, acquisition, and portfolio management in Windsor-Essex.</p>
+                </div>
+                <div class="bg-white p-6 rounded-xl shadow-sm">
+                    <h3 class="font-semibold text-gray-900 mb-2">Mixed-Use Developments</h3>
+                    <p class="text-gray-600 text-sm">Properties combining residential, retail, office, or industrial uses requiring specialized mixed-use valuation methodology, including redevelopment sites near the downtown core.</p>
+                </div>
+                <div class="bg-white p-6 rounded-xl shadow-sm">
+                    <h3 class="font-semibold text-gray-900 mb-2">Special Purpose Properties</h3>
+                    <p class="text-gray-600 text-sm">Hotels, automotive-related facilities, gas stations, development land, and other special purpose properties throughout Windsor and Essex County.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Windsor Market Context + Why Choose Us -->
+    <section class="py-16 sm:py-20 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
+                <div data-aos="fade-right">
+                    <h2 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-6">Windsor-Essex Commercial Real Estate Market</h2>
+                    <p class="text-gray-600 mb-4">Windsor-Essex is one of Canada's most strategically important commercial real estate markets. The region's economy is anchored by the automotive manufacturing sector — including Stellantis and the Ford supply chain — and reinforced by Canada's busiest commercial border crossing at Windsor-Detroit.</p>
+                    <p class="text-gray-600 mb-4">Key market drivers shaping Windsor commercial property values in 2026:</p>
+                    <ul class="space-y-3 text-gray-600 mb-6">
+                        <li class="flex items-start gap-2"><span class="text-metrix-green font-bold mt-1">→</span><span><strong>Gordie Howe Bridge:</strong> The new international crossing is generating significant industrial and logistics demand in the bridge corridor, creating new valuation complexity.</span></li>
+                        <li class="flex items-start gap-2"><span class="text-metrix-green font-bold mt-1">→</span><span><strong>Automotive Sector:</strong> Stellantis and Ford supply chain activity drives industrial and commercial demand across the region — unique to Windsor among Ontario markets.</span></li>
+                        <li class="flex items-start gap-2"><span class="text-metrix-green font-bold mt-1">→</span><span><strong>Tight Market:</strong> Windsor-Essex commercial vacancy is generally lower than London, with limited new supply across most asset classes.</span></li>
+                        <li class="flex items-start gap-2"><span class="text-metrix-green font-bold mt-1">→</span><span><strong>Essex County Agriculture:</strong> Rural commercial and agri-business properties in Essex, Leamington, and Kingsville require specialized rural commercial valuation expertise.</span></li>
+                    </ul>
+                    <p class="text-gray-600">Metrix appraisers use CoStar Professional, local comparable sales, and direct market knowledge to ensure every Windsor commercial appraisal reflects current conditions.</p>
+                </div>
+                <div data-aos="fade-left">
+                    <div class="bg-metrix-blue rounded-2xl p-8 text-white">
+                        <h3 class="text-xl font-bold mb-6">Why Windsor Businesses Choose Metrix</h3>
+                        <div class="space-y-4">
+                            <div class="flex items-start gap-3">
+                                <span class="text-metrix-green text-xl font-bold">✓</span>
+                                <div>
+                                    <p class="font-semibold">Windsor Office — Local Market Expertise</p>
+                                    <p class="text-white/75 text-sm">Located at 2557 Dougall Ave, Windsor. Our appraisers know this market from the inside.</p>
+                                </div>
+                            </div>
+                            <div class="flex items-start gap-3">
+                                <span class="text-metrix-green text-xl font-bold">✓</span>
+                                <div>
+                                    <p class="font-semibold">30+ Years &amp; 50,000+ Files</p>
+                                    <p class="text-white/75 text-sm">Founded in 1995. Decades of Southwestern Ontario appraisal experience behind every report.</p>
+                                </div>
+                            </div>
+                            <div class="flex items-start gap-3">
+                                <span class="text-metrix-green text-xl font-bold">✓</span>
+                                <div>
+                                    <p class="font-semibold">RICS &amp; IRWA Designations</p>
+                                    <p class="text-white/75 text-sm">International credentialing that provides added assurance for cross-border Windsor-Detroit transactions.</p>
+                                </div>
+                            </div>
+                            <div class="flex items-start gap-3">
+                                <span class="text-metrix-green text-xl font-bold">✓</span>
+                                <div>
+                                    <p class="font-semibold">All Major Lenders Accepted</p>
+                                    <p class="text-white/75 text-sm">Reports accepted by all Canadian banks, credit unions, <a href="https://www.cmhc-schl.gc.ca/" target="_blank" rel="noopener noreferrer" class="underline">CMHC</a>, and private lenders.</p>
+                                </div>
+                            </div>
+                            <div class="flex items-start gap-3">
+                                <span class="text-metrix-green text-xl font-bold">✓</span>
+                                <div>
+                                    <p class="font-semibold"><a href="https://www.aicanada.ca/about-aic/cuspap/" target="_blank" rel="noopener noreferrer" class="underline">CUSPAP</a> Compliant</p>
+                                    <p class="text-white/75 text-sm">Every report meets the Canadian Uniform Standards of Professional Appraisal Practice.</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Process -->
+    <section class="py-16 sm:py-20 bg-gray-50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="max-w-3xl mx-auto text-center mb-12" data-aos="fade-up">
+                <h2 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-4">Our Windsor Commercial Appraisal Process</h2>
+                <p class="text-gray-600 text-lg">A straightforward, transparent process from first contact to final report delivery.</p>
+            </div>
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6" data-aos="fade-up" data-aos-delay="100">
+                <div class="bg-white rounded-xl p-6 shadow-sm text-center">
+                    <div class="w-12 h-12 bg-metrix-blue text-white rounded-full flex items-center justify-center text-xl font-bold mx-auto mb-4">1</div>
+                    <h3 class="font-semibold text-gray-900 mb-2">Consultation</h3>
+                    <p class="text-gray-600 text-sm">We discuss your property, appraisal purpose, intended users, and provide a transparent fee quote and confirmed timeline.</p>
+                </div>
+                <div class="bg-white rounded-xl p-6 shadow-sm text-center">
+                    <div class="w-12 h-12 bg-metrix-blue text-white rounded-full flex items-center justify-center text-xl font-bold mx-auto mb-4">2</div>
+                    <h3 class="font-semibold text-gray-900 mb-2">Property Inspection</h3>
+                    <p class="text-gray-600 text-sm">Thorough on-site inspection documenting physical condition, improvements, tenancy, and all value-affecting factors specific to the Windsor market.</p>
+                </div>
+                <div class="bg-white rounded-xl p-6 shadow-sm text-center">
+                    <div class="w-12 h-12 bg-metrix-blue text-white rounded-full flex items-center justify-center text-xl font-bold mx-auto mb-4">3</div>
+                    <h3 class="font-semibold text-gray-900 mb-2">Market Research</h3>
+                    <p class="text-gray-600 text-sm">Analysis of comparable sales, lease rates, cap rates, and Windsor-Essex market conditions using CoStar Professional and local transactional data.</p>
+                </div>
+                <div class="bg-white rounded-xl p-6 shadow-sm text-center">
+                    <div class="w-12 h-12 bg-metrix-blue text-white rounded-full flex items-center justify-center text-xl font-bold mx-auto mb-4">4</div>
+                    <h3 class="font-semibold text-gray-900 mb-2">Report Delivery</h3>
+                    <p class="text-gray-600 text-sm">Detailed, professionally formatted CUSPAP-compliant appraisal report. Standard: 5–10 business days. Rush: 24–48 hours available.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Service Area -->
+    <section class="py-12 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="bg-gray-50 rounded-2xl p-8" data-aos="fade-up">
+                <h2 class="text-xl font-bold text-gray-900 mb-4">Windsor-Essex Service Area</h2>
+                <p class="text-gray-600 mb-4">Our Windsor office serves commercial clients throughout Essex County and the surrounding region:</p>
+                <div class="flex flex-wrap gap-3">
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">Windsor</span>
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">LaSalle</span>
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">Tecumseh</span>
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">Amherstburg</span>
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">Essex</span>
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">Kingsville</span>
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">Leamington</span>
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">Lakeshore</span>
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">All of Essex County</span>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- FAQ -->
+    <section class="py-16 sm:py-20 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="max-w-3xl mx-auto">
+                <h2 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-10 text-center" data-aos="fade-up">Frequently Asked Questions</h2>
+                <div class="space-y-6" data-aos="fade-up" data-aos-delay="100">
+                    <div class="border border-gray-200 rounded-xl p-6">
+                        <h3 class="font-semibold text-gray-900 mb-2">Who provides commercial appraisals in Windsor, Ontario?</h3>
+                        <p class="text-gray-600">Metrix Realty Group provides commercial appraisals in Windsor through its local office at 2557 Dougall Ave #6. Founded in 1995 with over 50,000 files completed, Metrix brings AACI-designated appraisers with deep Windsor-Essex market knowledge to every assignment. Our team serves clients from Windsor through LaSalle, Tecumseh, Amherstburg, and throughout Essex County.</p>
+                    </div>
+                    <div class="border border-gray-200 rounded-xl p-6">
+                        <h3 class="font-semibold text-gray-900 mb-2">What commercial property types are appraised in Windsor-Essex?</h3>
+                        <p class="text-gray-600">We appraise all commercial property types in Windsor-Essex including office buildings, retail plazas and shopping centres, multi-tenant commercial properties, multi-family investment properties (5+ units), mixed-use developments, and special purpose properties. Windsor's commercial market includes unique automotive sector and border-crossing influences that require local expertise to value accurately.</p>
+                    </div>
+                    <div class="border border-gray-200 rounded-xl p-6">
+                        <h3 class="font-semibold text-gray-900 mb-2">Are Metrix commercial appraisals accepted by Windsor lenders?</h3>
+                        <p class="text-gray-600">Yes. Our <a href="https://www.aicanada.ca/designation/aaci/" target="_blank" rel="noopener noreferrer" class="text-metrix-blue hover:underline">AACI</a>-designated appraisers produce CUSPAP-compliant reports accepted by all major Canadian financial institutions including banks, credit unions, CMHC, and private lenders for commercial mortgage financing, refinancing, and construction loans in Windsor, Essex County, and throughout Southwestern Ontario.</p>
+                    </div>
+                    <div class="border border-gray-200 rounded-xl p-6">
+                        <h3 class="font-semibold text-gray-900 mb-2">How does the Windsor commercial real estate market differ from other Ontario cities?</h3>
+                        <p class="text-gray-600">Windsor-Essex has a distinct commercial real estate market shaped by three major factors: the automotive manufacturing sector (Stellantis, Ford supply chain), Canada's busiest commercial border crossing at Windsor-Detroit, and the new Gordie Howe International Bridge generating logistics corridor demand. These factors create tighter vacancy rates and unique valuation considerations compared to inland Ontario cities. Our Windsor appraisers understand these dynamics and reflect them accurately in every report.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- CTA -->
+    <section class="py-16 sm:py-20 bg-metrix-blue text-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+            <h2 class="text-2xl sm:text-3xl font-bold mb-4" data-aos="fade-up">Get a Windsor Commercial Appraisal Quote</h2>
+            <p class="text-white/80 text-lg mb-8 max-w-2xl mx-auto" data-aos="fade-up" data-aos-delay="100">Tell us your property type, purpose, intended users, and timeline. Our AACI-designated Windsor team will respond with a transparent fee quote.</p>
+            <div class="flex flex-col sm:flex-row gap-4 justify-center" data-aos="fade-up" data-aos-delay="200">
+                <a href="/contact" class="inline-flex items-center justify-center px-8 py-4 bg-white text-metrix-blue font-semibold rounded-lg hover:bg-gray-100 transition-colors text-lg">
+                    Connect with an Appraiser
+                </a>
+                <a href="tel:519-672-7550" class="inline-flex items-center justify-center px-8 py-4 bg-transparent text-white font-semibold rounded-lg border-2 border-white hover:bg-white hover:text-metrix-blue transition-colors text-lg">
+                    Call (519) 672-7550
+                </a>
+            </div>
+            <p class="text-white/60 text-sm mt-6">Windsor office: 2557 Dougall Ave #6, Windsor, ON N8X 1T5 &nbsp;|&nbsp; <a href="/windsor/" class="underline hover:text-white">Windsor Hub</a></p>
+        </div>
+    </section>
+
+    <!-- Footer -->
+    <footer class="bg-black text-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
+                <!-- Company Info -->
+                <div class="lg:col-span-1">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-6 leading-relaxed">
+                        Trusted • Valued • Experienced
+                    </p>
+                    <div class="text-gray-300">
+                        <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
+                        <p class="mb-4">London, ON N6A 5J9</p>
+                        <p class="font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
+                            </svg>
+                            <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
+                        </p>
+                        <p>Toll Free: 1-866-672-9101</p>
+                        <p>Fax: (519) 672-9321</p>
+                        <p class="mt-4 font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                            </svg>
+                            <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
+                        </p>
+                    </div>
+                </div>
+
+                <!-- Services -->
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
+                    <ul class="space-y-3 text-gray-300">
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government &amp; Institutional</a></li>
+                        <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
+                    </ul>
+                </div>
+
+                <!-- Market Areas -->
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
+                    </ul>
+                </div>
+
+                <!-- Company -->
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
+                        <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
+                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
+                    </ul>
+                </div>
+            </div>
+
+            <!-- Professional Affiliations -->
+            <div class="border-t border-gray-800 pt-8 mb-8 text-center">
+                <div class="mb-6">
+                    <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
+                    <span>AIC - <a href="https://www.aicanada.ca/" target="_blank" rel="noopener noreferrer">Appraisal Institute of Canada</a></span>
+                    <span>RICS - Royal Institution of Chartered Surveyors</span>
+                    <span>AOLE - Association of Ontario Land Economists</span>
+                    <span>IRWA - International Right of Way Association</span>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6">
+                    <span>Data Providers:</span>
+                    <span>CoStar Professional</span>
+                    <span>TRREB - Toronto Regional Real Estate Board</span>
+                </div>
+                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
+                    <p>Reports completed in compliance with <a href="https://www.aicanada.ca/about-aic/cuspap/" target="_blank" rel="noopener noreferrer">CUSPAP</a> (Canadian Uniform Standards of Professional Appraisal Practice)</p>
+                </div>
+            </div>
+
+            <!-- Copyright -->
+            <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
+                <p>&copy; 2026 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
+    <script>
+        AOS.init({ once: true, duration: 800 });
+        document.addEventListener('DOMContentLoaded', function() {
+            const mobileMenuButton = document.getElementById('mobile-menu-button');
+            const mobileMenu = document.getElementById('mobile-menu');
+            const mobileMenuOverlay = document.getElementById('mobile-menu-overlay');
+            const mobileMenuClose = document.getElementById('mobile-menu-close');
+            const hamburger = document.querySelector('.hamburger');
+            if (!mobileMenuButton || !mobileMenu) return;
+            function openMobileMenu() {
+                mobileMenu.classList.add('open');
+                if (mobileMenuOverlay) mobileMenuOverlay.classList.add('show');
+                if (hamburger) hamburger.classList.add('open');
+                document.body.classList.add('menu-open');
+                mobileMenuButton.setAttribute('aria-expanded', 'true');
+            }
+            function closeMobileMenu() {
+                mobileMenu.classList.remove('open');
+                if (mobileMenuOverlay) mobileMenuOverlay.classList.remove('show');
+                if (hamburger) hamburger.classList.remove('open');
+                document.body.classList.remove('menu-open');
+                mobileMenuButton.setAttribute('aria-expanded', 'false');
+            }
+            mobileMenuButton.addEventListener('click', function() {
+                mobileMenu.classList.contains('open') ? closeMobileMenu() : openMobileMenu();
+            });
+            if (mobileMenuClose) mobileMenuClose.addEventListener('click', closeMobileMenu);
+            if (mobileMenuOverlay) mobileMenuOverlay.addEventListener('click', closeMobileMenu);
+        });
+    </script>
+</body>
+</html>

--- a/windsor/industrial-appraisal/index.html
+++ b/windsor/industrial-appraisal/index.html
@@ -1,0 +1,636 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Industrial Appraisal Windsor Ontario | Metrix Realty</title>
+    <link rel="icon" type="image/png" href="/favicon.png">
+    <meta name="description" content="AACI-designated industrial appraisers serving Windsor-Essex. Manufacturing, warehouse, flex industrial, and automotive valuations. Lender-recognized.">
+    <meta name="keywords" content="industrial appraisal Windsor Ontario, industrial property appraiser Windsor, warehouse appraisal Windsor Essex, manufacturing facility appraisal Windsor, automotive plant appraisal Windsor">
+    <link rel="canonical" href="https://metrixrealty.com/windsor/industrial-appraisal">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Metrix Realty Group">
+    <meta property="og:title" content="Industrial Appraisal Windsor Ontario | Metrix Realty">
+    <meta property="og:description" content="AACI-designated industrial appraisers serving Windsor-Essex. Manufacturing, warehouse, flex industrial, and automotive valuations. Lender-recognized.">
+    <meta property="og:url" content="https://metrixrealty.com/windsor/industrial-appraisal">
+    <meta property="og:image" content="https://metrixrealty.com/assets/images/metrix-realty-logo.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="robots" content="noindex, nofollow">
+
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
+    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: { 'metrix-blue': '#233c75', 'metrix-blue-light': '#3d5a9e', 'metrix-blue-dark': '#1a2d5a', 'metrix-green': '#3faa4d' },
+                    fontFamily: { 'inter': ['Inter', 'sans-serif'] }
+                }
+            }
+        }
+    </script>
+    <style>
+        .bg-hero { background: linear-gradient(135deg, #233c75 0%, #1a2d5a 70%, #3faa4d 100%); }
+        .hamburger-line { transition: all 0.3s ease; }
+        .hamburger.open .hamburger-line:nth-child(1) { transform: rotate(45deg) translate(5px, 5px); }
+        .hamburger.open .hamburger-line:nth-child(2) { opacity: 0; }
+        .hamburger.open .hamburger-line:nth-child(3) { transform: rotate(-45deg) translate(7px, -6px); }
+        .mobile-menu { position: fixed; top: 0; right: 0; height: 100vh; width: 320px; background: #ffffff !important; box-shadow: -10px 0 25px rgba(0,0,0,0.15); z-index: 99999 !important; transform: translateX(100%); transition: transform 0.4s cubic-bezier(0.25,0.46,0.45,0.94); border-left: 1px solid #e5e7eb; }
+        .mobile-menu.open { transform: translateX(0); }
+        .mobile-menu-close { position: absolute; top: 24px; right: 24px; background: none; border: none; padding: 8px; cursor: pointer; color: #9ca3af; border-radius: 8px; transition: all 0.2s ease; }
+        .mobile-menu-close:hover { background: #f3f4f6; color: #374151; }
+        .mobile-menu-content { padding: 80px 32px 32px; height: 100%; overflow-y: auto; }
+        .mobile-nav { display: flex; flex-direction: column; gap: 8px; }
+        .mobile-nav-link { display: block; padding: 16px 0; color: #374151; font-weight: 500; font-size: 18px; text-decoration: none; border-bottom: 1px solid #f3f4f6; transition: all 0.2s ease; }
+        .mobile-nav-link:hover { color: #233c75; background: #f8fafc; padding-left: 16px; border-radius: 8px; border-bottom: 1px solid transparent; }
+        .mobile-nav-link.active { color: #233c75; font-weight: 600; }
+        .mobile-menu-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 99998 !important; opacity: 0; visibility: hidden; transition: all 0.3s ease; }
+        .mobile-menu-overlay.show { opacity: 1; visibility: visible; }
+        body.menu-open { overflow: hidden; }
+        .nav-link { position: relative; transition: all 0.3s cubic-bezier(0.4,0,0.2,1); }
+        .nav-link::after { content: ''; position: absolute; bottom: -2px; left: 0; width: 0; height: 2px; background: linear-gradient(90deg,#1a202c,#2d3748); transition: width 0.3s cubic-bezier(0.4,0,0.2,1); }
+        .nav-link:hover::after { width: 100%; }
+        .nav-link:hover { color: #1a202c; transform: translateY(-1px); }
+        .nav-link.active { color: #1a202c; font-weight: 600; }
+        .nav-link.active::after { width: 100%; }
+        .mega-menu-item { display: block; border-radius: 12px; transition: all 0.2s ease; }
+        .mega-menu-item:hover { background: #f8fafc; }
+        .mega-menu-item:hover .mega-menu-title { color: #233c75; }
+        .btn-primary { position: relative; overflow: hidden; transition: all 0.3s cubic-bezier(0.4,0,0.2,1); }
+        .btn-primary:hover { transform: translateY(-2px); box-shadow: 0 10px 25px rgba(26,32,44,0.25); }
+        .touch-target { min-height: 44px; min-width: 44px; }
+    </style>
+
+    <!-- Structured Data -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "ProfessionalService",
+      "name": "Metrix Realty Group – Industrial Appraisal Windsor Ontario",
+      "url": "https://metrixrealty.com/windsor/industrial-appraisal",
+      "description": "AACI-designated industrial property appraisers in Windsor-Essex. Manufacturing, warehouse, flex industrial, automotive plant, and food processing valuations accepted by all major Canadian lenders.",
+      "telephone": "+1-519-672-7550",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "2557 Dougall Ave #6",
+        "addressLocality": "Windsor",
+        "addressRegion": "ON",
+        "postalCode": "N8X 1T5",
+        "addressCountry": "CA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 42.3149,
+        "longitude": -83.0364
+      },
+      "areaServed": { "@type": "City", "name": "Windsor", "containedInPlace": { "@type": "AdministrativeArea", "name": "Ontario" } },
+      "hasCredential": ["AACI", "CUSPAP", "RICS"],
+      "parentOrganization": { "@type": "Organization", "name": "Metrix Realty Group", "url": "https://metrixrealty.com" }
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://metrixrealty.com/"},
+        {"@type": "ListItem", "position": 2, "name": "Windsor", "item": "https://metrixrealty.com/windsor/"},
+        {"@type": "ListItem", "position": 3, "name": "Industrial Appraisal", "item": "https://metrixrealty.com/windsor/industrial-appraisal"}
+      ]
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "Who appraises industrial properties in Windsor, Ontario?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Metrix Realty Group appraises industrial properties throughout Windsor-Essex from its Windsor office at 2557 Dougall Ave #6. Our AACI-designated appraisers have extensive experience valuing manufacturing facilities, automotive supply chain properties, warehouses, distribution centres, flex industrial, and food processing facilities across Essex County."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "How are automotive manufacturing facilities appraised in Windsor?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Automotive manufacturing facilities in Windsor require specialized appraisal methodology. Our appraisers apply cost, income, and sales comparison approaches — often weighting cost approach heavily for purpose-built plants — and consider functional and economic obsolescence factors specific to automotive manufacturing, including retooling costs, process-specific infrastructure, and market demand from the Stellantis and Ford supply chain ecosystem."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "How is the Gordie Howe International Bridge affecting Windsor industrial property values?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "The Gordie Howe International Bridge is driving meaningful demand growth in Windsor's industrial market. Properties in the bridge corridor and surrounding logistics zones are experiencing increased interest from distribution, warehousing, and cross-border logistics operators. This has contributed to tightening vacancy and upward pressure on industrial land and building values in the affected sub-markets. Our appraisers monitor this evolving market condition closely."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Do Metrix industrial appraisals include replacement cost estimates?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Yes. Metrix Realty industrial appraisals routinely include replacement cost new (RCN) and depreciated replacement cost estimates where relevant — particularly for insurance purposes, plant closure and restructuring assignments, and specialized or purpose-built facilities where the cost approach is the most reliable or required valuation method. All cost estimates comply with CUSPAP and are supported by current construction cost data."
+          }
+        }
+      ]
+    }
+    </script>
+</head>
+<body class="font-inter">
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+
+    <!-- Global Header -->
+    <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
+        <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center justify-between h-16 sm:h-20">
+                <!-- Logo -->
+                <div class="flex-shrink-0">
+                    <a href="/">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
+                    </a>
+                </div>
+
+                <!-- Desktop Navigation -->
+                <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
+                    <a href="/" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Home</a>
+                    <div class="relative group">
+                        <a href="/services" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Services</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-96 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50 backdrop-blur-sm">
+                            <div class="p-8">
+                                <div>
+                                    <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal &amp; Consulting Services</h4>
+                                    <div class="space-y-1">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
+                                        </a>
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
+                                        </a>
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
+                                        </a>
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government &amp; Institutional Services</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link active text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Team</a>
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold nav-text-enhanced text-smooth focus-readable">Contact</a>
+                </div>
+
+                <!-- CTA Button -->
+                <div class="hidden md:block">
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
+                        Connect with an Appraiser
+                    </a>
+                </div>
+
+                <!-- Mobile menu button -->
+                <div class="md:hidden">
+                    <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
+                        <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                        </div>
+                    </button>
+                </div>
+            </div>
+        </nav>
+
+        <!-- Mobile Menu -->
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link active">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link">Team</a>
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+        <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
+    </header>
+
+    <!-- Hero -->
+    <section class="bg-hero pt-20 sm:pt-24 pb-16 sm:pb-20 text-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <nav class="text-sm mb-6 text-white/70" aria-label="Breadcrumb">
+                <ol class="flex flex-wrap gap-1 items-center">
+                    <li><a href="/" class="hover:text-white transition-colors">Home</a></li>
+                    <li class="text-white/40 mx-1">/</li>
+                    <li><a href="/windsor/" class="hover:text-white transition-colors">Windsor</a></li>
+                    <li class="text-white/40 mx-1">/</li>
+                    <li class="text-white">Industrial Appraisal</li>
+                </ol>
+            </nav>
+            <div class="max-w-4xl" data-aos="fade-up">
+                <p class="text-metrix-green font-semibold text-sm uppercase tracking-wider mb-3">Windsor, Ontario</p>
+                <h1 class="text-3xl sm:text-4xl lg:text-5xl font-bold mb-6 leading-tight">Industrial Property Appraisal in Windsor, Ontario</h1>
+                <p class="text-lg sm:text-xl text-white/85 mb-8 leading-relaxed max-w-3xl">Expert industrial valuations by <a href="https://www.aicanada.ca/designation/aaci/" target="_blank" rel="noopener noreferrer" class="underline hover:text-white">AACI</a>-designated appraisers. Manufacturing plants, automotive supply chain facilities, distribution centres, and flex industrial across Windsor-Essex and Essex County.</p>
+                <div class="flex flex-col sm:flex-row gap-4">
+                    <a href="/contact" class="inline-flex items-center justify-center px-8 py-4 bg-white text-metrix-blue font-semibold rounded-lg hover:bg-gray-100 transition-colors text-lg">
+                        Request a Quote
+                        <svg class="w-5 h-5 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"/></svg>
+                    </a>
+                    <a href="tel:519-672-7550" class="inline-flex items-center justify-center px-8 py-4 bg-transparent text-white font-semibold rounded-lg border-2 border-white hover:bg-white hover:text-metrix-blue transition-colors text-lg">
+                        (519) 672-7550
+                    </a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- When You Need Us -->
+    <section class="py-16 sm:py-20 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="max-w-3xl mx-auto text-center mb-12" data-aos="fade-up">
+                <h2 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-4">When Is an Industrial Appraisal Required in Windsor?</h2>
+                <p class="text-gray-600 text-lg">Industrial appraisals in Windsor-Essex arise across financing, legal, insurance, and corporate transactions — often with tight timelines and complex valuation requirements.</p>
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6" data-aos="fade-up" data-aos-delay="100">
+                <div class="p-6 rounded-xl border border-gray-200 hover:border-metrix-blue hover:shadow-md transition-all">
+                    <h3 class="font-semibold text-gray-900 mb-2">Financing &amp; Refinancing</h3>
+                    <p class="text-gray-600 text-sm">Lender-approved industrial property appraisals for mortgage financing, refinancing, and construction loans. Accepted by all major Canadian financial institutions and CMHC.</p>
+                </div>
+                <div class="p-6 rounded-xl border border-gray-200 hover:border-metrix-blue hover:shadow-md transition-all">
+                    <h3 class="font-semibold text-gray-900 mb-2">Sale &amp; Acquisition</h3>
+                    <p class="text-gray-600 text-sm">Independent market value opinions for industrial property purchases, sales, and sale-leaseback transactions across Windsor's manufacturing and logistics corridors.</p>
+                </div>
+                <div class="p-6 rounded-xl border border-gray-200 hover:border-metrix-blue hover:shadow-md transition-all">
+                    <h3 class="font-semibold text-gray-900 mb-2">Insurance Replacement Cost</h3>
+                    <p class="text-gray-600 text-sm">Detailed replacement cost new (RCN) estimates for industrial facilities, manufacturing plants, and specialized structures for insurance underwriting and claims support.</p>
+                </div>
+                <div class="p-6 rounded-xl border border-gray-200 hover:border-metrix-blue hover:shadow-md transition-all">
+                    <h3 class="font-semibold text-gray-900 mb-2">Property Tax Assessment Appeals</h3>
+                    <p class="text-gray-600 text-sm">Expert appraisals and analysis to support Assessment Review Board (ARB) appeals for industrial properties in Windsor, LaSalle, Tecumseh, and throughout Essex County.</p>
+                </div>
+                <div class="p-6 rounded-xl border border-gray-200 hover:border-metrix-blue hover:shadow-md transition-all">
+                    <h3 class="font-semibold text-gray-900 mb-2">Litigation &amp; Expropriation</h3>
+                    <p class="text-gray-600 text-sm">Court-ready valuations and expert witness testimony for industrial property disputes, partnership litigation, and expropriation proceedings including Gordie Howe Bridge corridor properties.</p>
+                </div>
+                <div class="p-6 rounded-xl border border-gray-200 hover:border-metrix-blue hover:shadow-md transition-all">
+                    <h3 class="font-semibold text-gray-900 mb-2">Plant Closure &amp; Restructuring</h3>
+                    <p class="text-gray-600 text-sm">Valuations for corporate restructuring, plant closures, asset dispositions, and insolvency proceedings involving manufacturing or industrial properties in the Windsor automotive sector.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Property Types -->
+    <section class="py-16 sm:py-20 bg-gray-50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="max-w-3xl mx-auto text-center mb-12" data-aos="fade-up">
+                <h2 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-4">Industrial Property Types We Appraise in Windsor</h2>
+                <p class="text-gray-600 text-lg">Windsor-Essex has one of Ontario's most diverse and specialized industrial property bases. Our AACI-designated appraisers have hands-on experience with all of them.</p>
+            </div>
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6" data-aos="fade-up" data-aos-delay="100">
+                <div class="bg-white p-6 rounded-xl shadow-sm">
+                    <h3 class="font-semibold text-gray-900 mb-2">Manufacturing Facilities</h3>
+                    <p class="text-gray-600 text-sm">General and precision manufacturing plants, assembly facilities, and purpose-built industrial structures across Windsor and Essex County's established industrial corridors.</p>
+                </div>
+                <div class="bg-white p-6 rounded-xl shadow-sm">
+                    <h3 class="font-semibold text-gray-900 mb-2">Automotive Plants &amp; Supply Chain</h3>
+                    <p class="text-gray-600 text-sm">Tier 1 and Tier 2 automotive supplier facilities, stamping plants, tooling shops, and specialized properties tied to Windsor's Stellantis and Ford supply chain ecosystem.</p>
+                </div>
+                <div class="bg-white p-6 rounded-xl shadow-sm">
+                    <h3 class="font-semibold text-gray-900 mb-2">Distribution &amp; Warehouse</h3>
+                    <p class="text-gray-600 text-sm">Cross-dock facilities, distribution centres, warehousing complexes, and logistics properties — including those in the Gordie Howe Bridge corridor benefiting from cross-border trade access.</p>
+                </div>
+                <div class="bg-white p-6 rounded-xl shadow-sm">
+                    <h3 class="font-semibold text-gray-900 mb-2">Flex Industrial</h3>
+                    <p class="text-gray-600 text-sm">Flexible industrial buildings combining office, showroom, and warehouse functions. Popular among Windsor's SME manufacturers and service businesses requiring adaptable space.</p>
+                </div>
+                <div class="bg-white p-6 rounded-xl shadow-sm">
+                    <h3 class="font-semibold text-gray-900 mb-2">Food Processing Facilities</h3>
+                    <p class="text-gray-600 text-sm">Agri-food processing plants, cold storage facilities, and food production buildings across Essex County, Leamington, and Kingsville — Canada's greenhouse capital.</p>
+                </div>
+                <div class="bg-white p-6 rounded-xl shadow-sm">
+                    <h3 class="font-semibold text-gray-900 mb-2">Special Purpose Industrial</h3>
+                    <p class="text-gray-600 text-sm">Chemical plants, environmental facilities, utility properties, and other special purpose industrial assets requiring market research beyond standard comparable sales analysis.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Windsor Industrial Market Context + Why Choose Us -->
+    <section class="py-16 sm:py-20 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
+                <div data-aos="fade-right">
+                    <h2 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-6">Windsor-Essex Industrial Real Estate Market</h2>
+                    <p class="text-gray-600 mb-4">Windsor-Essex is Ontario's premier industrial market for automotive manufacturing and cross-border trade. The region's industrial real estate landscape is driven by factors found nowhere else in Canada.</p>
+                    <p class="text-gray-600 mb-4">Key industrial market drivers in Windsor-Essex as of 2026:</p>
+                    <ul class="space-y-3 text-gray-600 mb-6">
+                        <li class="flex items-start gap-2"><span class="text-metrix-green font-bold mt-1">→</span><span><strong>Automotive Sector:</strong> Stellantis' Windsor Assembly Plant and the Ford supply chain create dominant demand for industrial space. Tier 1–3 suppliers occupy a significant portion of Essex County's industrial inventory.</span></li>
+                        <li class="flex items-start gap-2"><span class="text-metrix-green font-bold mt-1">→</span><span><strong>Gordie Howe Bridge:</strong> The new international crossing is accelerating logistics and distribution demand in Windsor's west end and Sandwich South industrial zones.</span></li>
+                        <li class="flex items-start gap-2"><span class="text-metrix-green font-bold mt-1">→</span><span><strong>Essex County Food Processing:</strong> Leamington and Kingsville's greenhouse and food processing sectors drive demand for refrigerated storage, packing facilities, and agri-industrial space.</span></li>
+                        <li class="flex items-start gap-2"><span class="text-metrix-green font-bold mt-1">→</span><span><strong>Tight Vacancy:</strong> Windsor industrial vacancy is among the tightest in Southwestern Ontario, with limited shovel-ready land constraining new supply growth.</span></li>
+                    </ul>
+                    <p class="text-gray-600">Our Windsor appraisers combine local transactional knowledge with CoStar Professional data to deliver market-accurate industrial valuations every time.</p>
+                </div>
+                <div data-aos="fade-left">
+                    <div class="bg-metrix-blue rounded-2xl p-8 text-white">
+                        <h3 class="text-xl font-bold mb-6">Why Windsor Industrial Clients Choose Metrix</h3>
+                        <div class="space-y-4">
+                            <div class="flex items-start gap-3">
+                                <span class="text-metrix-green text-xl font-bold">✓</span>
+                                <div>
+                                    <p class="font-semibold">Automotive Sector Expertise</p>
+                                    <p class="text-white/75 text-sm">Hands-on experience valuing automotive manufacturing and supply chain properties unique to Windsor.</p>
+                                </div>
+                            </div>
+                            <div class="flex items-start gap-3">
+                                <span class="text-metrix-green text-xl font-bold">✓</span>
+                                <div>
+                                    <p class="font-semibold">Local Windsor Office</p>
+                                    <p class="text-white/75 text-sm">On-the-ground presence at 2557 Dougall Ave — no outsourced appraisers unfamiliar with the Windsor market.</p>
+                                </div>
+                            </div>
+                            <div class="flex items-start gap-3">
+                                <span class="text-metrix-green text-xl font-bold">✓</span>
+                                <div>
+                                    <p class="font-semibold">30+ Years &amp; 50,000+ Files</p>
+                                    <p class="text-white/75 text-sm">Founded 1995. Decades of Southwestern Ontario industrial appraisal experience behind every report.</p>
+                                </div>
+                            </div>
+                            <div class="flex items-start gap-3">
+                                <span class="text-metrix-green text-xl font-bold">✓</span>
+                                <div>
+                                    <p class="font-semibold">All Major Lenders Accepted</p>
+                                    <p class="text-white/75 text-sm">CUSPAP-compliant reports accepted by all Canadian banks, credit unions, <a href="https://www.cmhc-schl.gc.ca/" target="_blank" rel="noopener noreferrer" class="underline">CMHC</a>, and private lenders.</p>
+                                </div>
+                            </div>
+                            <div class="flex items-start gap-3">
+                                <span class="text-metrix-green text-xl font-bold">✓</span>
+                                <div>
+                                    <p class="font-semibold">RICS &amp; IRWA Designations</p>
+                                    <p class="text-white/75 text-sm">International designations providing added credibility for cross-border and institutional industrial clients.</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Process -->
+    <section class="py-16 sm:py-20 bg-gray-50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="max-w-3xl mx-auto text-center mb-12" data-aos="fade-up">
+                <h2 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-4">Our Windsor Industrial Appraisal Process</h2>
+                <p class="text-gray-600 text-lg">From initial consultation to final report, a clear and professional process tailored to Windsor-Essex industrial properties.</p>
+            </div>
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6" data-aos="fade-up" data-aos-delay="100">
+                <div class="bg-white rounded-xl p-6 shadow-sm text-center">
+                    <div class="w-12 h-12 bg-metrix-blue text-white rounded-full flex items-center justify-center text-xl font-bold mx-auto mb-4">1</div>
+                    <h3 class="font-semibold text-gray-900 mb-2">Consultation</h3>
+                    <p class="text-gray-600 text-sm">We discuss your facility, appraisal purpose, intended users, required approaches, and confirm a transparent fee and timeline.</p>
+                </div>
+                <div class="bg-white rounded-xl p-6 shadow-sm text-center">
+                    <div class="w-12 h-12 bg-metrix-blue text-white rounded-full flex items-center justify-center text-xl font-bold mx-auto mb-4">2</div>
+                    <h3 class="font-semibold text-gray-900 mb-2">Property Inspection</h3>
+                    <p class="text-gray-600 text-sm">Thorough on-site inspection documenting building specifications, clear heights, mechanical systems, site coverage, and all value-affecting industrial characteristics.</p>
+                </div>
+                <div class="bg-white rounded-xl p-6 shadow-sm text-center">
+                    <div class="w-12 h-12 bg-metrix-blue text-white rounded-full flex items-center justify-center text-xl font-bold mx-auto mb-4">3</div>
+                    <h3 class="font-semibold text-gray-900 mb-2">Market Research</h3>
+                    <p class="text-gray-600 text-sm">Analysis of comparable industrial sales, lease rates, and Windsor-Essex market conditions using CoStar Professional and local transaction data.</p>
+                </div>
+                <div class="bg-white rounded-xl p-6 shadow-sm text-center">
+                    <div class="w-12 h-12 bg-metrix-blue text-white rounded-full flex items-center justify-center text-xl font-bold mx-auto mb-4">4</div>
+                    <h3 class="font-semibold text-gray-900 mb-2">Report Delivery</h3>
+                    <p class="text-gray-600 text-sm">Detailed CUSPAP-compliant industrial appraisal report. Standard: 5–10 business days. Rush assignments available in 24–48 hours.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Service Area -->
+    <section class="py-12 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="bg-gray-50 rounded-2xl p-8" data-aos="fade-up">
+                <h2 class="text-xl font-bold text-gray-900 mb-4">Windsor-Essex Industrial Service Area</h2>
+                <p class="text-gray-600 mb-4">Our Windsor office appraises industrial properties throughout Essex County and the broader region:</p>
+                <div class="flex flex-wrap gap-3">
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">Windsor</span>
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">LaSalle</span>
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">Tecumseh</span>
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">Amherstburg</span>
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">Essex</span>
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">Kingsville</span>
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">Leamington</span>
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">Lakeshore</span>
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">All of Essex County</span>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- FAQ -->
+    <section class="py-16 sm:py-20 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="max-w-3xl mx-auto">
+                <h2 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-10 text-center" data-aos="fade-up">Frequently Asked Questions</h2>
+                <div class="space-y-6" data-aos="fade-up" data-aos-delay="100">
+                    <div class="border border-gray-200 rounded-xl p-6">
+                        <h3 class="font-semibold text-gray-900 mb-2">Who appraises industrial properties in Windsor, Ontario?</h3>
+                        <p class="text-gray-600">Metrix Realty Group appraises industrial properties throughout Windsor-Essex from its Windsor office at 2557 Dougall Ave #6. Our <a href="https://www.aicanada.ca/designation/aaci/" target="_blank" rel="noopener noreferrer" class="text-metrix-blue hover:underline">AACI</a>-designated appraisers bring specialized experience with manufacturing plants, automotive supply chain facilities, warehouses, distribution centres, flex industrial buildings, and food processing operations across Essex County.</p>
+                    </div>
+                    <div class="border border-gray-200 rounded-xl p-6">
+                        <h3 class="font-semibold text-gray-900 mb-2">How are automotive manufacturing facilities appraised in Windsor?</h3>
+                        <p class="text-gray-600">Automotive manufacturing facilities require specialized valuation methodology. Our appraisers apply cost, income, and sales comparison approaches — often weighting the cost approach heavily for purpose-built plants — and consider functional and economic obsolescence specific to automotive manufacturing, including retooling costs, process infrastructure, and market demand from the Stellantis and Ford supply chain ecosystem unique to Windsor.</p>
+                    </div>
+                    <div class="border border-gray-200 rounded-xl p-6">
+                        <h3 class="font-semibold text-gray-900 mb-2">How is the Gordie Howe International Bridge affecting Windsor industrial values?</h3>
+                        <p class="text-gray-600">The Gordie Howe International Bridge is driving meaningful demand growth in Windsor's industrial market. Properties in the bridge corridor and surrounding logistics zones are experiencing increased interest from distribution, warehousing, and cross-border logistics operators. This has contributed to tightening vacancy and upward pressure on industrial land and building values in affected sub-markets — a dynamic our Windsor appraisers monitor closely.</p>
+                    </div>
+                    <div class="border border-gray-200 rounded-xl p-6">
+                        <h3 class="font-semibold text-gray-900 mb-2">Do Metrix industrial appraisals include replacement cost estimates?</h3>
+                        <p class="text-gray-600">Yes. Metrix Realty industrial appraisals routinely include replacement cost new (RCN) and depreciated replacement cost estimates where relevant — particularly for insurance purposes, plant closure assignments, and specialized facilities where the cost approach is the most reliable valuation method. All cost estimates comply with CUSPAP and are supported by current construction cost data applicable to Windsor-Essex.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- CTA -->
+    <section class="py-16 sm:py-20 bg-metrix-blue text-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+            <h2 class="text-2xl sm:text-3xl font-bold mb-4" data-aos="fade-up">Get a Windsor Industrial Appraisal Quote</h2>
+            <p class="text-white/80 text-lg mb-8 max-w-2xl mx-auto" data-aos="fade-up" data-aos-delay="100">Manufacturing plant, warehouse, automotive facility, or food processing operation — our AACI-designated Windsor appraisers handle it all. Contact us for a transparent fee quote.</p>
+            <div class="flex flex-col sm:flex-row gap-4 justify-center" data-aos="fade-up" data-aos-delay="200">
+                <a href="/contact" class="inline-flex items-center justify-center px-8 py-4 bg-white text-metrix-blue font-semibold rounded-lg hover:bg-gray-100 transition-colors text-lg">
+                    Connect with an Appraiser
+                </a>
+                <a href="tel:519-672-7550" class="inline-flex items-center justify-center px-8 py-4 bg-transparent text-white font-semibold rounded-lg border-2 border-white hover:bg-white hover:text-metrix-blue transition-colors text-lg">
+                    Call (519) 672-7550
+                </a>
+            </div>
+            <p class="text-white/60 text-sm mt-6">Windsor office: 2557 Dougall Ave #6, Windsor, ON N8X 1T5 &nbsp;|&nbsp; <a href="/windsor/" class="underline hover:text-white">Windsor Hub</a></p>
+        </div>
+    </section>
+
+    <!-- Footer -->
+    <footer class="bg-black text-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
+                <div class="lg:col-span-1">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-6 leading-relaxed">Trusted • Valued • Experienced</p>
+                    <div class="text-gray-300">
+                        <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
+                        <p class="mb-4">London, ON N6A 5J9</p>
+                        <p class="font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/></svg>
+                            <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
+                        </p>
+                        <p>Toll Free: 1-866-672-9101</p>
+                        <p>Fax: (519) 672-9321</p>
+                        <p class="mt-4 font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
+                            <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
+                        </p>
+                    </div>
+                </div>
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
+                    <ul class="space-y-3 text-gray-300">
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government &amp; Institutional</a></li>
+                        <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
+                        <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
+                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="border-t border-gray-800 pt-8 mb-8 text-center">
+                <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
+                    <span>AIC - <a href="https://www.aicanada.ca/" target="_blank" rel="noopener noreferrer">Appraisal Institute of Canada</a></span>
+                    <span>RICS - Royal Institution of Chartered Surveyors</span>
+                    <span>AOLE - Association of Ontario Land Economists</span>
+                    <span>IRWA - International Right of Way Association</span>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6">
+                    <span>Data Providers:</span>
+                    <span>CoStar Professional</span>
+                    <span>TRREB - Toronto Regional Real Estate Board</span>
+                </div>
+                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
+                    <p>Reports completed in compliance with <a href="https://www.aicanada.ca/about-aic/cuspap/" target="_blank" rel="noopener noreferrer">CUSPAP</a> (Canadian Uniform Standards of Professional Appraisal Practice)</p>
+                </div>
+            </div>
+            <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
+                <p>&copy; 2026 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
+    <script>
+        AOS.init({ once: true, duration: 800 });
+        document.addEventListener('DOMContentLoaded', function() {
+            const mobileMenuButton = document.getElementById('mobile-menu-button');
+            const mobileMenu = document.getElementById('mobile-menu');
+            const mobileMenuOverlay = document.getElementById('mobile-menu-overlay');
+            const mobileMenuClose = document.getElementById('mobile-menu-close');
+            const hamburger = document.querySelector('.hamburger');
+            if (!mobileMenuButton || !mobileMenu) return;
+            function openMobileMenu() {
+                mobileMenu.classList.add('open');
+                if (mobileMenuOverlay) mobileMenuOverlay.classList.add('show');
+                if (hamburger) hamburger.classList.add('open');
+                document.body.classList.add('menu-open');
+                mobileMenuButton.setAttribute('aria-expanded', 'true');
+            }
+            function closeMobileMenu() {
+                mobileMenu.classList.remove('open');
+                if (mobileMenuOverlay) mobileMenuOverlay.classList.remove('show');
+                if (hamburger) hamburger.classList.remove('open');
+                document.body.classList.remove('menu-open');
+                mobileMenuButton.setAttribute('aria-expanded', 'false');
+            }
+            mobileMenuButton.addEventListener('click', function() {
+                mobileMenu.classList.contains('open') ? closeMobileMenu() : openMobileMenu();
+            });
+            if (mobileMenuClose) mobileMenuClose.addEventListener('click', closeMobileMenu);
+            if (mobileMenuOverlay) mobileMenuOverlay.addEventListener('click', closeMobileMenu);
+        });
+    </script>
+</body>
+</html>

--- a/windsor/investment-appraisal/index.html
+++ b/windsor/investment-appraisal/index.html
@@ -1,0 +1,637 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Investment Property Appraisal Windsor Ontario | Metrix Realty</title>
+    <link rel="icon" type="image/png" href="/favicon.png">
+    <meta name="description" content="AACI-designated investment property appraisers in Windsor-Essex. Multi-family, apartment building, and commercial investment valuations for lenders, buyers, and portfolio managers.">
+    <meta name="keywords" content="investment property appraisal Windsor Ontario, multi-family appraisal Windsor, apartment building appraisal Windsor, investment property valuation Windsor Essex, AACI investment appraiser Windsor, CMHC appraisal Windsor">
+    <link rel="canonical" href="https://metrixrealty.com/windsor/investment-appraisal">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Metrix Realty Group">
+    <meta property="og:title" content="Investment Property Appraisal Windsor Ontario | Metrix Realty">
+    <meta property="og:description" content="AACI-designated investment property appraisers in Windsor-Essex. Multi-family, apartment building, and commercial investment valuations for lenders, buyers, and portfolio managers.">
+    <meta property="og:url" content="https://metrixrealty.com/windsor/investment-appraisal">
+    <meta property="og:image" content="https://metrixrealty.com/assets/images/metrix-realty-logo.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="robots" content="noindex, nofollow">
+
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
+    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: { 'metrix-blue': '#233c75', 'metrix-blue-light': '#3d5a9e', 'metrix-blue-dark': '#1a2d5a', 'metrix-green': '#3faa4d' },
+                    fontFamily: { 'inter': ['Inter', 'sans-serif'] }
+                }
+            }
+        }
+    </script>
+    <style>
+        .bg-hero { background: linear-gradient(135deg, #233c75 0%, #1a2d5a 70%, #3faa4d 100%); }
+        .hamburger-line { transition: all 0.3s ease; }
+        .hamburger.open .hamburger-line:nth-child(1) { transform: rotate(45deg) translate(5px, 5px); }
+        .hamburger.open .hamburger-line:nth-child(2) { opacity: 0; }
+        .hamburger.open .hamburger-line:nth-child(3) { transform: rotate(-45deg) translate(7px, -6px); }
+        .mobile-menu { position: fixed; top: 0; right: 0; height: 100vh; width: 320px; background: #ffffff !important; box-shadow: -10px 0 25px rgba(0,0,0,0.15); z-index: 99999 !important; transform: translateX(100%); transition: transform 0.4s cubic-bezier(0.25,0.46,0.45,0.94); border-left: 1px solid #e5e7eb; }
+        .mobile-menu.open { transform: translateX(0); }
+        .mobile-menu-close { position: absolute; top: 24px; right: 24px; background: none; border: none; padding: 8px; cursor: pointer; color: #9ca3af; border-radius: 8px; transition: all 0.2s ease; }
+        .mobile-menu-close:hover { background: #f3f4f6; color: #374151; }
+        .mobile-menu-content { padding: 80px 32px 32px; height: 100%; overflow-y: auto; }
+        .mobile-nav { display: flex; flex-direction: column; gap: 8px; }
+        .mobile-nav-link { display: block; padding: 16px 0; color: #374151; font-weight: 500; font-size: 18px; text-decoration: none; border-bottom: 1px solid #f3f4f6; transition: all 0.2s ease; }
+        .mobile-nav-link:hover { color: #233c75; background: #f8fafc; padding-left: 16px; border-radius: 8px; border-bottom: 1px solid transparent; }
+        .mobile-nav-link.active { color: #233c75; font-weight: 600; }
+        .mobile-menu-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 99998 !important; opacity: 0; visibility: hidden; transition: all 0.3s ease; }
+        .mobile-menu-overlay.show { opacity: 1; visibility: visible; }
+        body.menu-open { overflow: hidden; }
+        .nav-link { position: relative; transition: all 0.3s cubic-bezier(0.4,0,0.2,1); }
+        .nav-link::after { content: ''; position: absolute; bottom: -2px; left: 0; width: 0; height: 2px; background: linear-gradient(90deg,#1a202c,#2d3748); transition: width 0.3s cubic-bezier(0.4,0,0.2,1); }
+        .nav-link:hover::after { width: 100%; }
+        .nav-link:hover { color: #1a202c; transform: translateY(-1px); }
+        .nav-link.active { color: #1a202c; font-weight: 600; }
+        .nav-link.active::after { width: 100%; }
+        .mega-menu-item { display: block; border-radius: 12px; transition: all 0.2s ease; }
+        .mega-menu-item:hover { background: #f8fafc; }
+        .mega-menu-item:hover .mega-menu-title { color: #233c75; }
+        .btn-primary { position: relative; overflow: hidden; transition: all 0.3s cubic-bezier(0.4,0,0.2,1); }
+        .btn-primary:hover { transform: translateY(-2px); box-shadow: 0 10px 25px rgba(26,32,44,0.25); }
+        .touch-target { min-height: 44px; min-width: 44px; }
+    </style>
+
+    <!-- Structured Data -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "ProfessionalService",
+      "name": "Metrix Realty Group – Investment Property Appraisal Windsor Ontario",
+      "url": "https://metrixrealty.com/windsor/investment-appraisal",
+      "description": "AACI-designated investment property and multi-family appraisers in Windsor-Essex. Apartment buildings, rental complexes, and commercial investment valuations accepted by all major Canadian lenders including CMHC.",
+      "telephone": "+1-519-672-7550",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "2557 Dougall Ave #6",
+        "addressLocality": "Windsor",
+        "addressRegion": "ON",
+        "postalCode": "N8X 1T5",
+        "addressCountry": "CA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 42.3149,
+        "longitude": -83.0364
+      },
+      "areaServed": { "@type": "City", "name": "Windsor", "containedInPlace": { "@type": "AdministrativeArea", "name": "Ontario" } },
+      "hasCredential": ["AACI", "CUSPAP", "RICS"],
+      "parentOrganization": { "@type": "Organization", "name": "Metrix Realty Group", "url": "https://metrixrealty.com" }
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://metrixrealty.com/"},
+        {"@type": "ListItem", "position": 2, "name": "Windsor", "item": "https://metrixrealty.com/windsor/"},
+        {"@type": "ListItem", "position": 3, "name": "Investment Appraisal", "item": "https://metrixrealty.com/windsor/investment-appraisal"}
+      ]
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "Who provides investment property appraisals in Windsor, Ontario?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Metrix Realty Group provides investment property and multi-family appraisals in Windsor through its local office at 2557 Dougall Ave #6. Metrix AACI-designated appraisers have completed investment property valuations across Windsor-Essex for lenders, investors, and portfolio managers. Reports are accepted by all major Canadian lenders including CMHC."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "What investment property types does Metrix appraise in Windsor?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Metrix appraises apartment buildings (5+ units), multi-unit rental complexes, mixed-use investment properties, NNN leased commercial investments, commercial investment portfolios, and development land in Windsor and throughout Essex County. Note: Metrix does not provide single-family residential appraisals in Windsor — our Windsor focus is multi-family (5+ units) and commercial investment properties."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Are Metrix investment appraisals accepted for CMHC financing in Windsor?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Yes. Metrix AACI-designated appraisers produce CUSPAP-compliant reports accepted by CMHC for insured multi-family and commercial mortgage financing in Windsor-Essex. Our appraisers are experienced with the CMHC appraisal requirements for multi-residential and mixed-use investment properties."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "What is the Windsor multi-family investment market like?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Windsor-Essex has a strong multi-family rental market supported by a diverse employment base including the automotive sector, healthcare, education, and cross-border workers. Vacancy rates are generally tight compared to other Ontario markets, and cap rates have adjusted from 2021-2022 lows in line with provincial trends. The addition of the Gordie Howe International Bridge is generating new investment interest in areas of Windsor near the bridge corridor."
+          }
+        }
+      ]
+    }
+    </script>
+</head>
+<body class="font-inter">
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+
+    <!-- Global Header -->
+    <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
+        <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center justify-between h-16 sm:h-20">
+                <div class="flex-shrink-0">
+                    <a href="/">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
+                    </a>
+                </div>
+
+                <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
+                    <a href="/" class="nav-link text-gray-900 font-semibold">Home</a>
+                    <div class="relative group">
+                        <a href="/services" class="nav-link text-gray-900 font-semibold">Services</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-96 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50 backdrop-blur-sm">
+                            <div class="p-8">
+                                <div>
+                                    <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal &amp; Consulting Services</h4>
+                                    <div class="space-y-1">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
+                                        </a>
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
+                                        </a>
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
+                                        </a>
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government &amp; Institutional Services</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link active text-gray-900 font-semibold">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link text-gray-900 font-semibold">Team</a>
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold">Contact</a>
+                </div>
+
+                <div class="hidden md:block">
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
+                        Connect with an Appraiser
+                    </a>
+                </div>
+
+                <div class="md:hidden">
+                    <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
+                        <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                        </div>
+                    </button>
+                </div>
+            </div>
+        </nav>
+
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link active">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link">Team</a>
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+
+        <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
+    </header>
+
+    <!-- Hero -->
+    <section class="bg-hero pt-20 sm:pt-24 pb-16 sm:pb-20 text-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <nav class="text-sm mb-6 text-white/70" aria-label="Breadcrumb">
+                <ol class="flex flex-wrap gap-1 items-center">
+                    <li><a href="/" class="hover:text-white transition-colors">Home</a></li>
+                    <li class="text-white/40 mx-1">/</li>
+                    <li><a href="/windsor/" class="hover:text-white transition-colors">Windsor</a></li>
+                    <li class="text-white/40 mx-1">/</li>
+                    <li class="text-white">Investment Appraisal</li>
+                </ol>
+            </nav>
+            <div class="max-w-4xl" data-aos="fade-up">
+                <p class="text-metrix-green font-semibold text-sm uppercase tracking-wider mb-3">Windsor, Ontario</p>
+                <h1 class="text-3xl sm:text-4xl lg:text-5xl font-bold mb-6 leading-tight">Investment Property Appraisal in Windsor, Ontario</h1>
+                <p class="text-lg sm:text-xl text-white/85 mb-8 leading-relaxed max-w-3xl">Lender-approved valuations for multi-family and commercial investment properties in Windsor-Essex. <a href="https://www.aicanada.ca/designation/aaci/" target="_blank" rel="noopener noreferrer" class="underline hover:text-white">AACI</a>-designated appraisers accepted by all major Canadian lenders including <a href="https://www.cmhc-schl.gc.ca/" target="_blank" rel="noopener noreferrer" class="underline hover:text-white">CMHC</a>.</p>
+                <div class="flex flex-col sm:flex-row gap-4">
+                    <a href="/contact" class="inline-flex items-center justify-center px-8 py-4 bg-white text-metrix-blue font-semibold rounded-lg hover:bg-gray-100 transition-colors text-lg">
+                        Request a Quote
+                        <svg class="w-5 h-5 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"/></svg>
+                    </a>
+                    <a href="tel:519-672-7550" class="inline-flex items-center justify-center px-8 py-4 bg-transparent text-white font-semibold rounded-lg border-2 border-white hover:bg-white hover:text-metrix-blue transition-colors text-lg">
+                        (519) 672-7550
+                    </a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- When You Need Us -->
+    <section class="py-16 sm:py-20 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="max-w-3xl mx-auto text-center mb-12" data-aos="fade-up">
+                <h2 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-4">When Is an Investment Property Appraisal Required in Windsor?</h2>
+                <p class="text-gray-600 text-lg">Windsor-Essex investment property owners, buyers, and lenders rely on independent appraisals across a wide range of situations — from acquisition financing to portfolio reporting.</p>
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6" data-aos="fade-up" data-aos-delay="100">
+                <div class="p-6 rounded-xl border border-gray-200 hover:border-metrix-blue hover:shadow-md transition-all">
+                    <h3 class="font-semibold text-gray-900 mb-2">CMHC &amp; Insured Financing</h3>
+                    <p class="text-gray-600 text-sm">CMHC-insured financing for multi-family apartment buildings requires appraisals from AACI-designated appraisers. Metrix produces CMHC-accepted reports for multi-residential properties throughout Windsor-Essex.</p>
+                </div>
+                <div class="p-6 rounded-xl border border-gray-200 hover:border-metrix-blue hover:shadow-md transition-all">
+                    <h3 class="font-semibold text-gray-900 mb-2">Acquisition &amp; Disposition</h3>
+                    <p class="text-gray-600 text-sm">Independent market value opinions for the purchase or sale of apartment buildings, mixed-use investment properties, and NNN commercial assets across Windsor-Essex and Essex County.</p>
+                </div>
+                <div class="p-6 rounded-xl border border-gray-200 hover:border-metrix-blue hover:shadow-md transition-all">
+                    <h3 class="font-semibold text-gray-900 mb-2">Conventional Mortgage Financing</h3>
+                    <p class="text-gray-600 text-sm">Lender-recognized appraisals for conventional commercial and multi-family mortgage applications, refinancing, and construction draws. Accepted by all major Canadian chartered banks, credit unions, and private lenders.</p>
+                </div>
+                <div class="p-6 rounded-xl border border-gray-200 hover:border-metrix-blue hover:shadow-md transition-all">
+                    <h3 class="font-semibold text-gray-900 mb-2">Portfolio Management &amp; Reporting</h3>
+                    <p class="text-gray-600 text-sm">Periodic portfolio valuations for institutional investors, private REITs, property management companies, and individual investors requiring accurate Windsor-Essex investment property values for reporting and planning.</p>
+                </div>
+                <div class="p-6 rounded-xl border border-gray-200 hover:border-metrix-blue hover:shadow-md transition-all">
+                    <h3 class="font-semibold text-gray-900 mb-2">IFRS &amp; Financial Reporting</h3>
+                    <p class="text-gray-600 text-sm">Fair value assessments for IFRS financial reporting and audited financial statements. Metrix reports meet the standards required by corporate and institutional property holders for annual and quarterly reporting.</p>
+                </div>
+                <div class="p-6 rounded-xl border border-gray-200 hover:border-metrix-blue hover:shadow-md transition-all">
+                    <h3 class="font-semibold text-gray-900 mb-2">Estate &amp; Dispute Matters</h3>
+                    <p class="text-gray-600 text-sm">Investment property valuations for estate administration, matrimonial equalization, partnership disputes, and other legal matters requiring an independent value opinion for multi-family or commercial investment assets.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Property Types -->
+    <section class="py-16 sm:py-20 bg-gray-50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="max-w-3xl mx-auto text-center mb-12" data-aos="fade-up">
+                <h2 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-4">Investment Property Types We Appraise in Windsor</h2>
+                <p class="text-gray-600 text-lg">Our AACI-designated appraisers cover multi-family and commercial investment properties across Windsor, Essex County, and the surrounding region.</p>
+            </div>
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6" data-aos="fade-up" data-aos-delay="100">
+                <div class="bg-white p-6 rounded-xl shadow-sm">
+                    <h3 class="font-semibold text-gray-900 mb-2">Apartment Buildings (5+ Units)</h3>
+                    <p class="text-gray-600 text-sm">Multi-unit residential investment properties from small walk-ups to large apartment complexes in Windsor and throughout Essex County. CMHC and conventional lender accepted.</p>
+                </div>
+                <div class="bg-white p-6 rounded-xl shadow-sm">
+                    <h3 class="font-semibold text-gray-900 mb-2">Mixed-Use Investment Properties</h3>
+                    <p class="text-gray-600 text-sm">Properties combining residential rental units with ground-floor commercial, retail, or office space — a common investment property type in Windsor's established neighbourhoods and downtown areas.</p>
+                </div>
+                <div class="bg-white p-6 rounded-xl shadow-sm">
+                    <h3 class="font-semibold text-gray-900 mb-2">NNN &amp; Net-Leased Commercial</h3>
+                    <p class="text-gray-600 text-sm">Net-leased commercial investment properties including triple-net retail, automotive-related facilities, and long-term leased industrial assets with investment-grade or creditworthy tenants.</p>
+                </div>
+                <div class="bg-white p-6 rounded-xl shadow-sm">
+                    <h3 class="font-semibold text-gray-900 mb-2">Commercial Investment Portfolios</h3>
+                    <p class="text-gray-600 text-sm">Multi-property portfolio valuations for investors and lenders requiring consistent, reliable values across a collection of Windsor-Essex commercial or multi-family assets.</p>
+                </div>
+                <div class="bg-white p-6 rounded-xl shadow-sm">
+                    <h3 class="font-semibold text-gray-900 mb-2">Development Land</h3>
+                    <p class="text-gray-600 text-sm">Land valuations for multi-family or commercial development sites in Windsor-Essex, including sites near the Gordie Howe Bridge corridor and infill development opportunities.</p>
+                </div>
+                <div class="bg-white p-6 rounded-xl shadow-sm">
+                    <h3 class="font-semibold text-gray-900 mb-2">Special Purpose Investment</h3>
+                    <p class="text-gray-600 text-sm">Automotive-related commercial investments, border-adjacent commercial properties, and other income-producing special purpose assets that require Windsor-specific market expertise to value accurately.</p>
+                </div>
+            </div>
+            <div class="mt-8 bg-amber-50 border border-amber-200 rounded-xl p-6" data-aos="fade-up">
+                <p class="text-amber-800 text-sm"><strong>Note on residential scope:</strong> Metrix does not provide single-family residential appraisals in Windsor. Our Windsor office focuses on multi-family properties (5+ units), commercial investment, and industrial appraisals. For investment properties 5 units and above, contact us directly.</p>
+            </div>
+        </div>
+    </section>
+
+    <!-- Windsor Market Context + Why Choose Us -->
+    <section class="py-16 sm:py-20 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
+                <div data-aos="fade-right">
+                    <h2 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-6">Windsor-Essex Investment Property Market</h2>
+                    <p class="text-gray-600 mb-4">Windsor-Essex has one of Ontario's strongest multi-family rental markets, supported by stable employment from the automotive sector, healthcare, education, and cross-border economic activity at the Windsor-Detroit border crossing.</p>
+                    <p class="text-gray-600 mb-4">Key investment market dynamics in Windsor-Essex for 2026:</p>
+                    <ul class="space-y-3 text-gray-600 mb-6">
+                        <li class="flex items-start gap-2"><span class="text-metrix-green font-bold mt-1">→</span><span><strong>Tight Vacancy:</strong> Multi-family vacancy in Windsor-Essex is among the lowest in Southwestern Ontario, reflecting persistent rental demand from a diverse employment base.</span></li>
+                        <li class="flex items-start gap-2"><span class="text-metrix-green font-bold mt-1">→</span><span><strong>Gordie Howe Bridge Corridor:</strong> New investment interest near the bridge corridor is creating development and repositioning opportunities that require local appraisal expertise to assess accurately.</span></li>
+                        <li class="flex items-start gap-2"><span class="text-metrix-green font-bold mt-1">→</span><span><strong>Cap Rate Adjustment:</strong> Investment property cap rates have moved from 2021–2022 lows in line with broader Ontario trends, with values stabilizing as financing costs normalize.</span></li>
+                        <li class="flex items-start gap-2"><span class="text-metrix-green font-bold mt-1">→</span><span><strong>Essex County Agriculture:</strong> Rural investment properties in Essex, Leamington, and Kingsville — including food processing facilities — require separate rural market expertise.</span></li>
+                    </ul>
+                    <p class="text-gray-600">Metrix appraisers use income approach analysis, CoStar Professional data, and direct Windsor-Essex transactional evidence to ensure every investment appraisal reflects current market conditions.</p>
+                </div>
+                <div data-aos="fade-left">
+                    <div class="bg-metrix-blue rounded-2xl p-8 text-white">
+                        <h3 class="text-xl font-bold mb-6">Why Windsor Investors Choose Metrix</h3>
+                        <div class="space-y-4">
+                            <div class="flex items-start gap-3">
+                                <span class="text-metrix-green text-xl font-bold">✓</span>
+                                <div>
+                                    <p class="font-semibold">Windsor Office — Local Market Knowledge</p>
+                                    <p class="text-white/75 text-sm">Located at 2557 Dougall Ave. Our appraisers understand Windsor-Essex rental markets from the inside.</p>
+                                </div>
+                            </div>
+                            <div class="flex items-start gap-3">
+                                <span class="text-metrix-green text-xl font-bold">✓</span>
+                                <div>
+                                    <p class="font-semibold">CMHC Accepted</p>
+                                    <p class="text-white/75 text-sm">Reports accepted for CMHC-insured multi-family financing — a critical requirement for apartment building acquisitions and refinancing.</p>
+                                </div>
+                            </div>
+                            <div class="flex items-start gap-3">
+                                <span class="text-metrix-green text-xl font-bold">✓</span>
+                                <div>
+                                    <p class="font-semibold">All Major Lenders Accepted</p>
+                                    <p class="text-white/75 text-sm">Reports recognized by all Canadian chartered banks, credit unions, and private lenders for commercial and multi-family investment financing.</p>
+                                </div>
+                            </div>
+                            <div class="flex items-start gap-3">
+                                <span class="text-metrix-green text-xl font-bold">✓</span>
+                                <div>
+                                    <p class="font-semibold">30+ Years &amp; 50,000+ Files</p>
+                                    <p class="text-white/75 text-sm">Founded in 1995. Decades of Southwestern Ontario investment property appraisal experience behind every report.</p>
+                                </div>
+                            </div>
+                            <div class="flex items-start gap-3">
+                                <span class="text-metrix-green text-xl font-bold">✓</span>
+                                <div>
+                                    <p class="font-semibold"><a href="https://www.aicanada.ca/about-aic/cuspap/" target="_blank" rel="noopener noreferrer" class="underline">CUSPAP</a> Compliant</p>
+                                    <p class="text-white/75 text-sm">Every report meets the Canadian Uniform Standards of Professional Appraisal Practice.</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Process -->
+    <section class="py-16 sm:py-20 bg-gray-50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="max-w-3xl mx-auto text-center mb-12" data-aos="fade-up">
+                <h2 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-4">Our Windsor Investment Appraisal Process</h2>
+                <p class="text-gray-600 text-lg">A thorough, transparent process built for the income-producing property decisions Windsor investors and lenders face.</p>
+            </div>
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6" data-aos="fade-up" data-aos-delay="100">
+                <div class="bg-white rounded-xl p-6 shadow-sm text-center">
+                    <div class="w-12 h-12 bg-metrix-blue text-white rounded-full flex items-center justify-center text-xl font-bold mx-auto mb-4">1</div>
+                    <h3 class="font-semibold text-gray-900 mb-2">Consultation</h3>
+                    <p class="text-gray-600 text-sm">We discuss the property, intended use, authorized users, and any lender-specific requirements. We request rent rolls, leases, operating statements, and relevant documents upfront.</p>
+                </div>
+                <div class="bg-white rounded-xl p-6 shadow-sm text-center">
+                    <div class="w-12 h-12 bg-metrix-blue text-white rounded-full flex items-center justify-center text-xl font-bold mx-auto mb-4">2</div>
+                    <h3 class="font-semibold text-gray-900 mb-2">Property Inspection</h3>
+                    <p class="text-gray-600 text-sm">On-site inspection of the property and, where applicable, a selection of individual units to document condition, tenancy mix, amenities, and all value-affecting factors.</p>
+                </div>
+                <div class="bg-white rounded-xl p-6 shadow-sm text-center">
+                    <div class="w-12 h-12 bg-metrix-blue text-white rounded-full flex items-center justify-center text-xl font-bold mx-auto mb-4">3</div>
+                    <h3 class="font-semibold text-gray-900 mb-2">Income &amp; Market Analysis</h3>
+                    <p class="text-gray-600 text-sm">Income approach analysis using actual and market rents, vacancy, expenses, and capitalization rates supported by Windsor-Essex comparable sales and CoStar Professional data.</p>
+                </div>
+                <div class="bg-white rounded-xl p-6 shadow-sm text-center">
+                    <div class="w-12 h-12 bg-metrix-blue text-white rounded-full flex items-center justify-center text-xl font-bold mx-auto mb-4">4</div>
+                    <h3 class="font-semibold text-gray-900 mb-2">Report Delivery</h3>
+                    <p class="text-gray-600 text-sm">Detailed CUSPAP-compliant report. Standard: 5–10 business days from inspection. Rush: 24–48 hours depending on property complexity and data availability.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Service Area -->
+    <section class="py-12 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="bg-gray-50 rounded-2xl p-8" data-aos="fade-up">
+                <h2 class="text-xl font-bold text-gray-900 mb-4">Windsor-Essex Service Area</h2>
+                <p class="text-gray-600 mb-4">Our Windsor office serves investment property clients throughout Essex County and the surrounding region:</p>
+                <div class="flex flex-wrap gap-3">
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">Windsor</span>
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">LaSalle</span>
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">Tecumseh</span>
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">Amherstburg</span>
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">Essex</span>
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">Kingsville</span>
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">Leamington</span>
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">Lakeshore</span>
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">All of Essex County</span>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- FAQ -->
+    <section class="py-16 sm:py-20 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="max-w-3xl mx-auto">
+                <h2 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-10 text-center" data-aos="fade-up">Frequently Asked Questions</h2>
+                <div class="space-y-6" data-aos="fade-up" data-aos-delay="100">
+                    <div class="border border-gray-200 rounded-xl p-6">
+                        <h3 class="font-semibold text-gray-900 mb-2">Who provides investment property appraisals in Windsor, Ontario?</h3>
+                        <p class="text-gray-600">Metrix Realty Group provides investment property and multi-family appraisals in Windsor through its local office at 2557 Dougall Ave #6. AACI-designated appraisers with Windsor-Essex market experience serve investors, lenders, and portfolio managers. Reports are accepted by all major Canadian lenders including CMHC.</p>
+                    </div>
+                    <div class="border border-gray-200 rounded-xl p-6">
+                        <h3 class="font-semibold text-gray-900 mb-2">What investment property types does Metrix appraise in Windsor?</h3>
+                        <p class="text-gray-600">We appraise apartment buildings (5+ units), multi-unit rental complexes, mixed-use investment properties, NNN leased commercial investments, commercial investment portfolios, and development land in Windsor and throughout Essex County. Note: our Windsor office does not provide single-family residential appraisals — our Windsor focus is multi-family (5+ units) and commercial investment properties.</p>
+                    </div>
+                    <div class="border border-gray-200 rounded-xl p-6">
+                        <h3 class="font-semibold text-gray-900 mb-2">Are Metrix investment appraisals accepted for CMHC financing in Windsor?</h3>
+                        <p class="text-gray-600">Yes. Our <a href="https://www.aicanada.ca/designation/aaci/" target="_blank" rel="noopener noreferrer" class="text-metrix-blue hover:underline">AACI</a>-designated appraisers produce CUSPAP-compliant reports accepted by CMHC for insured multi-family and commercial mortgage financing in Windsor-Essex. Our appraisers are experienced with CMHC appraisal requirements for multi-residential and mixed-use investment properties.</p>
+                    </div>
+                    <div class="border border-gray-200 rounded-xl p-6">
+                        <h3 class="font-semibold text-gray-900 mb-2">What is the Windsor multi-family investment market like in 2026?</h3>
+                        <p class="text-gray-600">Windsor-Essex has a strong multi-family rental market with tight vacancy driven by the automotive sector, healthcare, education, and cross-border employment. Cap rates have adjusted from their 2021–2022 lows in line with broader Ontario trends. The Gordie Howe International Bridge corridor is generating new investment interest near the bridge approach areas. Our Windsor appraisers track local rental rates, cap rate trends, and comparable sales to ensure income property valuations reflect current conditions.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- CTA -->
+    <section class="py-16 sm:py-20 bg-metrix-blue text-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+            <h2 class="text-2xl sm:text-3xl font-bold mb-4" data-aos="fade-up">Get a Windsor Investment Property Appraisal Quote</h2>
+            <p class="text-white/80 text-lg mb-8 max-w-2xl mx-auto" data-aos="fade-up" data-aos-delay="100">Tell us your property type, unit count, intended use, and lender requirements. Our AACI-designated Windsor team will respond with a transparent fee quote.</p>
+            <div class="flex flex-col sm:flex-row gap-4 justify-center" data-aos="fade-up" data-aos-delay="200">
+                <a href="/contact" class="inline-flex items-center justify-center px-8 py-4 bg-white text-metrix-blue font-semibold rounded-lg hover:bg-gray-100 transition-colors text-lg">
+                    Connect with an Appraiser
+                </a>
+                <a href="tel:519-672-7550" class="inline-flex items-center justify-center px-8 py-4 bg-transparent text-white font-semibold rounded-lg border-2 border-white hover:bg-white hover:text-metrix-blue transition-colors text-lg">
+                    Call (519) 672-7550
+                </a>
+            </div>
+            <p class="text-white/60 text-sm mt-6">Windsor office: 2557 Dougall Ave #6, Windsor, ON N8X 1T5 &nbsp;|&nbsp; <a href="/windsor/" class="underline hover:text-white">Windsor Hub</a></p>
+        </div>
+    </section>
+
+    <!-- Footer -->
+    <footer class="bg-black text-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
+                <div class="lg:col-span-1">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-6 leading-relaxed">Trusted • Valued • Experienced</p>
+                    <div class="text-gray-300">
+                        <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
+                        <p class="mb-4">London, ON N6A 5J9</p>
+                        <p class="font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/></svg>
+                            <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
+                        </p>
+                        <p>Toll Free: 1-866-672-9101</p>
+                        <p>Fax: (519) 672-9321</p>
+                        <p class="mt-4 font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
+                            <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
+                        </p>
+                    </div>
+                </div>
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
+                    <ul class="space-y-3 text-gray-300">
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government &amp; Institutional</a></li>
+                        <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
+                        <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
+                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="border-t border-gray-800 pt-8 mb-8 text-center">
+                <div class="mb-6">
+                    <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
+                    <span>AIC - <a href="https://www.aicanada.ca/" target="_blank" rel="noopener noreferrer">Appraisal Institute of Canada</a></span>
+                    <span>RICS - Royal Institution of Chartered Surveyors</span>
+                    <span>AOLE - Association of Ontario Land Economists</span>
+                    <span>IRWA - International Right of Way Association</span>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6">
+                    <span>Data Providers:</span>
+                    <span>CoStar Professional</span>
+                    <span>TRREB - Toronto Regional Real Estate Board</span>
+                </div>
+                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
+                    <p>Reports completed in compliance with <a href="https://www.aicanada.ca/about-aic/cuspap/" target="_blank" rel="noopener noreferrer">CUSPAP</a> (Canadian Uniform Standards of Professional Appraisal Practice)</p>
+                </div>
+            </div>
+            <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
+                <p>&copy; 2026 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
+    <script>
+        AOS.init({ once: true, duration: 800 });
+        document.addEventListener('DOMContentLoaded', function() {
+            const mobileMenuButton = document.getElementById('mobile-menu-button');
+            const mobileMenu = document.getElementById('mobile-menu');
+            const mobileMenuOverlay = document.getElementById('mobile-menu-overlay');
+            const mobileMenuClose = document.getElementById('mobile-menu-close');
+            const hamburger = document.querySelector('.hamburger');
+            if (!mobileMenuButton || !mobileMenu) return;
+            function openMobileMenu() {
+                mobileMenu.classList.add('open');
+                if (mobileMenuOverlay) mobileMenuOverlay.classList.add('show');
+                if (hamburger) hamburger.classList.add('open');
+                document.body.classList.add('menu-open');
+                mobileMenuButton.setAttribute('aria-expanded', 'true');
+            }
+            function closeMobileMenu() {
+                mobileMenu.classList.remove('open');
+                if (mobileMenuOverlay) mobileMenuOverlay.classList.remove('show');
+                if (hamburger) hamburger.classList.remove('open');
+                document.body.classList.remove('menu-open');
+                mobileMenuButton.setAttribute('aria-expanded', 'false');
+            }
+            mobileMenuButton.addEventListener('click', function() {
+                mobileMenu.classList.contains('open') ? closeMobileMenu() : openMobileMenu();
+            });
+            if (mobileMenuClose) mobileMenuClose.addEventListener('click', closeMobileMenu);
+            if (mobileMenuOverlay) mobileMenuOverlay.addEventListener('click', closeMobileMenu);
+        });
+    </script>
+</body>
+</html>

--- a/windsor/litigation-support/index.html
+++ b/windsor/litigation-support/index.html
@@ -1,0 +1,639 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Litigation Support Appraisal Windsor Ontario | Metrix Realty</title>
+    <link rel="icon" type="image/png" href="/favicon.png">
+    <meta name="description" content="Court-ready appraisals and expert witness testimony in Windsor-Essex. AACI-designated appraisers for property disputes, divorce, estates, and expropriation in Ontario courts.">
+    <meta name="keywords" content="litigation support appraiser Windsor Ontario, expert witness real estate Windsor, property dispute appraisal Windsor, divorce appraisal Windsor, estate appraisal Windsor Essex, expropriation appraisal Windsor, retrospective appraisal Windsor">
+    <link rel="canonical" href="https://metrixrealty.com/windsor/litigation-support">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Metrix Realty Group">
+    <meta property="og:title" content="Litigation Support Appraisal Windsor Ontario | Metrix Realty">
+    <meta property="og:description" content="Court-ready appraisals and expert witness testimony in Windsor-Essex. AACI-designated appraisers for property disputes, divorce, estates, and expropriation in Ontario courts.">
+    <meta property="og:url" content="https://metrixrealty.com/windsor/litigation-support">
+    <meta property="og:image" content="https://metrixrealty.com/assets/images/metrix-realty-logo.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="robots" content="noindex, nofollow">
+
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
+    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: { 'metrix-blue': '#233c75', 'metrix-blue-light': '#3d5a9e', 'metrix-blue-dark': '#1a2d5a', 'metrix-green': '#3faa4d' },
+                    fontFamily: { 'inter': ['Inter', 'sans-serif'] }
+                }
+            }
+        }
+    </script>
+    <style>
+        .bg-hero { background: linear-gradient(135deg, #233c75 0%, #1a2d5a 70%, #3faa4d 100%); }
+        .hamburger-line { transition: all 0.3s ease; }
+        .hamburger.open .hamburger-line:nth-child(1) { transform: rotate(45deg) translate(5px, 5px); }
+        .hamburger.open .hamburger-line:nth-child(2) { opacity: 0; }
+        .hamburger.open .hamburger-line:nth-child(3) { transform: rotate(-45deg) translate(7px, -6px); }
+        .mobile-menu { position: fixed; top: 0; right: 0; height: 100vh; width: 320px; background: #ffffff !important; box-shadow: -10px 0 25px rgba(0,0,0,0.15); z-index: 99999 !important; transform: translateX(100%); transition: transform 0.4s cubic-bezier(0.25,0.46,0.45,0.94); border-left: 1px solid #e5e7eb; }
+        .mobile-menu.open { transform: translateX(0); }
+        .mobile-menu-close { position: absolute; top: 24px; right: 24px; background: none; border: none; padding: 8px; cursor: pointer; color: #9ca3af; border-radius: 8px; transition: all 0.2s ease; }
+        .mobile-menu-close:hover { background: #f3f4f6; color: #374151; }
+        .mobile-menu-content { padding: 80px 32px 32px; height: 100%; overflow-y: auto; }
+        .mobile-nav { display: flex; flex-direction: column; gap: 8px; }
+        .mobile-nav-link { display: block; padding: 16px 0; color: #374151; font-weight: 500; font-size: 18px; text-decoration: none; border-bottom: 1px solid #f3f4f6; transition: all 0.2s ease; }
+        .mobile-nav-link:hover { color: #233c75; background: #f8fafc; padding-left: 16px; border-radius: 8px; border-bottom: 1px solid transparent; }
+        .mobile-nav-link.active { color: #233c75; font-weight: 600; }
+        .mobile-menu-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 99998 !important; opacity: 0; visibility: hidden; transition: all 0.3s ease; }
+        .mobile-menu-overlay.show { opacity: 1; visibility: visible; }
+        body.menu-open { overflow: hidden; }
+        .nav-link { position: relative; transition: all 0.3s cubic-bezier(0.4,0,0.2,1); }
+        .nav-link::after { content: ''; position: absolute; bottom: -2px; left: 0; width: 0; height: 2px; background: linear-gradient(90deg,#1a202c,#2d3748); transition: width 0.3s cubic-bezier(0.4,0,0.2,1); }
+        .nav-link:hover::after { width: 100%; }
+        .nav-link:hover { color: #1a202c; transform: translateY(-1px); }
+        .nav-link.active { color: #1a202c; font-weight: 600; }
+        .nav-link.active::after { width: 100%; }
+        .mega-menu-item { display: block; border-radius: 12px; transition: all 0.2s ease; }
+        .mega-menu-item:hover { background: #f8fafc; }
+        .mega-menu-item:hover .mega-menu-title { color: #233c75; }
+        .btn-primary { position: relative; overflow: hidden; transition: all 0.3s cubic-bezier(0.4,0,0.2,1); }
+        .btn-primary:hover { transform: translateY(-2px); box-shadow: 0 10px 25px rgba(26,32,44,0.25); }
+        .touch-target { min-height: 44px; min-width: 44px; }
+    </style>
+
+    <!-- Structured Data -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "ProfessionalService",
+      "name": "Metrix Realty Group – Litigation Support Windsor Ontario",
+      "url": "https://metrixrealty.com/windsor/litigation-support",
+      "description": "AACI-designated real estate appraisers providing litigation support, expert witness testimony, and court-ready valuations in Windsor-Essex and throughout Ontario courts.",
+      "telephone": "+1-519-672-7550",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "2557 Dougall Ave #6",
+        "addressLocality": "Windsor",
+        "addressRegion": "ON",
+        "postalCode": "N8X 1T5",
+        "addressCountry": "CA"
+      },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 42.3149,
+        "longitude": -83.0364
+      },
+      "areaServed": { "@type": "City", "name": "Windsor", "containedInPlace": { "@type": "AdministrativeArea", "name": "Ontario" } },
+      "hasCredential": ["AACI", "CUSPAP", "RICS"],
+      "parentOrganization": { "@type": "Organization", "name": "Metrix Realty Group", "url": "https://metrixrealty.com" }
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://metrixrealty.com/"},
+        {"@type": "ListItem", "position": 2, "name": "Windsor", "item": "https://metrixrealty.com/windsor/"},
+        {"@type": "ListItem", "position": 3, "name": "Litigation Support", "item": "https://metrixrealty.com/windsor/litigation-support"}
+      ]
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "Who provides litigation support appraisals in Windsor, Ontario?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Metrix Realty Group provides litigation support appraisals in Windsor-Essex through its Windsor office at 2557 Dougall Ave #6. Metrix appraisers have appeared as expert witnesses in Ontario courts, including the Ontario Superior Court of Justice in Windsor, and provide CUSPAP-compliant reports designed to withstand legal scrutiny."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "What types of legal matters require a real estate appraisal in Windsor?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Common legal matters requiring real estate appraisals in Windsor-Essex include matrimonial and divorce property valuations, estate and date-of-death valuations, shareholder and partnership disputes, expropriation proceedings (including the Gordie Howe Bridge corridor), property tax assessment appeals, and commercial litigation involving property value disputes."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Can Metrix Realty provide retrospective appraisals for estate or legal matters in Windsor?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Yes. Metrix provides retrospective appraisals — valuations as of a past effective date — for estate matters, date-of-death valuations, CRA purposes, separation agreements, and litigation requiring historical property values. Our AACI-designated appraisers are experienced in documenting methodology and evidence to support a past-date value opinion that can withstand legal and professional review."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Are Metrix litigation appraisals accepted in Ontario courts?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Metrix Realty appraisers have provided expert witness testimony in Ontario courts. Reports are prepared in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice) and the Rules of Civil Procedure (Rule 53.03 for expert witnesses). Our appraisers can prepare independent reports, provide supplemental materials, and attend examinations for discovery or trial proceedings in Windsor and across Ontario."
+          }
+        }
+      ]
+    }
+    </script>
+</head>
+<body class="font-inter">
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+
+    <!-- Global Header -->
+    <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
+        <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center justify-between h-16 sm:h-20">
+                <!-- Logo -->
+                <div class="flex-shrink-0">
+                    <a href="/">
+                        <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto">
+                    </a>
+                </div>
+
+                <!-- Desktop Navigation -->
+                <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
+                    <a href="/" class="nav-link text-gray-900 font-semibold">Home</a>
+                    <div class="relative group">
+                        <a href="/services" class="nav-link text-gray-900 font-semibold">Services</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-96 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50 backdrop-blur-sm">
+                            <div class="p-8">
+                                <div>
+                                    <h4 class="font-bold text-gray-900 mb-6 pb-3 border-b-2 border-metrix-blue text-lg">Appraisal &amp; Consulting Services</h4>
+                                    <div class="space-y-1">
+                                        <a href="/services/commercial-property-valuations" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Commercial Appraisals</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert valuations for office, retail, and industrial properties</div>
+                                        </a>
+                                        <a href="/services/litigation-support-expert-testimony" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Litigation Support</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Expert witness testimony and legal valuations</div>
+                                        </a>
+                                        <a href="/services/real-estate-consulting" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Real Estate Consulting</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Strategic market analysis and investment advisory services</div>
+                                        </a>
+                                        <a href="/services/government-institutional-services" class="mega-menu-item block p-4">
+                                            <div class="mega-menu-title font-semibold text-gray-900 mb-2">Government &amp; Institutional Services</div>
+                                            <div class="text-sm text-gray-600 leading-relaxed">Specialized services for federal, provincial, and municipal clients</div>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="relative group">
+                        <a href="/market-areas" class="nav-link active text-gray-900 font-semibold">Market Areas</a>
+                        <div class="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 w-48 bg-white rounded-2xl shadow-2xl border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 z-50">
+                            <div class="py-3 px-2">
+                                <a href="/london/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">London, ON</a>
+                                <a href="/windsor/" class="block px-4 py-2.5 font-semibold text-gray-900 hover:bg-gray-50 rounded-xl text-sm">Windsor, ON</a>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="/team" class="nav-link text-gray-900 font-semibold">Team</a>
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold">Contact</a>
+                </div>
+
+                <!-- CTA Button -->
+                <div class="hidden md:block">
+                    <a href="/contact" class="btn-primary inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors duration-200">
+                        Connect with an Appraiser
+                    </a>
+                </div>
+
+                <!-- Mobile menu button -->
+                <div class="md:hidden">
+                    <button id="mobile-menu-button" class="touch-target text-gray-900 hover:text-metrix-blue p-2" aria-label="Toggle mobile menu">
+                        <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                            <span class="hamburger-line block h-0.5 w-6 bg-current"></span>
+                        </div>
+                    </button>
+                </div>
+            </div>
+        </nav>
+
+        <!-- Mobile Menu -->
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link active">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2.5rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2.5rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link">Team</a>
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+                    <div style="margin-top: 32px;">
+                        <a href="/contact" class="btn-primary block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 transition-colors duration-200">
+                            Connect with an Appraiser
+                        </a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+
+        <!-- Mobile Menu Overlay -->
+        <div id="mobile-menu-overlay" class="mobile-menu-overlay md:hidden"></div>
+    </header>
+
+    <!-- Hero -->
+    <section class="bg-hero pt-20 sm:pt-24 pb-16 sm:pb-20 text-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <nav class="text-sm mb-6 text-white/70" aria-label="Breadcrumb">
+                <ol class="flex flex-wrap gap-1 items-center">
+                    <li><a href="/" class="hover:text-white transition-colors">Home</a></li>
+                    <li class="text-white/40 mx-1">/</li>
+                    <li><a href="/windsor/" class="hover:text-white transition-colors">Windsor</a></li>
+                    <li class="text-white/40 mx-1">/</li>
+                    <li class="text-white">Litigation Support</li>
+                </ol>
+            </nav>
+            <div class="max-w-4xl" data-aos="fade-up">
+                <p class="text-metrix-green font-semibold text-sm uppercase tracking-wider mb-3">Windsor, Ontario</p>
+                <h1 class="text-3xl sm:text-4xl lg:text-5xl font-bold mb-6 leading-tight">Real Estate Litigation Support in Windsor, Ontario</h1>
+                <p class="text-lg sm:text-xl text-white/85 mb-8 leading-relaxed max-w-3xl">Court-ready appraisals and expert witness testimony from <a href="https://www.aicanada.ca/designation/aaci/" target="_blank" rel="noopener noreferrer" class="underline hover:text-white">AACI</a>-designated appraisers. Serving Windsor-Essex lawyers, estates, and courts for divorce, expropriation, and property dispute matters.</p>
+                <div class="flex flex-col sm:flex-row gap-4">
+                    <a href="/contact" class="inline-flex items-center justify-center px-8 py-4 bg-white text-metrix-blue font-semibold rounded-lg hover:bg-gray-100 transition-colors text-lg">
+                        Request a Quote
+                        <svg class="w-5 h-5 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"/></svg>
+                    </a>
+                    <a href="tel:519-672-7550" class="inline-flex items-center justify-center px-8 py-4 bg-transparent text-white font-semibold rounded-lg border-2 border-white hover:bg-white hover:text-metrix-blue transition-colors text-lg">
+                        (519) 672-7550
+                    </a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- When You Need Us -->
+    <section class="py-16 sm:py-20 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="max-w-3xl mx-auto text-center mb-12" data-aos="fade-up">
+                <h2 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-4">When Is a Litigation Appraisal Required in Windsor?</h2>
+                <p class="text-gray-600 text-lg">Legal and dispute matters involving real property in Windsor-Essex frequently require an independent, CUSPAP-compliant appraisal prepared by a qualified professional.</p>
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6" data-aos="fade-up" data-aos-delay="100">
+                <div class="p-6 rounded-xl border border-gray-200 hover:border-metrix-blue hover:shadow-md transition-all">
+                    <h3 class="font-semibold text-gray-900 mb-2">Matrimonial &amp; Divorce</h3>
+                    <p class="text-gray-600 text-sm">Independent property valuations for equalization of net family property under the Family Law Act. Serving Windsor-area lawyers, mediators, and courts requiring defensible property value opinions at the date of separation.</p>
+                </div>
+                <div class="p-6 rounded-xl border border-gray-200 hover:border-metrix-blue hover:shadow-md transition-all">
+                    <h3 class="font-semibold text-gray-900 mb-2">Estate &amp; Date-of-Death Valuations</h3>
+                    <p class="text-gray-600 text-sm">Retrospective appraisals prepared as of the date of death for estate administration, probate, CRA compliance, and equalization among beneficiaries. Accepted by estate trustees, lawyers, and accountants.</p>
+                </div>
+                <div class="p-6 rounded-xl border border-gray-200 hover:border-metrix-blue hover:shadow-md transition-all">
+                    <h3 class="font-semibold text-gray-900 mb-2">Expropriation Matters</h3>
+                    <p class="text-gray-600 text-sm">Compensation valuations for expropriation proceedings under the Expropriations Act. Windsor-Essex has active infrastructure development — including the Gordie Howe International Bridge corridor — requiring experienced expropriation appraisal support.</p>
+                </div>
+                <div class="p-6 rounded-xl border border-gray-200 hover:border-metrix-blue hover:shadow-md transition-all">
+                    <h3 class="font-semibold text-gray-900 mb-2">Shareholder &amp; Partnership Disputes</h3>
+                    <p class="text-gray-600 text-sm">Independent valuations for commercial and investment property disputes between business partners, shareholders, or co-owners requiring a neutral, defensible property value opinion.</p>
+                </div>
+                <div class="p-6 rounded-xl border border-gray-200 hover:border-metrix-blue hover:shadow-md transition-all">
+                    <h3 class="font-semibold text-gray-900 mb-2">Property Tax Assessment Appeals</h3>
+                    <p class="text-gray-600 text-sm">Appraisal evidence supporting MPAC assessment appeals before the <a href="https://tribunalsontario.ca/arb/" target="_blank" rel="noopener noreferrer" class="text-metrix-blue hover:underline">Assessment Review Board</a> for commercial, industrial, and investment properties in Windsor and Essex County.</p>
+                </div>
+                <div class="p-6 rounded-xl border border-gray-200 hover:border-metrix-blue hover:shadow-md transition-all">
+                    <h3 class="font-semibold text-gray-900 mb-2">Commercial Property Disputes</h3>
+                    <p class="text-gray-600 text-sm">Court-ready valuations for commercial litigation matters including lease disputes, insurance claims, construction liens, and mortgage enforcement proceedings in Windsor-area courts.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Expert Witness Section -->
+    <section class="py-16 sm:py-20 bg-gray-50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="max-w-3xl mx-auto text-center mb-12" data-aos="fade-up">
+                <h2 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-4">Expert Witness Testimony in Windsor</h2>
+                <p class="text-gray-600 text-lg">Metrix appraisers are experienced in preparing reports and providing testimony that meets the requirements of Ontario courts.</p>
+            </div>
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6" data-aos="fade-up" data-aos-delay="100">
+                <div class="bg-white p-6 rounded-xl shadow-sm">
+                    <h3 class="font-semibold text-gray-900 mb-2">Rule 53.03 Compliance</h3>
+                    <p class="text-gray-600 text-sm">Expert reports prepared in accordance with Rule 53.03 of the Ontario Rules of Civil Procedure, including the required acknowledgment of the expert's duty to the court.</p>
+                </div>
+                <div class="bg-white p-6 rounded-xl shadow-sm">
+                    <h3 class="font-semibold text-gray-900 mb-2">Examinations for Discovery</h3>
+                    <p class="text-gray-600 text-sm">Metrix appraisers are available to attend examinations for discovery in Windsor and can prepare clear, defensible supporting documentation in advance.</p>
+                </div>
+                <div class="bg-white p-6 rounded-xl shadow-sm">
+                    <h3 class="font-semibold text-gray-900 mb-2">Trial Testimony</h3>
+                    <p class="text-gray-600 text-sm">Our appraisers have experience presenting valuation evidence at the Ontario Superior Court of Justice, including Windsor courthouse proceedings, and responding to cross-examination.</p>
+                </div>
+                <div class="bg-white p-6 rounded-xl shadow-sm">
+                    <h3 class="font-semibold text-gray-900 mb-2">Retrospective Appraisals</h3>
+                    <p class="text-gray-600 text-sm">Value opinions as of a past effective date for estate administration, separation proceedings, CRA disputes, or any legal matter requiring a historical property value.</p>
+                </div>
+                <div class="bg-white p-6 rounded-xl shadow-sm">
+                    <h3 class="font-semibold text-gray-900 mb-2">Appraisal Review</h3>
+                    <p class="text-gray-600 text-sm">Independent review of a third-party appraisal report to assess compliance, methodology, and supportability — useful for challenging or rebutting an opposing valuation.</p>
+                </div>
+                <div class="bg-white p-6 rounded-xl shadow-sm">
+                    <h3 class="font-semibold text-gray-900 mb-2">Consulting &amp; Advisory</h3>
+                    <p class="text-gray-600 text-sm">Pre-litigation consulting to help lawyers understand property value issues, settlement ranges, and the strengths and limitations of the available appraisal evidence before proceeding to trial.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Windsor Market Context + Why Choose Us -->
+    <section class="py-16 sm:py-20 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
+                <div data-aos="fade-right">
+                    <h2 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-6">Litigation Appraisals in Windsor-Essex: What Makes This Market Different</h2>
+                    <p class="text-gray-600 mb-4">Windsor-Essex has a distinct commercial and industrial property market shaped by factors that require local knowledge to value accurately in a legal context. An appraiser unfamiliar with the Windsor market can produce a report that is technically compliant but factually incorrect.</p>
+                    <p class="text-gray-600 mb-4">Key Windsor-Essex considerations that affect litigation appraisals:</p>
+                    <ul class="space-y-3 text-gray-600 mb-6">
+                        <li class="flex items-start gap-2"><span class="text-metrix-green font-bold mt-1">→</span><span><strong>Gordie Howe Bridge Corridor:</strong> Expropriation and proximity impacts along the new international crossing require familiarity with Windsor's infrastructure development and the Expropriations Act process.</span></li>
+                        <li class="flex items-start gap-2"><span class="text-metrix-green font-bold mt-1">→</span><span><strong>Automotive Industrial Values:</strong> Industrial and manufacturing properties tied to the Stellantis and Ford supply chain have unique market characteristics that general appraisers may not understand.</span></li>
+                        <li class="flex items-start gap-2"><span class="text-metrix-green font-bold mt-1">→</span><span><strong>Essex County Agricultural Land:</strong> Rural and agricultural properties in Essex, Leamington, and Kingsville require separate market expertise distinct from urban Windsor valuations.</span></li>
+                        <li class="flex items-start gap-2"><span class="text-metrix-green font-bold mt-1">→</span><span><strong>Cross-Border Considerations:</strong> Some Windsor commercial properties have values influenced by proximity to the US border — a factor rarely considered outside of Windsor appraisals.</span></li>
+                    </ul>
+                </div>
+                <div data-aos="fade-left">
+                    <div class="bg-metrix-blue rounded-2xl p-8 text-white">
+                        <h3 class="text-xl font-bold mb-6">Why Windsor Lawyers Choose Metrix</h3>
+                        <div class="space-y-4">
+                            <div class="flex items-start gap-3">
+                                <span class="text-metrix-green text-xl font-bold">✓</span>
+                                <div>
+                                    <p class="font-semibold">Windsor Office — Local Market Knowledge</p>
+                                    <p class="text-white/75 text-sm">Located at 2557 Dougall Ave. Our appraisers know Windsor-Essex from the inside — courts notice the difference.</p>
+                                </div>
+                            </div>
+                            <div class="flex items-start gap-3">
+                                <span class="text-metrix-green text-xl font-bold">✓</span>
+                                <div>
+                                    <p class="font-semibold">AACI Designation</p>
+                                    <p class="text-white/75 text-sm">The highest professional designation in Canadian real estate appraisal — recognized by Ontario courts as a credential of qualified experts.</p>
+                                </div>
+                            </div>
+                            <div class="flex items-start gap-3">
+                                <span class="text-metrix-green text-xl font-bold">✓</span>
+                                <div>
+                                    <p class="font-semibold">RICS &amp; IRWA Designations</p>
+                                    <p class="text-white/75 text-sm">International credentialing that reinforces expert qualification, particularly relevant for Windsor cross-border matters.</p>
+                                </div>
+                            </div>
+                            <div class="flex items-start gap-3">
+                                <span class="text-metrix-green text-xl font-bold">✓</span>
+                                <div>
+                                    <p class="font-semibold">30+ Years &amp; 50,000+ Files</p>
+                                    <p class="text-white/75 text-sm">Founded in 1995. Decades of Southwestern Ontario appraisal experience behind every litigation report.</p>
+                                </div>
+                            </div>
+                            <div class="flex items-start gap-3">
+                                <span class="text-metrix-green text-xl font-bold">✓</span>
+                                <div>
+                                    <p class="font-semibold"><a href="https://www.aicanada.ca/about-aic/cuspap/" target="_blank" rel="noopener noreferrer" class="underline">CUSPAP</a> Compliant</p>
+                                    <p class="text-white/75 text-sm">Every report complies with Canadian Uniform Standards of Professional Appraisal Practice — a requirement for defensible court evidence.</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Process -->
+    <section class="py-16 sm:py-20 bg-gray-50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="max-w-3xl mx-auto text-center mb-12" data-aos="fade-up">
+                <h2 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-4">Our Windsor Litigation Appraisal Process</h2>
+                <p class="text-gray-600 text-lg">We work directly with lawyers, estate trustees, and mediators to provide the right appraisal product for the legal matter at hand.</p>
+            </div>
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6" data-aos="fade-up" data-aos-delay="100">
+                <div class="bg-white rounded-xl p-6 shadow-sm text-center">
+                    <div class="w-12 h-12 bg-metrix-blue text-white rounded-full flex items-center justify-center text-xl font-bold mx-auto mb-4">1</div>
+                    <h3 class="font-semibold text-gray-900 mb-2">Brief &amp; Scope</h3>
+                    <p class="text-gray-600 text-sm">We discuss the legal matter, intended use, effective date, authorized users, and any specific requirements of the retaining counsel or court process.</p>
+                </div>
+                <div class="bg-white rounded-xl p-6 shadow-sm text-center">
+                    <div class="w-12 h-12 bg-metrix-blue text-white rounded-full flex items-center justify-center text-xl font-bold mx-auto mb-4">2</div>
+                    <h3 class="font-semibold text-gray-900 mb-2">Property Inspection</h3>
+                    <p class="text-gray-600 text-sm">Thorough on-site inspection documenting all value-affecting factors. For retrospective assignments, we rely on historical records, photos, and documentation from the relevant date.</p>
+                </div>
+                <div class="bg-white rounded-xl p-6 shadow-sm text-center">
+                    <div class="w-12 h-12 bg-metrix-blue text-white rounded-full flex items-center justify-center text-xl font-bold mx-auto mb-4">3</div>
+                    <h3 class="font-semibold text-gray-900 mb-2">Research &amp; Analysis</h3>
+                    <p class="text-gray-600 text-sm">Market evidence research, comparable analysis, and valuation methodology applied to the specific effective date — current or historical — required by the legal matter.</p>
+                </div>
+                <div class="bg-white rounded-xl p-6 shadow-sm text-center">
+                    <div class="w-12 h-12 bg-metrix-blue text-white rounded-full flex items-center justify-center text-xl font-bold mx-auto mb-4">4</div>
+                    <h3 class="font-semibold text-gray-900 mb-2">Report &amp; Testimony</h3>
+                    <p class="text-gray-600 text-sm">Detailed CUSPAP-compliant report delivered to the retaining party. Available for examination for discovery, mediation, arbitration, and trial testimony as required.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Service Area -->
+    <section class="py-12 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="bg-gray-50 rounded-2xl p-8" data-aos="fade-up">
+                <h2 class="text-xl font-bold text-gray-900 mb-4">Windsor-Essex Service Area</h2>
+                <p class="text-gray-600 mb-4">Our Windsor office serves litigation clients and their counsel throughout Essex County and the surrounding region:</p>
+                <div class="flex flex-wrap gap-3">
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">Windsor</span>
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">LaSalle</span>
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">Tecumseh</span>
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">Amherstburg</span>
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">Essex</span>
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">Kingsville</span>
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">Leamington</span>
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">Lakeshore</span>
+                    <span class="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 font-medium">All of Essex County</span>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- FAQ -->
+    <section class="py-16 sm:py-20 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="max-w-3xl mx-auto">
+                <h2 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-10 text-center" data-aos="fade-up">Frequently Asked Questions</h2>
+                <div class="space-y-6" data-aos="fade-up" data-aos-delay="100">
+                    <div class="border border-gray-200 rounded-xl p-6">
+                        <h3 class="font-semibold text-gray-900 mb-2">Who provides litigation support appraisals in Windsor, Ontario?</h3>
+                        <p class="text-gray-600">Metrix Realty Group provides litigation support appraisals in Windsor through its local office at 2557 Dougall Ave #6. Metrix appraisers have appeared as expert witnesses in Ontario courts — including the Ontario Superior Court of Justice in Windsor — and produce CUSPAP-compliant reports prepared to withstand legal scrutiny and cross-examination.</p>
+                    </div>
+                    <div class="border border-gray-200 rounded-xl p-6">
+                        <h3 class="font-semibold text-gray-900 mb-2">What types of legal matters require a real estate appraisal in Windsor?</h3>
+                        <p class="text-gray-600">Common matters in Windsor-Essex include matrimonial and divorce property valuations, estate and date-of-death valuations for CRA and probate, expropriation proceedings (including the Gordie Howe Bridge corridor), shareholder and partnership disputes, property tax assessment appeals before the Assessment Review Board, and commercial litigation involving property value disputes.</p>
+                    </div>
+                    <div class="border border-gray-200 rounded-xl p-6">
+                        <h3 class="font-semibold text-gray-900 mb-2">Can Metrix provide retrospective appraisals for estate or legal matters?</h3>
+                        <p class="text-gray-600">Yes. We prepare retrospective appraisals — valuations as of a past effective date — for estate administration, date-of-death valuations, separation agreements, CRA compliance, and any legal matter requiring a historical value. Our AACI-designated appraisers document their methodology and evidence to support a past-date opinion that can withstand review by lawyers, accountants, courts, or CRA.</p>
+                    </div>
+                    <div class="border border-gray-200 rounded-xl p-6">
+                        <h3 class="font-semibold text-gray-900 mb-2">Are Metrix litigation appraisals accepted in Ontario courts?</h3>
+                        <p class="text-gray-600">Metrix appraisers have provided expert witness testimony in Ontario courts. Reports comply with CUSPAP and Ontario Rules of Civil Procedure (Rule 53.03). Our appraisers can prepare independent reports, provide supplemental materials for discovery, and attend trial proceedings in Windsor and across Ontario. Retaining counsel should confirm scope and timing requirements at the outset of the matter.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- CTA -->
+    <section class="py-16 sm:py-20 bg-metrix-blue text-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+            <h2 class="text-2xl sm:text-3xl font-bold mb-4" data-aos="fade-up">Retain a Windsor Litigation Appraiser</h2>
+            <p class="text-white/80 text-lg mb-8 max-w-2xl mx-auto" data-aos="fade-up" data-aos-delay="100">Tell us the property, the legal matter, the effective date required, and your timeline. Our AACI-designated team will respond promptly.</p>
+            <div class="flex flex-col sm:flex-row gap-4 justify-center" data-aos="fade-up" data-aos-delay="200">
+                <a href="/contact" class="inline-flex items-center justify-center px-8 py-4 bg-white text-metrix-blue font-semibold rounded-lg hover:bg-gray-100 transition-colors text-lg">
+                    Connect with an Appraiser
+                </a>
+                <a href="tel:519-672-7550" class="inline-flex items-center justify-center px-8 py-4 bg-transparent text-white font-semibold rounded-lg border-2 border-white hover:bg-white hover:text-metrix-blue transition-colors text-lg">
+                    Call (519) 672-7550
+                </a>
+            </div>
+            <p class="text-white/60 text-sm mt-6">Windsor office: 2557 Dougall Ave #6, Windsor, ON N8X 1T5 &nbsp;|&nbsp; <a href="/windsor/" class="underline hover:text-white">Windsor Hub</a></p>
+        </div>
+    </section>
+
+    <!-- Footer -->
+    <footer class="bg-black text-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
+                <div class="lg:col-span-1">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-6 leading-relaxed">Trusted • Valued • Experienced</p>
+                    <div class="text-gray-300">
+                        <p class="font-semibold text-white mb-2">620A Richmond Street, Suite 203</p>
+                        <p class="mb-4">London, ON N6A 5J9</p>
+                        <p class="font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/></svg>
+                            <a href="tel:519-672-7550" class="text-white hover:text-gray-200 transition-colors">(519) 672-7550</a>
+                        </p>
+                        <p>Toll Free: 1-866-672-9101</p>
+                        <p>Fax: (519) 672-9321</p>
+                        <p class="mt-4 font-semibold text-white flex items-center">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
+                            <a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200 transition-colors">info@metrixrealty.com</a>
+                        </p>
+                    </div>
+                </div>
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
+                    <ul class="space-y-3 text-gray-300">
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors duration-200">Commercial Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors duration-200">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors duration-200">Government &amp; Institutional</a></li>
+                        <li><a href="/services" class="hover:text-white transition-colors duration-200">View All Services</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
+                    </ul>
+                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
+                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/team" class="hover:text-white transition-colors duration-200">Our Team</a></li>
+                        <li><a href="/insights/" class="hover:text-white transition-colors duration-200">Market Insights</a></li>
+                        <li><a href="/contact" class="hover:text-white transition-colors duration-200">Contact</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="border-t border-gray-800 pt-8 mb-8 text-center">
+                <div class="mb-6">
+                    <h4 class="text-white font-semibold text-lg mb-4">Professional Affiliations</h4>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-300 mb-6">
+                    <span>AIC - <a href="https://www.aicanada.ca/" target="_blank" rel="noopener noreferrer">Appraisal Institute of Canada</a></span>
+                    <span>RICS - Royal Institution of Chartered Surveyors</span>
+                    <span>AOLE - Association of Ontario Land Economists</span>
+                    <span>IRWA - International Right of Way Association</span>
+                </div>
+                <div class="flex flex-wrap justify-center gap-8 text-sm text-gray-400 mb-6">
+                    <span>Data Providers:</span>
+                    <span>CoStar Professional</span>
+                    <span>TRREB - Toronto Regional Real Estate Board</span>
+                </div>
+                <div class="text-sm text-gray-400 border-t border-gray-800 pt-6">
+                    <p>Reports completed in compliance with <a href="https://www.aicanada.ca/about-aic/cuspap/" target="_blank" rel="noopener noreferrer">CUSPAP</a> (Canadian Uniform Standards of Professional Appraisal Practice)</p>
+                </div>
+            </div>
+            <div class="border-t border-gray-800 pt-8 text-center text-gray-400 text-sm">
+                <p>&copy; 2026 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-4 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-400 hover:text-gray-300 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-400 hover:text-gray-300 text-sm">Terms of Service</a>
+                    <a href="/accessibility" class="text-gray-400 hover:text-gray-300 text-sm">Accessibility</a>
+                    <a href="/llms.txt" class="text-gray-400 hover:text-gray-300 text-sm">LLMs.txt</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
+    <script>
+        AOS.init({ once: true, duration: 800 });
+        document.addEventListener('DOMContentLoaded', function() {
+            const mobileMenuButton = document.getElementById('mobile-menu-button');
+            const mobileMenu = document.getElementById('mobile-menu');
+            const mobileMenuOverlay = document.getElementById('mobile-menu-overlay');
+            const mobileMenuClose = document.getElementById('mobile-menu-close');
+            const hamburger = document.querySelector('.hamburger');
+            if (!mobileMenuButton || !mobileMenu) return;
+            function openMobileMenu() {
+                mobileMenu.classList.add('open');
+                if (mobileMenuOverlay) mobileMenuOverlay.classList.add('show');
+                if (hamburger) hamburger.classList.add('open');
+                document.body.classList.add('menu-open');
+                mobileMenuButton.setAttribute('aria-expanded', 'true');
+            }
+            function closeMobileMenu() {
+                mobileMenu.classList.remove('open');
+                if (mobileMenuOverlay) mobileMenuOverlay.classList.remove('show');
+                if (hamburger) hamburger.classList.remove('open');
+                document.body.classList.remove('menu-open');
+                mobileMenuButton.setAttribute('aria-expanded', 'false');
+            }
+            mobileMenuButton.addEventListener('click', function() {
+                mobileMenu.classList.contains('open') ? closeMobileMenu() : openMobileMenu();
+            });
+            if (mobileMenuClose) mobileMenuClose.addEventListener('click', closeMobileMenu);
+            if (mobileMenuOverlay) mobileMenuOverlay.addEventListener('click', closeMobileMenu);
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- **Bug fix:** Removes `<a href>` tags that were placed inside `<title>` elements on 3 pages — HTML is invalid inside title tags and renders as literal text in browser tabs and SERPs, breaking title tag SEO
- **Consistency:** Adds outbound CUSPAP link to aicanada.ca on the footer compliance line across all pages that had it as plain text
- **Housekeeping:** Adds `session-notes.md` to `.gitignore`

## Pages with title tag fix
- `roman-virk/index.html`
- `team/index.html`
- `london/residential-appraisal/index.html`

## Pages with CUSPAP footer link added
- `index.html`, `404.html`
- `london/commercial-appraisal/`, `london/industrial-appraisal/`, `london/residential-appraisal/`
- `services/commercial-property-valuations/`, `services/residential-property-appraisals/`
- `suzanne-de-jong/`, `tyler-munn/`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes invalid HTML in title tags and standardizes the CUSPAP footer link to improve SEO and clarity. Also soft-launches Windsor service pages and two Insights articles with noindex/nofollow, plus minor housekeeping.

- **Bug Fixes**
  - Removed links from title tags on roman-virk, team, and london/residential-appraisal.
  - Converted the CUSPAP compliance line to a link to aicanada.ca across affected footers.

- **New Features**
  - Added Insights: insights/what-is-aaci-designation.html and insights/what-is-cuspap.html (noindex, nofollow).
  - Added Windsor pages: windsor/commercial-appraisal, windsor/industrial-appraisal, windsor/investment-appraisal, windsor/litigation-support (noindex, nofollow; not linked yet).
  - Updated llms.txt with new articles; added session-notes.md to .gitignore.

<sup>Written for commit c4665e962bdbb2f01bc838d54d9f1425695aa23c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

