### PR TITLE
Fix: /cdn-cgi redirect (37 backlinks) and jpetruzella canonical

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -9,6 +9,9 @@
 /market-insights       /insights/   301
 /market-insights.html  /insights/   301
 
+# Reclaim 37 inbound backlinks from Cloudflare email-obfuscation path
+/cdn-cgi/l/email-protection   /contact   301
+
 # Trailing-slash canonicalization
 /services              /services/   301
 /services/index        /services/   301

--- a/jpetruzella.html
+++ b/jpetruzella.html
@@ -5,14 +5,14 @@
     <meta name="robots" content="noindex, nofollow">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Redirecting...</title>
-    <link rel="canonical" href="https://metrixrealty.com/jeff-petruzella.html">
+    <link rel="canonical" href="https://metrixrealty.com/jeff-petruzella">
     <script>
         // 301-style redirect
-        window.location.replace("https://metrixrealty.com/jeff-petruzella.html");
+        window.location.replace("https://metrixrealty.com/jeff-petruzella");
     </script>
-    <meta http-equiv="refresh" content="0; url=https://metrixrealty.com/jeff-petruzella.html">
+    <meta http-equiv="refresh" content="0; url=https://metrixrealty.com/jeff-petruzella">
 </head>
 <body>
-    <p>If you are not redirected automatically, <a href="https://metrixrealty.com/jeff-petruzella.html">click here</a>.</p>
+    <p>If you are not redirected automatically, <a href="https://metrixrealty.com/jeff-petruzella">click here</a>.</p>
 </body>
 </html>


### PR DESCRIPTION
## What
Two small fixes with no content changes.

**1. Redirect /cdn-cgi/l/email-protection → /contact**
37 external backlinks were pointing to this Cloudflare email-obfuscation path and hitting a 404. One line added to `_redirects` reclaims all of them.

**2. Fix jpetruzella.html canonical URL**
The redirect stub was pointing to `/jeff-petruzella.html` instead of the clean URL `/jeff-petruzella`. Updated canonical, JS redirect, meta refresh, and fallback link.

## Safe to merge?
Yes — no content changes, no noindex changes, no schema changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 301 redirect from `/cdn-cgi/l/email-protection` to `/contact` to reclaim 37 backlinks. Fixes `jpetruzella.html` canonical, JS redirect, meta refresh, and fallback link to use the clean `/jeff-petruzella` URL.

<sup>Written for commit ca7d7a2fbbaed1b5599f5050f267fb00c1b22662. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

