### PR TITLE
fix(schema): upgrade ProfessionalService → LocalBusiness+ProfessionalService (20 pages)

### DIFF
--- a/contact/index.html
+++ b/contact/index.html
@@ -30,7 +30,7 @@
           ]
         },
         {
-          "@type": "ProfessionalService",
+          "@type": ["LocalBusiness", "ProfessionalService"],
           "@id": "https://metrixrealty.com/#organization",
           "name": "Metrix Realty Group",
           "url": "https://metrixrealty.com",

--- a/london/commercial-appraisal/index.html
+++ b/london/commercial-appraisal/index.html
@@ -74,7 +74,7 @@
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
-      "@type": "ProfessionalService",
+      "@type": ["LocalBusiness", "ProfessionalService"],
       "name": "Metrix Realty Group – Commercial Appraisal London Ontario",
       "url": "https://metrixrealty.com/london/commercial-appraisal",
       "description": "AACI-designated commercial real estate appraisers in London, Ontario. Office, retail, industrial, multi-family, and development land valuations accepted by all major Canadian lenders.",

--- a/london/industrial-appraisal/index.html
+++ b/london/industrial-appraisal/index.html
@@ -73,7 +73,7 @@
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
-      "@type": "ProfessionalService",
+      "@type": ["LocalBusiness", "ProfessionalService"],
       "name": "Metrix Realty Group – Industrial Appraisal London Ontario",
       "url": "https://metrixrealty.com/london/industrial-appraisal",
       "description": "AACI-designated industrial property appraisers in London, Ontario. Warehouse, manufacturing, logistics, flex industrial, and food processing facility valuations.",

--- a/london/residential-appraisal/index.html
+++ b/london/residential-appraisal/index.html
@@ -73,7 +73,7 @@
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
-      "@type": "ProfessionalService",
+      "@type": ["LocalBusiness", "ProfessionalService"],
       "name": "Metrix Realty Group – Residential Appraisal London Ontario",
       "url": "https://metrixrealty.com/london/residential-appraisal",
       "description": "AACI and CRA designated residential appraisers in London, Ontario. Home valuations for mortgage financing, estate planning, divorce proceedings, and MPAC property tax appeals.",

--- a/services-enhanced.html
+++ b/services-enhanced.html
@@ -38,7 +38,7 @@
           ]
         },
         {
-          "@type": "ProfessionalService",
+          "@type": ["LocalBusiness", "ProfessionalService"],
           "@id": "https://metrixrealty.com/services#service",
           "name": "Real Estate Appraisal & Valuation Services — Metrix Realty Group",
           "url": "https://metrixrealty.com/services",

--- a/services/commercial-property-valuations.html
+++ b/services/commercial-property-valuations.html
@@ -102,7 +102,7 @@
       "url": "https://metrixrealty.com/services/commercial-property-valuations",
       "serviceType": "Commercial Real Estate Appraisal",
       "provider": {
-        "@type": "ProfessionalService",
+        "@type": ["LocalBusiness", "ProfessionalService"],
         "name": "Metrix Realty Group",
         "url": "https://metrixrealty.com/",
         "telephone": "+15196727550",

--- a/services/commercial-property-valuations/index.html
+++ b/services/commercial-property-valuations/index.html
@@ -102,7 +102,7 @@
       "url": "https://metrixrealty.com/services/commercial-property-valuations",
       "serviceType": "Commercial Real Estate Appraisal",
       "provider": {
-        "@type": "ProfessionalService",
+        "@type": ["LocalBusiness", "ProfessionalService"],
         "name": "Metrix Realty Group",
         "url": "https://metrixrealty.com/",
         "telephone": "+15196727550",

--- a/services/government-institutional-services.html
+++ b/services/government-institutional-services.html
@@ -79,7 +79,7 @@
       "url": "https://metrixrealty.com/services/government-institutional-services",
       "serviceType": "Government and Institutional Property Appraisal",
       "provider": {
-        "@type": "ProfessionalService",
+        "@type": ["LocalBusiness", "ProfessionalService"],
         "name": "Metrix Realty Group",
         "url": "https://metrixrealty.com/",
         "telephone": "+15196727550",

--- a/services/government-institutional-services/index.html
+++ b/services/government-institutional-services/index.html
@@ -79,7 +79,7 @@
       "url": "https://metrixrealty.com/services/government-institutional-services",
       "serviceType": "Government and Institutional Property Appraisal",
       "provider": {
-        "@type": "ProfessionalService",
+        "@type": ["LocalBusiness", "ProfessionalService"],
         "name": "Metrix Realty Group",
         "url": "https://metrixrealty.com/",
         "telephone": "+15196727550",

--- a/services/index.html
+++ b/services/index.html
@@ -38,7 +38,7 @@
           ]
         },
         {
-          "@type": "ProfessionalService",
+          "@type": ["LocalBusiness", "ProfessionalService"],
           "@id": "https://metrixrealty.com/services#service",
           "name": "Real Estate Appraisal & Valuation Services — Metrix Realty Group",
           "url": "https://metrixrealty.com/services",

--- a/services/litigation-support-expert-testimony.html
+++ b/services/litigation-support-expert-testimony.html
@@ -79,7 +79,7 @@
       "url": "https://metrixrealty.com/services/litigation-support-expert-testimony",
       "serviceType": "Litigation Support Appraisal",
       "provider": {
-        "@type": "ProfessionalService",
+        "@type": ["LocalBusiness", "ProfessionalService"],
         "name": "Metrix Realty Group",
         "url": "https://metrixrealty.com/",
         "telephone": "+15196727550",

--- a/services/litigation-support-expert-testimony/index.html
+++ b/services/litigation-support-expert-testimony/index.html
@@ -79,7 +79,7 @@
       "url": "https://metrixrealty.com/services/litigation-support-expert-testimony",
       "serviceType": "Litigation Support Appraisal",
       "provider": {
-        "@type": "ProfessionalService",
+        "@type": ["LocalBusiness", "ProfessionalService"],
         "name": "Metrix Realty Group",
         "url": "https://metrixrealty.com/",
         "telephone": "+15196727550",

--- a/services/real-estate-consulting.html
+++ b/services/real-estate-consulting.html
@@ -79,7 +79,7 @@
       "url": "https://metrixrealty.com/services/real-estate-consulting",
       "serviceType": "Real Estate Consulting",
       "provider": {
-        "@type": "ProfessionalService",
+        "@type": ["LocalBusiness", "ProfessionalService"],
         "name": "Metrix Realty Group",
         "url": "https://metrixrealty.com/",
         "telephone": "+15196727550",

--- a/services/real-estate-consulting/index.html
+++ b/services/real-estate-consulting/index.html
@@ -79,7 +79,7 @@
       "url": "https://metrixrealty.com/services/real-estate-consulting",
       "serviceType": "Real Estate Consulting",
       "provider": {
-        "@type": "ProfessionalService",
+        "@type": ["LocalBusiness", "ProfessionalService"],
         "name": "Metrix Realty Group",
         "url": "https://metrixrealty.com/",
         "telephone": "+15196727550",

--- a/services/residential-property-appraisals.html
+++ b/services/residential-property-appraisals.html
@@ -89,7 +89,7 @@
       "url": "https://metrixrealty.com/services/residential-property-appraisals",
       "serviceType": "Residential Property Appraisal",
       "provider": {
-        "@type": "ProfessionalService",
+        "@type": ["LocalBusiness", "ProfessionalService"],
         "name": "Metrix Realty Group",
         "url": "https://metrixrealty.com/",
         "telephone": "+15196727550",

--- a/services/residential-property-appraisals/index.html
+++ b/services/residential-property-appraisals/index.html
@@ -89,7 +89,7 @@
       "url": "https://metrixrealty.com/services/residential-property-appraisals",
       "serviceType": "Residential Property Appraisal",
       "provider": {
-        "@type": "ProfessionalService",
+        "@type": ["LocalBusiness", "ProfessionalService"],
         "name": "Metrix Realty Group",
         "url": "https://metrixrealty.com/",
         "telephone": "+15196727550",

--- a/windsor/commercial-appraisal/index.html
+++ b/windsor/commercial-appraisal/index.html
@@ -76,7 +76,7 @@
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
-      "@type": "ProfessionalService",
+      "@type": ["LocalBusiness", "ProfessionalService"],
       "name": "Metrix Realty Group – Commercial Appraisal Windsor Ontario",
       "url": "https://metrixrealty.com/windsor/commercial-appraisal",
       "description": "AACI-designated commercial real estate appraisers in Windsor-Essex. Office, retail, industrial, and multi-family valuations accepted by all major Canadian lenders.",

--- a/windsor/industrial-appraisal/index.html
+++ b/windsor/industrial-appraisal/index.html
@@ -76,7 +76,7 @@
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
-      "@type": "ProfessionalService",
+      "@type": ["LocalBusiness", "ProfessionalService"],
       "name": "Metrix Realty Group – Industrial Appraisal Windsor Ontario",
       "url": "https://metrixrealty.com/windsor/industrial-appraisal",
       "description": "AACI-designated industrial property appraisers in Windsor-Essex. Manufacturing, warehouse, flex industrial, automotive plant, and food processing valuations accepted by all major Canadian lenders.",

--- a/windsor/investment-appraisal/index.html
+++ b/windsor/investment-appraisal/index.html
@@ -76,7 +76,7 @@
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
-      "@type": "ProfessionalService",
+      "@type": ["LocalBusiness", "ProfessionalService"],
       "name": "Metrix Realty Group – Investment Property Appraisal Windsor Ontario",
       "url": "https://metrixrealty.com/windsor/investment-appraisal",
       "description": "AACI-designated investment property and multi-family appraisers in Windsor-Essex. Apartment buildings, rental complexes, and commercial investment valuations accepted by all major Canadian lenders including CMHC.",

--- a/windsor/litigation-support/index.html
+++ b/windsor/litigation-support/index.html
@@ -76,7 +76,7 @@
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
-      "@type": "ProfessionalService",
+      "@type": ["LocalBusiness", "ProfessionalService"],
       "name": "Metrix Realty Group – Litigation Support Windsor Ontario",
       "url": "https://metrixrealty.com/windsor/litigation-support",
       "description": "AACI-designated real estate appraisers providing litigation support, expert witness testimony, and court-ready valuations in Windsor-Essex and throughout Ontario courts.",


### PR DESCRIPTION
## Summary

Upgrades `"@type": "ProfessionalService"` to `["LocalBusiness", "ProfessionalService"]` across all 20 pages where the deprecated standalone type appeared.

**Why:** `LocalBusiness` is Google's recognized type for local business rich results, Knowledge Panel association, and local search features. `ProfessionalService` alone doesn't trigger these. The array form retains Schema.org semantic specificity while adding full Google eligibility.

**Affected pages (20 total):**
- London service pages (commercial, residential, industrial)
- Windsor service pages (commercial, industrial, investment, litigation)
- Services hub pages (all 5 service verticals × 2 URL structures)
- Contact page
- Services index
- services-enhanced.html

## Test plan

- [ ] Validate representative pages via Rich Results Test — no errors expected
- [ ] Confirm `LocalBusiness` type recognized in Google Search Console structured data report after indexing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade JSON-LD `@type` from `"ProfessionalService"` to `["LocalBusiness", "ProfessionalService"]` on 20 pages to enable Google local business rich results and Knowledge Panel eligibility while keeping schema specificity.

- **Bug Fixes**
  - Replaced standalone `"ProfessionalService"` with the array in schema on service pages (London/Windsor), service hubs, contact, and services index.
  - Preserves `ProfessionalService` for Schema.org context and adds `LocalBusiness` for Google recognition.

<sup>Written for commit 1f4e52126ecf2103c7493a39613cb06100790e0b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

