### PR TITLE
feat(seo): add 4 London service landing pages (litigation, estate, divorce, property tax)

### DIFF
--- a/london/divorce-appraisal/index.html
+++ b/london/divorce-appraisal/index.html
@@ -1,0 +1,382 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Divorce & Matrimonial Property Appraisals London Ontario | Metrix Realty</title>
+    <link rel="icon" type="image/png" href="/favicon.png">
+    <meta name="description" content="Independent property appraisals for divorce and separation proceedings in London, Ontario. AACI-designated appraisers for matrimonial home and family law valuations.">
+    <link rel="canonical" href="https://metrixrealty.com/london/divorce-appraisal">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Metrix Realty Group">
+    <meta property="og:title" content="Divorce & Matrimonial Property Appraisals London Ontario | Metrix Realty">
+    <meta property="og:description" content="Independent property appraisals for divorce and separation proceedings in London, Ontario. AACI-designated appraisers for matrimonial home and family law valuations.">
+    <meta property="og:url" content="https://metrixrealty.com/london/divorce-appraisal">
+    <meta property="og:image" content="https://metrixrealty.com/assets/images/metrix-realty-logo.png">
+    <meta name="twitter:card" content="summary_large_image">
+
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: { 'metrix-blue': '#233c75', 'metrix-blue-light': '#3d5a9e', 'metrix-blue-dark': '#1a2d5a', 'metrix-green': '#3faa4d' },
+                    fontFamily: { 'inter': ['Inter', 'sans-serif'] }
+                }
+            }
+        }
+    </script>
+    <style>
+        body { font-family: 'Inter', sans-serif; }
+        .bg-hero { background: linear-gradient(135deg, #233c75 0%, #1a2d5a 70%, #3faa4d 100%); }
+        .mobile-menu { position: fixed; top: 0; right: 0; height: 100vh; width: 320px; background: #ffffff; box-shadow: -10px 0 25px rgba(0,0,0,0.15); z-index: 99999; transform: translateX(100%); transition: transform 0.3s ease; }
+        .mobile-menu.open { transform: translateX(0); }
+        .mobile-menu-close { position: absolute; top: 24px; right: 24px; background: none; border: none; padding: 8px; cursor: pointer; color: #9ca3af; border-radius: 8px; }
+        .mobile-menu-content { padding: 80px 32px 32px; height: 100%; overflow-y: auto; }
+        .mobile-nav { display: flex; flex-direction: column; gap: 8px; }
+        .mobile-nav-link { display: block; padding: 16px 0; color: #374151; font-weight: 500; font-size: 18px; text-decoration: none; border-bottom: 1px solid #f3f4f6; transition: all 0.2s ease; }
+        .mobile-nav-link:hover { color: #233c75; }
+        .mobile-menu-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 99998; opacity: 0; visibility: hidden; transition: all 0.3s ease; }
+        .mobile-menu-overlay.show { opacity: 1; visibility: visible; }
+        body.menu-open { overflow: hidden; }
+        .nav-link { position: relative; transition: all 0.3s ease; }
+        .nav-link::after { content: ''; position: absolute; bottom: -2px; left: 0; width: 0; height: 2px; background: #233c75; transition: width 0.3s ease; }
+        .nav-link:hover::after { width: 100%; }
+        .nav-link:hover { color: #233c75; }
+        .feature-card { transition: all 0.3s ease; border: 1px solid #e5e7eb; }
+        .feature-card:hover { transform: translateY(-3px); box-shadow: 0 10px 25px rgba(35,60,117,0.1); border-color: #233c75; }
+    </style>
+
+    <!-- Structured Data -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Service",
+      "name": "Divorce & Matrimonial Property Appraisals — London, Ontario",
+      "url": "https://metrixrealty.com/london/divorce-appraisal",
+      "serviceType": "Matrimonial Property Appraisal",
+      "description": "Independent property appraisals for divorce, separation, and family law proceedings in London and Southwestern Ontario. Joint and single-party retainer appointments available.",
+      "provider": {
+        "@type": ["LocalBusiness", "ProfessionalService"],
+        "name": "Metrix Realty Group",
+        "url": "https://metrixrealty.com/",
+        "telephone": "+15196727550",
+        "address": {
+          "@type": "PostalAddress",
+          "streetAddress": "620A Richmond Street, Suite 203",
+          "addressLocality": "London",
+          "addressRegion": "ON",
+          "postalCode": "N6A 5J9",
+          "addressCountry": "CA"
+        }
+      },
+      "areaServed": {
+        "@type": "Place",
+        "name": "London, Ontario and Southwestern Ontario"
+      }
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://metrixrealty.com/"},
+        {"@type": "ListItem", "position": 2, "name": "London", "item": "https://metrixrealty.com/london/"},
+        {"@type": "ListItem", "position": 3, "name": "Divorce Appraisal", "item": "https://metrixrealty.com/london/divorce-appraisal"}
+      ]
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "Do both spouses need separate appraisers for a divorce property valuation?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Not necessarily. An independent appraisal on a jointly retained basis — where both parties agree on the appraiser before the assignment is completed — is recognized under the Ontario Family Law Act and can reduce the cost and conflict associated with competing appraisals. In contested matters, each party may retain their own appraiser. Metrix can work under either arrangement."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "What value date is used for a matrimonial property appraisal in Ontario?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Under Ontario's Family Law Act, the equalization calculation is based on the net family property as of the valuation date, which is the date of separation. A retrospective appraisal is often required to establish the property's market value as of that date, which may be months or years prior to the date the appraisal is ordered."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Can Metrix appraise commercial or investment property in a divorce?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Yes. Metrix's AACI-designated appraisers are authorized to appraise all property types including commercial, industrial, multi-family rental, and development land. This is important in complex divorces involving business-related real estate, rental portfolios, or mixed-use assets that a residential-only appraiser may not be qualified to value."
+          }
+        }
+      ]
+    }
+    </script>
+</head>
+<body class="bg-white">
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+
+    <div id="mobile-menu-overlay" class="mobile-menu-overlay"></div>
+
+    <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
+        <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center justify-between h-16 sm:h-20">
+                <div class="flex-shrink-0">
+                    <a href="/"><img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto"></a>
+                </div>
+                <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
+                    <a href="/" class="nav-link text-gray-900 font-semibold">Home</a>
+                    <a href="/services" class="nav-link text-gray-900 font-semibold">Services</a>
+                    <a href="/market-areas" class="nav-link text-gray-900 font-semibold">Market Areas</a>
+                    <a href="/team" class="nav-link text-gray-900 font-semibold">Team</a>
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold">Contact</a>
+                </div>
+                <div class="hidden md:block">
+                    <a href="/contact" class="inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors">Connect with an Appraiser</a>
+                </div>
+                <div class="md:hidden">
+                    <button id="mobile-menu-button" class="text-gray-900 p-2" aria-label="Toggle menu">
+                        <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
+                            <span class="block h-0.5 w-6 bg-current transition-all"></span>
+                            <span class="block h-0.5 w-6 bg-current transition-all"></span>
+                            <span class="block h-0.5 w-6 bg-current transition-all"></span>
+                        </div>
+                    </button>
+                </div>
+            </div>
+        </nav>
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
+            </button>
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link">Team</a>
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+                    <div style="margin-top:32px">
+                        <a href="/contact" class="block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg">Connect with an Appraiser</a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <div class="h-16 sm:h-20"></div>
+
+    <!-- Breadcrumb -->
+    <div class="bg-gray-50 border-b">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+            <nav class="flex text-sm" aria-label="Breadcrumb">
+                <ol class="inline-flex items-center space-x-2">
+                    <li><a href="/" class="text-gray-500 hover:text-metrix-blue">Home</a></li>
+                    <li><span class="text-gray-400 mx-1">/</span></li>
+                    <li><a href="/london/" class="text-gray-500 hover:text-metrix-blue">London</a></li>
+                    <li><span class="text-gray-400 mx-1">/</span></li>
+                    <li><span class="text-gray-700 font-medium">Divorce Appraisal</span></li>
+                </ol>
+            </nav>
+        </div>
+    </div>
+
+    <!-- Hero -->
+    <section class="bg-hero text-white py-16 md:py-24">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="max-w-3xl">
+                <div class="inline-flex items-center px-3 py-1 bg-white/10 rounded-full text-sm font-medium mb-6">London, Ontario</div>
+                <h1 class="text-4xl md:text-5xl font-bold mb-6 leading-tight">Divorce & Matrimonial Property Appraisals<br>in London, Ontario</h1>
+                <p class="text-xl text-gray-200 mb-8 leading-relaxed">Independent property valuations for divorce, separation, and family law proceedings. AACI-designated appraisers serving London and Southwestern Ontario.</p>
+                <a href="/contact" class="inline-block bg-white text-metrix-blue px-8 py-4 rounded-lg font-semibold hover:bg-gray-100 transition-colors">Request a Matrimonial Appraisal</a>
+            </div>
+        </div>
+    </section>
+
+    <!-- Main Content -->
+    <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 md:py-24">
+
+        <!-- Intro -->
+        <div class="max-w-3xl mb-16">
+            <h2 class="text-3xl font-bold text-gray-900 mb-6">Property Valuations for Divorce and Separation in London</h2>
+            <p class="text-lg text-gray-600 leading-relaxed mb-6">When a marriage or common-law relationship ends, dividing property fairly requires an accurate, independent assessment of what each asset is worth. Real estate is typically the largest asset in a family law matter — and the value is rarely self-evident. A formal appraisal from an AACI-designated appraiser provides a defensible, CUSPAP-compliant value opinion that both parties and their lawyers can rely on.</p>
+            <p class="text-lg text-gray-600 leading-relaxed mb-6">Under Ontario's <em>Family Law Act</em>, the equalization of net family property is calculated as of the valuation date — typically the date of separation. A retrospective appraisal may be required to establish what a property was worth on that date, which may be months or years before the appraisal is ordered.</p>
+            <p class="text-lg text-gray-600 leading-relaxed">Metrix Realty Group serves family law lawyers, mediators, collaborative lawyers, and self-represented parties across London, Middlesex County, and Southwestern Ontario. We provide joint retainer and single-party appraisals for all property types.</p>
+        </div>
+
+        <!-- Services Grid -->
+        <div class="mb-16">
+            <h2 class="text-3xl font-bold text-gray-900 mb-8">Matrimonial Appraisal Services</h2>
+            <div class="grid md:grid-cols-2 gap-6">
+                <div class="feature-card bg-white rounded-xl p-6">
+                    <h3 class="text-lg font-bold text-gray-900 mb-3">Matrimonial Home Appraisal</h3>
+                    <p class="text-gray-600 leading-relaxed">Market value opinion for the primary residence at the date of separation or current date, depending on the needs of the file. Suitable for negotiated settlements, mediation, collaborative law, and contested court proceedings.</p>
+                </div>
+                <div class="feature-card bg-white rounded-xl p-6">
+                    <h3 class="text-lg font-bold text-gray-900 mb-3">Retrospective Valuations</h3>
+                    <p class="text-gray-600 leading-relaxed">Historical market value opinions as of the date of separation, marriage, or any other legally relevant date. Retrospective appraisals are supported by historical market data and prepared in compliance with CUSPAP.</p>
+                </div>
+                <div class="feature-card bg-white rounded-xl p-6">
+                    <h3 class="text-lg font-bold text-gray-900 mb-3">Joint Retainer Appointments</h3>
+                    <p class="text-gray-600 leading-relaxed">Single appraisal jointly retained by both parties, reducing the cost and adversarial dynamic of competing appraisals. Widely used in collaborative family law and mediated settlement processes in Ontario.</p>
+                </div>
+                <div class="feature-card bg-white rounded-xl p-6">
+                    <h3 class="text-lg font-bold text-gray-900 mb-3">Commercial & Investment Property</h3>
+                    <p class="text-gray-600 leading-relaxed">For complex estates involving commercial property, rental income portfolios, or investment real estate, Metrix's AACI designation authorizes appraisal of all property types — a capability that residential-only appraisers do not have.</p>
+                </div>
+            </div>
+        </div>
+
+        <!-- Independence note -->
+        <div class="bg-gray-50 rounded-2xl p-8 md:p-12 mb-16">
+            <h2 class="text-3xl font-bold text-gray-900 mb-6">What Makes a Matrimonial Appraisal Defensible</h2>
+            <p class="text-lg text-gray-600 leading-relaxed mb-6">In a contested divorce, a property value can be challenged by the opposing party's appraiser. The quality and credibility of the appraisal determines how well it holds up under scrutiny. Metrix appraisals are prepared by AACI-designated appraisers, comply fully with CUSPAP, and document all data and analysis used to support the value conclusion — meeting the disclosure standard courts expect from expert reports.</p>
+            <div class="grid md:grid-cols-3 gap-6 mt-8">
+                <div class="text-center">
+                    <div class="w-12 h-12 bg-metrix-blue/10 rounded-xl flex items-center justify-center mx-auto mb-3">
+                        <svg class="w-6 h-6 text-metrix-blue" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path></svg>
+                    </div>
+                    <h3 class="font-semibold text-gray-900 mb-2">CUSPAP Compliant</h3>
+                    <p class="text-gray-600 text-sm">Every report prepared under mandatory AIC professional standards.</p>
+                </div>
+                <div class="text-center">
+                    <div class="w-12 h-12 bg-metrix-blue/10 rounded-xl flex items-center justify-center mx-auto mb-3">
+                        <svg class="w-6 h-6 text-metrix-blue" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3"></path></svg>
+                    </div>
+                    <h3 class="font-semibold text-gray-900 mb-2">Fully Independent</h3>
+                    <p class="text-gray-600 text-sm">No contingent fees, no advocacy — an objective opinion of market value.</p>
+                </div>
+                <div class="text-center">
+                    <div class="w-12 h-12 bg-metrix-blue/10 rounded-xl flex items-center justify-center mx-auto mb-3">
+                        <svg class="w-6 h-6 text-metrix-blue" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 14v3m4-3v3m4-3v3M3 21h18M3 10h18M3 7l9-4 9 4M4 10h16v11H4V10z"></path></svg>
+                    </div>
+                    <h3 class="font-semibold text-gray-900 mb-2">Court-Ready</h3>
+                    <p class="text-gray-600 text-sm">Reports structured to meet expert witness disclosure requirements for Ontario court proceedings.</p>
+                </div>
+            </div>
+        </div>
+
+        <!-- FAQ -->
+        <div class="mb-16">
+            <h2 class="text-3xl font-bold text-gray-900 mb-8">Frequently Asked Questions</h2>
+            <div class="space-y-6">
+                <div class="border border-gray-200 rounded-xl p-6">
+                    <h3 class="font-semibold text-gray-900 mb-3">Do both spouses need separate appraisers for a divorce property valuation?</h3>
+                    <p class="text-gray-600">Not necessarily. An independent appraisal on a jointly retained basis — where both parties agree on the appraiser before the assignment is completed — is recognized under the Ontario Family Law Act and can reduce the cost and conflict associated with competing appraisals. In contested matters, each party may retain their own appraiser. Metrix can work under either arrangement.</p>
+                </div>
+                <div class="border border-gray-200 rounded-xl p-6">
+                    <h3 class="font-semibold text-gray-900 mb-3">What value date is used for a matrimonial property appraisal in Ontario?</h3>
+                    <p class="text-gray-600">Under Ontario's Family Law Act, the equalization calculation is based on net family property as of the valuation date — the date of separation. A retrospective appraisal is often required to establish the property's market value as of that date, which may be months or years prior to when the appraisal is ordered.</p>
+                </div>
+                <div class="border border-gray-200 rounded-xl p-6">
+                    <h3 class="font-semibold text-gray-900 mb-3">Can Metrix appraise commercial or investment property in a divorce?</h3>
+                    <p class="text-gray-600">Yes. Metrix's AACI-designated appraisers are authorized to appraise all property types including commercial, industrial, multi-family rental, and development land. This is important in complex divorces involving business-related real estate, rental portfolios, or mixed-use assets that a residential-only appraiser may not be qualified to value.</p>
+                </div>
+            </div>
+        </div>
+
+        <!-- CTA -->
+        <div class="bg-gradient-to-r from-metrix-blue to-metrix-blue-dark rounded-2xl p-8 md:p-12 text-white text-center">
+            <h2 class="text-3xl font-bold mb-4">Need a Divorce Property Appraisal in London, Ontario?</h2>
+            <p class="text-xl text-gray-200 mb-8 max-w-2xl mx-auto">Contact Metrix to discuss the property, the required valuation date, and whether a joint or single-party retainer is appropriate for your file.</p>
+            <div class="flex flex-col sm:flex-row gap-4 justify-center">
+                <a href="/contact" class="inline-block bg-white text-metrix-blue px-8 py-4 rounded-lg font-semibold hover:bg-gray-100 transition-colors">Request a Consultation</a>
+                <a href="/services/litigation-support-expert-testimony" class="inline-block border-2 border-white text-white px-8 py-4 rounded-lg font-semibold hover:bg-white/10 transition-colors">View Litigation Services</a>
+            </div>
+        </div>
+    </main>
+
+    <!-- Footer -->
+    <footer class="bg-black text-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
+                <div class="lg:col-span-1">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-4">Trusted • Valued • Experienced</p>
+                    <div class="text-gray-300 text-sm">
+                        <p class="font-semibold text-white mb-1">620A Richmond Street, Suite 203</p>
+                        <p class="mb-3">London, ON N6A 5J9</p>
+                        <p><a href="tel:519-672-7550" class="text-white hover:text-gray-200">(519) 672-7550</a></p>
+                        <p>Toll Free: 1-866-672-9101</p>
+                        <p class="mt-2"><a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200">info@metrixrealty.com</a></p>
+                    </div>
+                </div>
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
+                    <ul class="space-y-3 text-gray-300 text-sm">
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors">Government & Institutional</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">London, Ontario</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/london/commercial-appraisal" class="hover:text-white transition-colors">Commercial Appraisal</a></li>
+                        <li><a href="/london/residential-appraisal" class="hover:text-white transition-colors">Residential Appraisal</a></li>
+                        <li><a href="/london/industrial-appraisal" class="hover:text-white transition-colors">Industrial Appraisal</a></li>
+                        <li><a href="/london/litigation-support" class="hover:text-white transition-colors">Litigation Support</a></li>
+                        <li><a href="/london/estate-appraisal" class="hover:text-white transition-colors">Estate Appraisal</a></li>
+                        <li><a href="/london/divorce-appraisal" class="hover:text-white transition-colors font-semibold text-white">Divorce Appraisal</a></li>
+                        <li><a href="/london/property-tax-appeal" class="hover:text-white transition-colors">Property Tax Appeal</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/team" class="hover:text-white transition-colors">Our Team</a></li>
+                        <li><a href="/insights/" class="hover:text-white transition-colors">Market Insights</a></li>
+                        <li><a href="/contact" class="hover:text-white transition-colors">Contact</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors">Windsor Office</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="border-t border-gray-800 pt-8 text-center">
+                <p class="text-sm text-gray-400 mb-2">Professional Affiliations: AIC — Appraisal Institute of Canada &nbsp;|&nbsp; RICS — Royal Institution of Chartered Surveyors &nbsp;|&nbsp; AOLE &nbsp;|&nbsp; IRWA</p>
+                <p class="text-sm text-gray-400 mb-4">Reports completed in compliance with <a href="https://www.aicanada.ca/about-aic/cuspap/" target="_blank" rel="noopener noreferrer" class="hover:text-gray-300">CUSPAP</a></p>
+                <p class="text-sm text-gray-500">&copy; 2026 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-3 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-500 hover:text-gray-400 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-500 hover:text-gray-400 text-sm">Terms of Service</a>
+                    <a href="/llms.txt" class="text-gray-500 hover:text-gray-400 text-sm">LLMs.txt</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script>
+        const mobileMenuBtn = document.getElementById('mobile-menu-button');
+        const mobileMenu = document.getElementById('mobile-menu');
+        const mobileMenuOverlay = document.getElementById('mobile-menu-overlay');
+        const mobileMenuClose = document.getElementById('mobile-menu-close');
+        function openMenu() { mobileMenu.classList.add('open'); mobileMenuOverlay.classList.add('show'); document.body.classList.add('menu-open'); }
+        function closeMenu() { mobileMenu.classList.remove('open'); mobileMenuOverlay.classList.remove('show'); document.body.classList.remove('menu-open'); }
+        if (mobileMenuBtn) mobileMenuBtn.addEventListener('click', openMenu);
+        if (mobileMenuClose) mobileMenuClose.addEventListener('click', closeMenu);
+        if (mobileMenuOverlay) mobileMenuOverlay.addEventListener('click', closeMenu);
+        document.addEventListener('keydown', e => { if (e.key === 'Escape') closeMenu(); });
+    </script>
+    <script src="/assets/js/analytics-tracking.js"></script>
+</body>
+</html>

--- a/london/estate-appraisal/index.html
+++ b/london/estate-appraisal/index.html
@@ -1,0 +1,375 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Estate & Probate Appraisals London Ontario | Metrix Realty</title>
+    <link rel="icon" type="image/png" href="/favicon.png">
+    <meta name="description" content="Estate and probate property appraisals in London, Ontario. Date-of-death valuations, CRA fair market value, and retrospective appraisals by AACI-designated appraisers.">
+    <link rel="canonical" href="https://metrixrealty.com/london/estate-appraisal">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Metrix Realty Group">
+    <meta property="og:title" content="Estate & Probate Appraisals London Ontario | Metrix Realty">
+    <meta property="og:description" content="Estate and probate property appraisals in London, Ontario. Date-of-death valuations, CRA fair market value, and retrospective appraisals by AACI-designated appraisers.">
+    <meta property="og:url" content="https://metrixrealty.com/london/estate-appraisal">
+    <meta property="og:image" content="https://metrixrealty.com/assets/images/metrix-realty-logo.png">
+    <meta name="twitter:card" content="summary_large_image">
+
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: { 'metrix-blue': '#233c75', 'metrix-blue-light': '#3d5a9e', 'metrix-blue-dark': '#1a2d5a', 'metrix-green': '#3faa4d' },
+                    fontFamily: { 'inter': ['Inter', 'sans-serif'] }
+                }
+            }
+        }
+    </script>
+    <style>
+        body { font-family: 'Inter', sans-serif; }
+        .bg-hero { background: linear-gradient(135deg, #233c75 0%, #1a2d5a 70%, #3faa4d 100%); }
+        .mobile-menu { position: fixed; top: 0; right: 0; height: 100vh; width: 320px; background: #ffffff; box-shadow: -10px 0 25px rgba(0,0,0,0.15); z-index: 99999; transform: translateX(100%); transition: transform 0.3s ease; }
+        .mobile-menu.open { transform: translateX(0); }
+        .mobile-menu-close { position: absolute; top: 24px; right: 24px; background: none; border: none; padding: 8px; cursor: pointer; color: #9ca3af; border-radius: 8px; }
+        .mobile-menu-content { padding: 80px 32px 32px; height: 100%; overflow-y: auto; }
+        .mobile-nav { display: flex; flex-direction: column; gap: 8px; }
+        .mobile-nav-link { display: block; padding: 16px 0; color: #374151; font-weight: 500; font-size: 18px; text-decoration: none; border-bottom: 1px solid #f3f4f6; transition: all 0.2s ease; }
+        .mobile-nav-link:hover { color: #233c75; }
+        .mobile-menu-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 99998; opacity: 0; visibility: hidden; transition: all 0.3s ease; }
+        .mobile-menu-overlay.show { opacity: 1; visibility: visible; }
+        body.menu-open { overflow: hidden; }
+        .nav-link { position: relative; transition: all 0.3s ease; }
+        .nav-link::after { content: ''; position: absolute; bottom: -2px; left: 0; width: 0; height: 2px; background: #233c75; transition: width 0.3s ease; }
+        .nav-link:hover::after { width: 100%; }
+        .nav-link:hover { color: #233c75; }
+        .feature-card { transition: all 0.3s ease; border: 1px solid #e5e7eb; }
+        .feature-card:hover { transform: translateY(-3px); box-shadow: 0 10px 25px rgba(35,60,117,0.1); border-color: #233c75; }
+    </style>
+
+    <!-- Structured Data -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Service",
+      "name": "Estate & Probate Appraisals — London, Ontario",
+      "url": "https://metrixrealty.com/london/estate-appraisal",
+      "serviceType": "Estate Property Appraisal",
+      "description": "Date-of-death valuations, probate appraisals, and CRA fair market value opinions for estate administration in London and Southwestern Ontario.",
+      "provider": {
+        "@type": ["LocalBusiness", "ProfessionalService"],
+        "name": "Metrix Realty Group",
+        "url": "https://metrixrealty.com/",
+        "telephone": "+15196727550",
+        "address": {
+          "@type": "PostalAddress",
+          "streetAddress": "620A Richmond Street, Suite 203",
+          "addressLocality": "London",
+          "addressRegion": "ON",
+          "postalCode": "N6A 5J9",
+          "addressCountry": "CA"
+        }
+      },
+      "areaServed": {
+        "@type": "Place",
+        "name": "London, Ontario and Southwestern Ontario"
+      }
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://metrixrealty.com/"},
+        {"@type": "ListItem", "position": 2, "name": "London", "item": "https://metrixrealty.com/london/"},
+        {"@type": "ListItem", "position": 3, "name": "Estate Appraisal", "item": "https://metrixrealty.com/london/estate-appraisal"}
+      ]
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "What is a date-of-death appraisal and when is it required?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "A date-of-death appraisal establishes the fair market value of a property as of the date a person passed away. In Canada, this value is used to calculate the deemed disposition gain for income tax purposes on the deceased's final return, and to establish the adjusted cost base for beneficiaries. Estate trustees, executors, and estate lawyers in Ontario typically require a date-of-death appraisal from an AACI-designated appraiser to satisfy CRA documentation requirements."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Can an appraisal be done retroactively for an estate?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Yes. A retrospective appraisal establishes market value as of a historical effective date rather than the current date. For estate purposes, the effective date is typically the date of death. CUSPAP permits retrospective appraisals when sufficient historical market data exists to support a credible value opinion as of the specified past date."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "What property types does Metrix appraise for estate purposes in London?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Metrix appraises all property types for estate and probate purposes in the London area, including single-family homes, condominiums, rental properties, commercial buildings, agricultural land, and vacant lots. The AACI designation held by Metrix appraisers authorizes them to appraise all property types — unlike a CRA-designated appraiser who is limited to residential properties."
+          }
+        }
+      ]
+    }
+    </script>
+</head>
+<body class="bg-white">
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+
+    <div id="mobile-menu-overlay" class="mobile-menu-overlay"></div>
+
+    <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
+        <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center justify-between h-16 sm:h-20">
+                <div class="flex-shrink-0">
+                    <a href="/"><img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto"></a>
+                </div>
+                <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
+                    <a href="/" class="nav-link text-gray-900 font-semibold">Home</a>
+                    <a href="/services" class="nav-link text-gray-900 font-semibold">Services</a>
+                    <a href="/market-areas" class="nav-link text-gray-900 font-semibold">Market Areas</a>
+                    <a href="/team" class="nav-link text-gray-900 font-semibold">Team</a>
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold">Contact</a>
+                </div>
+                <div class="hidden md:block">
+                    <a href="/contact" class="inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors">Connect with an Appraiser</a>
+                </div>
+                <div class="md:hidden">
+                    <button id="mobile-menu-button" class="text-gray-900 p-2" aria-label="Toggle menu">
+                        <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
+                            <span class="block h-0.5 w-6 bg-current transition-all"></span>
+                            <span class="block h-0.5 w-6 bg-current transition-all"></span>
+                            <span class="block h-0.5 w-6 bg-current transition-all"></span>
+                        </div>
+                    </button>
+                </div>
+            </div>
+        </nav>
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
+            </button>
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link">Team</a>
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+                    <div style="margin-top:32px">
+                        <a href="/contact" class="block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg">Connect with an Appraiser</a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <div class="h-16 sm:h-20"></div>
+
+    <!-- Breadcrumb -->
+    <div class="bg-gray-50 border-b">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+            <nav class="flex text-sm" aria-label="Breadcrumb">
+                <ol class="inline-flex items-center space-x-2">
+                    <li><a href="/" class="text-gray-500 hover:text-metrix-blue">Home</a></li>
+                    <li><span class="text-gray-400 mx-1">/</span></li>
+                    <li><a href="/london/" class="text-gray-500 hover:text-metrix-blue">London</a></li>
+                    <li><span class="text-gray-400 mx-1">/</span></li>
+                    <li><span class="text-gray-700 font-medium">Estate Appraisal</span></li>
+                </ol>
+            </nav>
+        </div>
+    </div>
+
+    <!-- Hero -->
+    <section class="bg-hero text-white py-16 md:py-24">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="max-w-3xl">
+                <div class="inline-flex items-center px-3 py-1 bg-white/10 rounded-full text-sm font-medium mb-6">London, Ontario</div>
+                <h1 class="text-4xl md:text-5xl font-bold mb-6 leading-tight">Estate & Probate Appraisals<br>in London, Ontario</h1>
+                <p class="text-xl text-gray-200 mb-8 leading-relaxed">Date-of-death valuations, CRA fair market value opinions, and retrospective appraisals for estate trustees, lawyers, and executors in London and Southwestern Ontario.</p>
+                <a href="/contact" class="inline-block bg-white text-metrix-blue px-8 py-4 rounded-lg font-semibold hover:bg-gray-100 transition-colors">Request an Estate Appraisal</a>
+            </div>
+        </div>
+    </section>
+
+    <!-- Main Content -->
+    <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 md:py-24">
+
+        <!-- Intro -->
+        <div class="max-w-3xl mb-16">
+            <h2 class="text-3xl font-bold text-gray-900 mb-6">Appraisals for Estate Administration in London, Ontario</h2>
+            <p class="text-lg text-gray-600 leading-relaxed mb-6">When a property owner passes away, the estate trustee or executor is typically required to establish the fair market value of any real estate held by the deceased. This value is needed for the deceased's final income tax return, for probate purposes, and — where the property is being distributed or sold — to establish the adjusted cost base for beneficiaries.</p>
+            <p class="text-lg text-gray-600 leading-relaxed mb-6">The Canada Revenue Agency (CRA) requires that estate property valuations be prepared at fair market value as of the date of death (or an alternative valuation date in specific circumstances). A formal appraisal from an AACI-designated appraiser provides the documentation required to support these figures in a CRA review or audit.</p>
+            <p class="text-lg text-gray-600 leading-relaxed">Metrix Realty Group serves estate lawyers, notaries, trust companies, and executors across London, Middlesex County, and Southwestern Ontario. Our AACI-designated appraisers provide retrospective valuations dated to any historical effective date.</p>
+        </div>
+
+        <!-- Services -->
+        <div class="mb-16">
+            <h2 class="text-3xl font-bold text-gray-900 mb-8">Estate Appraisal Services</h2>
+            <div class="grid md:grid-cols-2 gap-6">
+                <div class="feature-card bg-white rounded-xl p-6">
+                    <h3 class="text-lg font-bold text-gray-900 mb-3">Date-of-Death Valuations</h3>
+                    <p class="text-gray-600 leading-relaxed">Market value opinions as of the date the property owner passed away. Used for the deemed disposition calculation on the terminal return and for establishing cost base for beneficiaries. All reports prepared in compliance with CUSPAP and accepted by CRA.</p>
+                </div>
+                <div class="feature-card bg-white rounded-xl p-6">
+                    <h3 class="text-lg font-bold text-gray-900 mb-3">Probate & Court of Estate Trustee</h3>
+                    <p class="text-gray-600 leading-relaxed">Appraisals for the Ontario Court of Justice probate process. Value opinions for Schedule A of the Estate Information Return, prepared at a level of detail appropriate for court submission.</p>
+                </div>
+                <div class="feature-card bg-white rounded-xl p-6">
+                    <h3 class="text-lg font-bold text-gray-900 mb-3">CRA Capital Gains Reporting</h3>
+                    <p class="text-gray-600 leading-relaxed">Appraisals supporting capital gains calculations on inherited property, including valuations at the time of death and at the time of subsequent disposition. CUSPAP-compliant reports accepted by CRA reviewers and auditors.</p>
+                </div>
+                <div class="feature-card bg-white rounded-xl p-6">
+                    <h3 class="text-lg font-bold text-gray-900 mb-3">All Property Types</h3>
+                    <p class="text-gray-600 leading-relaxed">Residential homes, condominiums, multi-family rental properties, commercial buildings, vacant land, agricultural properties, and cottages. The AACI designation authorizes Metrix appraisers to complete valuations on any property type — including commercial assets that a CRA-designated appraiser is not authorized to appraise.</p>
+                </div>
+            </div>
+        </div>
+
+        <!-- Process -->
+        <div class="bg-gray-50 rounded-2xl p-8 md:p-12 mb-16">
+            <h2 class="text-3xl font-bold text-gray-900 mb-8">What to Expect When Ordering an Estate Appraisal</h2>
+            <div class="grid md:grid-cols-3 gap-8">
+                <div class="text-center">
+                    <div class="w-12 h-12 bg-metrix-blue rounded-full flex items-center justify-center text-white font-bold text-xl mx-auto mb-4">1</div>
+                    <h3 class="font-semibold text-gray-900 mb-2">Contact Metrix</h3>
+                    <p class="text-gray-600 text-sm">Provide the property address, the required effective date (date of death), and the intended use of the report — CRA, probate, beneficiary distribution, or other.</p>
+                </div>
+                <div class="text-center">
+                    <div class="w-12 h-12 bg-metrix-blue rounded-full flex items-center justify-center text-white font-bold text-xl mx-auto mb-4">2</div>
+                    <h3 class="font-semibold text-gray-900 mb-2">Property Review</h3>
+                    <p class="text-gray-600 text-sm">The appraiser researches historical market data and, where access is available, inspects the property (or completes a desk review where inspection is not possible or necessary).</p>
+                </div>
+                <div class="text-center">
+                    <div class="w-12 h-12 bg-metrix-blue rounded-full flex items-center justify-center text-white font-bold text-xl mx-auto mb-4">3</div>
+                    <h3 class="font-semibold text-gray-900 mb-2">Report Delivery</h3>
+                    <p class="text-gray-600 text-sm">A CUSPAP-compliant appraisal report is delivered identifying the authorized client, authorized users, intended use, effective date, and supported value conclusion — everything CRA expects to see.</p>
+                </div>
+            </div>
+        </div>
+
+        <!-- FAQ -->
+        <div class="mb-16">
+            <h2 class="text-3xl font-bold text-gray-900 mb-8">Frequently Asked Questions</h2>
+            <div class="space-y-6">
+                <div class="border border-gray-200 rounded-xl p-6">
+                    <h3 class="font-semibold text-gray-900 mb-3">What is a date-of-death appraisal and when is it required?</h3>
+                    <p class="text-gray-600">A date-of-death appraisal establishes the fair market value of a property as of the date a person passed away. In Canada, this value is used to calculate the deemed disposition gain for income tax purposes on the deceased's final return, and to establish the adjusted cost base for beneficiaries. Estate trustees, executors, and estate lawyers in Ontario typically require a date-of-death appraisal from an AACI-designated appraiser to satisfy CRA documentation requirements.</p>
+                </div>
+                <div class="border border-gray-200 rounded-xl p-6">
+                    <h3 class="font-semibold text-gray-900 mb-3">Can an appraisal be done retroactively for an estate?</h3>
+                    <p class="text-gray-600">Yes. A retrospective appraisal establishes market value as of a historical effective date rather than the current date. For estate purposes, the effective date is typically the date of death. CUSPAP permits retrospective appraisals when sufficient historical market data exists to support a credible value opinion as of the specified past date.</p>
+                </div>
+                <div class="border border-gray-200 rounded-xl p-6">
+                    <h3 class="font-semibold text-gray-900 mb-3">What property types does Metrix appraise for estate purposes in London?</h3>
+                    <p class="text-gray-600">Metrix appraises all property types for estate and probate purposes in the London area, including single-family homes, condominiums, rental properties, commercial buildings, agricultural land, and vacant lots. The AACI designation authorizes Metrix appraisers to appraise all property types — unlike a CRA-designated appraiser who is limited to residential properties.</p>
+                </div>
+            </div>
+        </div>
+
+        <!-- CTA -->
+        <div class="bg-gradient-to-r from-metrix-blue to-metrix-blue-dark rounded-2xl p-8 md:p-12 text-white text-center">
+            <h2 class="text-3xl font-bold mb-4">Need an Estate Appraisal in London, Ontario?</h2>
+            <p class="text-xl text-gray-200 mb-8 max-w-2xl mx-auto">Contact Metrix to discuss the property, the required effective date, and the intended use. We work with estate lawyers, trust companies, and executors across the London area.</p>
+            <div class="flex flex-col sm:flex-row gap-4 justify-center">
+                <a href="/contact" class="inline-block bg-white text-metrix-blue px-8 py-4 rounded-lg font-semibold hover:bg-gray-100 transition-colors">Request a Consultation</a>
+                <a href="/services/residential-property-appraisals" class="inline-block border-2 border-white text-white px-8 py-4 rounded-lg font-semibold hover:bg-white/10 transition-colors">View Residential Services</a>
+            </div>
+        </div>
+    </main>
+
+    <!-- Footer -->
+    <footer class="bg-black text-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
+                <div class="lg:col-span-1">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-4">Trusted • Valued • Experienced</p>
+                    <div class="text-gray-300 text-sm">
+                        <p class="font-semibold text-white mb-1">620A Richmond Street, Suite 203</p>
+                        <p class="mb-3">London, ON N6A 5J9</p>
+                        <p><a href="tel:519-672-7550" class="text-white hover:text-gray-200">(519) 672-7550</a></p>
+                        <p>Toll Free: 1-866-672-9101</p>
+                        <p class="mt-2"><a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200">info@metrixrealty.com</a></p>
+                    </div>
+                </div>
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
+                    <ul class="space-y-3 text-gray-300 text-sm">
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors">Government & Institutional</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">London, Ontario</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/london/commercial-appraisal" class="hover:text-white transition-colors">Commercial Appraisal</a></li>
+                        <li><a href="/london/residential-appraisal" class="hover:text-white transition-colors">Residential Appraisal</a></li>
+                        <li><a href="/london/industrial-appraisal" class="hover:text-white transition-colors">Industrial Appraisal</a></li>
+                        <li><a href="/london/litigation-support" class="hover:text-white transition-colors">Litigation Support</a></li>
+                        <li><a href="/london/estate-appraisal" class="hover:text-white transition-colors font-semibold text-white">Estate Appraisal</a></li>
+                        <li><a href="/london/divorce-appraisal" class="hover:text-white transition-colors">Divorce Appraisal</a></li>
+                        <li><a href="/london/property-tax-appeal" class="hover:text-white transition-colors">Property Tax Appeal</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/team" class="hover:text-white transition-colors">Our Team</a></li>
+                        <li><a href="/insights/" class="hover:text-white transition-colors">Market Insights</a></li>
+                        <li><a href="/contact" class="hover:text-white transition-colors">Contact</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors">Windsor Office</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="border-t border-gray-800 pt-8 text-center">
+                <p class="text-sm text-gray-400 mb-2">Professional Affiliations: AIC — Appraisal Institute of Canada &nbsp;|&nbsp; RICS — Royal Institution of Chartered Surveyors &nbsp;|&nbsp; AOLE &nbsp;|&nbsp; IRWA</p>
+                <p class="text-sm text-gray-400 mb-4">Reports completed in compliance with <a href="https://www.aicanada.ca/about-aic/cuspap/" target="_blank" rel="noopener noreferrer" class="hover:text-gray-300">CUSPAP</a></p>
+                <p class="text-sm text-gray-500">&copy; 2026 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-3 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-500 hover:text-gray-400 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-500 hover:text-gray-400 text-sm">Terms of Service</a>
+                    <a href="/llms.txt" class="text-gray-500 hover:text-gray-400 text-sm">LLMs.txt</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script>
+        const mobileMenuBtn = document.getElementById('mobile-menu-button');
+        const mobileMenu = document.getElementById('mobile-menu');
+        const mobileMenuOverlay = document.getElementById('mobile-menu-overlay');
+        const mobileMenuClose = document.getElementById('mobile-menu-close');
+        function openMenu() { mobileMenu.classList.add('open'); mobileMenuOverlay.classList.add('show'); document.body.classList.add('menu-open'); }
+        function closeMenu() { mobileMenu.classList.remove('open'); mobileMenuOverlay.classList.remove('show'); document.body.classList.remove('menu-open'); }
+        if (mobileMenuBtn) mobileMenuBtn.addEventListener('click', openMenu);
+        if (mobileMenuClose) mobileMenuClose.addEventListener('click', closeMenu);
+        if (mobileMenuOverlay) mobileMenuOverlay.addEventListener('click', closeMenu);
+        document.addEventListener('keydown', e => { if (e.key === 'Escape') closeMenu(); });
+    </script>
+    <script src="/assets/js/analytics-tracking.js"></script>
+</body>
+</html>

--- a/london/litigation-support/index.html
+++ b/london/litigation-support/index.html
@@ -1,0 +1,351 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Litigation Support Appraisals London Ontario | Metrix Realty</title>
+    <link rel="icon" type="image/png" href="/favicon.png">
+    <meta name="description" content="Expert real estate litigation support and appraisals in London, Ontario. AACI-designated appraisers with PLE credentials for court, arbitration, and expropriation matters.">
+    <link rel="canonical" href="https://metrixrealty.com/london/litigation-support">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Metrix Realty Group">
+    <meta property="og:title" content="Litigation Support Appraisals London Ontario | Metrix Realty">
+    <meta property="og:description" content="Expert real estate litigation support and appraisals in London, Ontario. AACI-designated appraisers with PLE credentials for court, arbitration, and expropriation matters.">
+    <meta property="og:url" content="https://metrixrealty.com/london/litigation-support">
+    <meta property="og:image" content="https://metrixrealty.com/assets/images/metrix-realty-logo.png">
+    <meta name="twitter:card" content="summary_large_image">
+
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: { 'metrix-blue': '#233c75', 'metrix-blue-light': '#3d5a9e', 'metrix-blue-dark': '#1a2d5a', 'metrix-green': '#3faa4d' },
+                    fontFamily: { 'inter': ['Inter', 'sans-serif'] }
+                }
+            }
+        }
+    </script>
+    <style>
+        body { font-family: 'Inter', sans-serif; }
+        .bg-hero { background: linear-gradient(135deg, #233c75 0%, #1a2d5a 70%, #3faa4d 100%); }
+        .mobile-menu { position: fixed; top: 0; right: 0; height: 100vh; width: 320px; background: #ffffff; box-shadow: -10px 0 25px rgba(0,0,0,0.15); z-index: 99999; transform: translateX(100%); transition: transform 0.3s ease; }
+        .mobile-menu.open { transform: translateX(0); }
+        .mobile-menu-close { position: absolute; top: 24px; right: 24px; background: none; border: none; padding: 8px; cursor: pointer; color: #9ca3af; border-radius: 8px; }
+        .mobile-menu-content { padding: 80px 32px 32px; height: 100%; overflow-y: auto; }
+        .mobile-nav { display: flex; flex-direction: column; gap: 8px; }
+        .mobile-nav-link { display: block; padding: 16px 0; color: #374151; font-weight: 500; font-size: 18px; text-decoration: none; border-bottom: 1px solid #f3f4f6; transition: all 0.2s ease; }
+        .mobile-nav-link:hover { color: #233c75; }
+        .mobile-menu-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 99998; opacity: 0; visibility: hidden; transition: all 0.3s ease; }
+        .mobile-menu-overlay.show { opacity: 1; visibility: visible; }
+        body.menu-open { overflow: hidden; }
+        .nav-link { position: relative; transition: all 0.3s ease; }
+        .nav-link::after { content: ''; position: absolute; bottom: -2px; left: 0; width: 0; height: 2px; background: #233c75; transition: width 0.3s ease; }
+        .nav-link:hover::after { width: 100%; }
+        .nav-link:hover { color: #233c75; }
+        .feature-card { transition: all 0.3s ease; border: 1px solid #e5e7eb; }
+        .feature-card:hover { transform: translateY(-3px); box-shadow: 0 10px 25px rgba(35,60,117,0.1); border-color: #233c75; }
+    </style>
+
+    <!-- Structured Data -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Service",
+      "name": "Litigation Support Appraisals — London, Ontario",
+      "url": "https://metrixrealty.com/london/litigation-support",
+      "serviceType": "Litigation Support Real Estate Appraisal",
+      "description": "Independent real estate appraisals and expert witness services for litigation, arbitration, expropriation, and court proceedings in London and Southwestern Ontario.",
+      "provider": {
+        "@type": ["LocalBusiness", "ProfessionalService"],
+        "name": "Metrix Realty Group",
+        "url": "https://metrixrealty.com/",
+        "telephone": "+15196727550",
+        "address": {
+          "@type": "PostalAddress",
+          "streetAddress": "620A Richmond Street, Suite 203",
+          "addressLocality": "London",
+          "addressRegion": "ON",
+          "postalCode": "N6A 5J9",
+          "addressCountry": "CA"
+        }
+      },
+      "areaServed": {
+        "@type": "Place",
+        "name": "London, Ontario and Southwestern Ontario"
+      }
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://metrixrealty.com/"},
+        {"@type": "ListItem", "position": 2, "name": "London", "item": "https://metrixrealty.com/london/"},
+        {"@type": "ListItem", "position": 3, "name": "Litigation Support", "item": "https://metrixrealty.com/london/litigation-support"}
+      ]
+    }
+    </script>
+</head>
+<body class="bg-white">
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+
+    <div id="mobile-menu-overlay" class="mobile-menu-overlay"></div>
+
+    <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
+        <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center justify-between h-16 sm:h-20">
+                <div class="flex-shrink-0">
+                    <a href="/"><img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto"></a>
+                </div>
+                <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
+                    <a href="/" class="nav-link text-gray-900 font-semibold">Home</a>
+                    <a href="/services" class="nav-link text-gray-900 font-semibold">Services</a>
+                    <a href="/market-areas" class="nav-link text-gray-900 font-semibold">Market Areas</a>
+                    <a href="/team" class="nav-link text-gray-900 font-semibold">Team</a>
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold">Contact</a>
+                </div>
+                <div class="hidden md:block">
+                    <a href="/contact" class="inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors">Connect with an Appraiser</a>
+                </div>
+                <div class="md:hidden">
+                    <button id="mobile-menu-button" class="text-gray-900 p-2" aria-label="Toggle menu">
+                        <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
+                            <span class="block h-0.5 w-6 bg-current transition-all"></span>
+                            <span class="block h-0.5 w-6 bg-current transition-all"></span>
+                            <span class="block h-0.5 w-6 bg-current transition-all"></span>
+                        </div>
+                    </button>
+                </div>
+            </div>
+        </nav>
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
+            </button>
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link">Team</a>
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+                    <div style="margin-top:32px">
+                        <a href="/contact" class="block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg">Connect with an Appraiser</a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <div class="h-16 sm:h-20"></div>
+
+    <!-- Breadcrumb -->
+    <div class="bg-gray-50 border-b">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+            <nav class="flex text-sm" aria-label="Breadcrumb">
+                <ol class="inline-flex items-center space-x-2">
+                    <li><a href="/" class="text-gray-500 hover:text-metrix-blue">Home</a></li>
+                    <li><span class="text-gray-400 mx-1">/</span></li>
+                    <li><a href="/london/" class="text-gray-500 hover:text-metrix-blue">London</a></li>
+                    <li><span class="text-gray-400 mx-1">/</span></li>
+                    <li><span class="text-gray-700 font-medium">Litigation Support</span></li>
+                </ol>
+            </nav>
+        </div>
+    </div>
+
+    <!-- Hero -->
+    <section class="bg-hero text-white py-16 md:py-24">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="max-w-3xl">
+                <div class="inline-flex items-center px-3 py-1 bg-white/10 rounded-full text-sm font-medium mb-6">London, Ontario</div>
+                <h1 class="text-4xl md:text-5xl font-bold mb-6 leading-tight">Litigation Support Appraisals<br>in London, Ontario</h1>
+                <p class="text-xl text-gray-200 mb-8 leading-relaxed">Independent, court-ready real estate valuations for lawyers, courts, and tribunals in London and Southwestern Ontario. AACI-designated appraisers with PLE credentials.</p>
+                <a href="/contact" class="inline-block bg-white text-metrix-blue px-8 py-4 rounded-lg font-semibold hover:bg-gray-100 transition-colors">Request a Litigation Appraisal</a>
+            </div>
+        </div>
+    </section>
+
+    <!-- Main Content -->
+    <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 md:py-24">
+
+        <!-- Intro -->
+        <div class="max-w-3xl mb-16">
+            <h2 class="text-3xl font-bold text-gray-900 mb-6">Real Estate Expert Witness Services in London, Ontario</h2>
+            <p class="text-lg text-gray-600 leading-relaxed mb-6">When a property valuation is contested in court, before the Ontario Land Tribunal, or in arbitration, the appraiser who prepares the report must be able to defend their methodology and conclusions under cross-examination. Metrix Realty Group's litigation support practice is built around exactly this requirement.</p>
+            <p class="text-lg text-gray-600 leading-relaxed mb-6">Dan Van Houtte, MRICS, P.App., AACI, PLE — Metrix's President — holds the Professional Legal Expert (PLE) designation, which is specific to court-qualified appraisal expert witness work. He has provided expert witness testimony in Ontario Superior Court, the Ontario Land Tribunal, and numerous arbitration and mediation proceedings across Southwestern Ontario.</p>
+            <p class="text-lg text-gray-600 leading-relaxed">All litigation support appraisals prepared by Metrix are completed in compliance with CUSPAP (Canadian Uniform Standards of Professional Appraisal Practice) and are structured to meet the disclosure requirements for expert witness reports under the Ontario Rules of Civil Procedure.</p>
+        </div>
+
+        <!-- Services Grid -->
+        <div class="mb-16">
+            <h2 class="text-3xl font-bold text-gray-900 mb-8">Litigation Appraisal Services</h2>
+            <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+                <div class="feature-card bg-white rounded-xl p-6">
+                    <div class="w-10 h-10 bg-metrix-blue/10 rounded-lg flex items-center justify-center mb-4">
+                        <svg class="w-5 h-5 text-metrix-blue" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3"></path></svg>
+                    </div>
+                    <h3 class="text-lg font-bold text-gray-900 mb-2">Expropriation</h3>
+                    <p class="text-gray-600 text-sm leading-relaxed">Market value and injurious affection opinions for federal, provincial, and municipal expropriations under the Ontario Expropriations Act.</p>
+                </div>
+                <div class="feature-card bg-white rounded-xl p-6">
+                    <div class="w-10 h-10 bg-metrix-blue/10 rounded-lg flex items-center justify-center mb-4">
+                        <svg class="w-5 h-5 text-metrix-blue" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"></path></svg>
+                    </div>
+                    <h3 class="text-lg font-bold text-gray-900 mb-2">Matrimonial & Family Law</h3>
+                    <p class="text-gray-600 text-sm leading-relaxed">Independent valuations for contested property division under the Family Law Act. Joint and single-party retainer appointments available.</p>
+                </div>
+                <div class="feature-card bg-white rounded-xl p-6">
+                    <div class="w-10 h-10 bg-metrix-blue/10 rounded-lg flex items-center justify-center mb-4">
+                        <svg class="w-5 h-5 text-metrix-blue" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path></svg>
+                    </div>
+                    <h3 class="text-lg font-bold text-gray-900 mb-2">Expert Witness Testimony</h3>
+                    <p class="text-gray-600 text-sm leading-relaxed">Court-qualified appraisal testimony in Ontario Superior Court, Small Claims Court, and the Ontario Land Tribunal. Reports structured for Rule 53 disclosure.</p>
+                </div>
+                <div class="feature-card bg-white rounded-xl p-6">
+                    <div class="w-10 h-10 bg-metrix-blue/10 rounded-lg flex items-center justify-center mb-4">
+                        <svg class="w-5 h-5 text-metrix-blue" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path></svg>
+                    </div>
+                    <h3 class="text-lg font-bold text-gray-900 mb-2">Insurance Disputes</h3>
+                    <p class="text-gray-600 text-sm leading-relaxed">Pre-loss and post-loss replacement cost opinions for property insurance claims and coverage disputes.</p>
+                </div>
+                <div class="feature-card bg-white rounded-xl p-6">
+                    <div class="w-10 h-10 bg-metrix-blue/10 rounded-lg flex items-center justify-center mb-4">
+                        <svg class="w-5 h-5 text-metrix-blue" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-2 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"></path></svg>
+                    </div>
+                    <h3 class="text-lg font-bold text-gray-900 mb-2">Partnership & Shareholder Disputes</h3>
+                    <p class="text-gray-600 text-sm leading-relaxed">Real property valuations for partnership dissolutions, shareholder buyouts, and commercial litigation involving real estate assets.</p>
+                </div>
+                <div class="feature-card bg-white rounded-xl p-6">
+                    <div class="w-10 h-10 bg-metrix-blue/10 rounded-lg flex items-center justify-center mb-4">
+                        <svg class="w-5 h-5 text-metrix-blue" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path></svg>
+                    </div>
+                    <h3 class="text-lg font-bold text-gray-900 mb-2">Retrospective Valuations</h3>
+                    <p class="text-gray-600 text-sm leading-relaxed">Historical date-of-value appraisals for tax, legal, and accounting purposes. Effective dates backdated to any prior period.</p>
+                </div>
+            </div>
+        </div>
+
+        <!-- Why Metrix -->
+        <div class="bg-gray-50 rounded-2xl p-8 md:p-12 mb-16">
+            <h2 class="text-3xl font-bold text-gray-900 mb-6">Why Lawyers in London Retain Metrix for Litigation Support</h2>
+            <div class="grid md:grid-cols-2 gap-8">
+                <div>
+                    <h3 class="text-lg font-semibold text-gray-900 mb-3">PLE Designation</h3>
+                    <p class="text-gray-600 leading-relaxed">Dan Van Houtte holds the Professional Legal Expert (PLE) designation — a credential specific to appraisers who regularly provide expert witness testimony. This is not a standard AIC credential; it requires demonstrated experience in legal proceedings and specialized training in expert witness obligations.</p>
+                </div>
+                <div>
+                    <h3 class="text-lg font-semibold text-gray-900 mb-3">MRICS Standing</h3>
+                    <p class="text-gray-600 leading-relaxed">As a Member of the Royal Institution of Chartered Surveyors (MRICS), Metrix's lead appraiser is bound by both AIC and RICS professional standards — two separate international bodies with their own discipline processes. This dual standing strengthens the credibility of expert opinions for sophisticated commercial files.</p>
+                </div>
+                <div>
+                    <h3 class="text-lg font-semibold text-gray-900 mb-3">All Commercial Property Types</h3>
+                    <p class="text-gray-600 leading-relaxed">Metrix's AACI-designated appraisers handle office, retail, industrial, multi-family, development land, agricultural, and special-use properties. For litigation, this matters: many local firms can appraise residential but lack the designation or experience to testify on commercial assets.</p>
+                </div>
+                <div>
+                    <h3 class="text-lg font-semibold text-gray-900 mb-3">30 Years in Southwestern Ontario</h3>
+                    <p class="text-gray-600 leading-relaxed">Founded in London in 1995, Metrix appraisers have deep familiarity with local market conditions, comparable transactions, and property-specific factors that affect value in the London-Middlesex, Elgin, Oxford, and surrounding county markets — precisely the kind of local knowledge courts expect from qualified experts.</p>
+                </div>
+            </div>
+        </div>
+
+        <!-- CTA -->
+        <div class="bg-gradient-to-r from-metrix-blue to-metrix-blue-dark rounded-2xl p-8 md:p-12 text-white text-center">
+            <h2 class="text-3xl font-bold mb-4">Need a Litigation Appraisal in London, Ontario?</h2>
+            <p class="text-xl text-gray-200 mb-8 max-w-2xl mx-auto">Contact Metrix to discuss the file, the property type, and the timeline. We work with instructing lawyers, legal aid, and self-represented litigants across Southwestern Ontario.</p>
+            <div class="flex flex-col sm:flex-row gap-4 justify-center">
+                <a href="/contact" class="inline-block bg-white text-metrix-blue px-8 py-4 rounded-lg font-semibold hover:bg-gray-100 transition-colors">Request a Consultation</a>
+                <a href="/services/litigation-support-expert-testimony" class="inline-block border-2 border-white text-white px-8 py-4 rounded-lg font-semibold hover:bg-white/10 transition-colors">View Service Details</a>
+            </div>
+        </div>
+    </main>
+
+    <!-- Footer -->
+    <footer class="bg-black text-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
+                <div class="lg:col-span-1">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-4">Trusted • Valued • Experienced</p>
+                    <div class="text-gray-300 text-sm">
+                        <p class="font-semibold text-white mb-1">620A Richmond Street, Suite 203</p>
+                        <p class="mb-3">London, ON N6A 5J9</p>
+                        <p><a href="tel:519-672-7550" class="text-white hover:text-gray-200">(519) 672-7550</a></p>
+                        <p>Toll Free: 1-866-672-9101</p>
+                        <p class="mt-2"><a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200">info@metrixrealty.com</a></p>
+                    </div>
+                </div>
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
+                    <ul class="space-y-3 text-gray-300 text-sm">
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors">Government & Institutional</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">London, Ontario</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/london/commercial-appraisal" class="hover:text-white transition-colors">Commercial Appraisal</a></li>
+                        <li><a href="/london/residential-appraisal" class="hover:text-white transition-colors">Residential Appraisal</a></li>
+                        <li><a href="/london/industrial-appraisal" class="hover:text-white transition-colors">Industrial Appraisal</a></li>
+                        <li><a href="/london/litigation-support" class="hover:text-white transition-colors font-semibold text-white">Litigation Support</a></li>
+                        <li><a href="/london/estate-appraisal" class="hover:text-white transition-colors">Estate Appraisal</a></li>
+                        <li><a href="/london/divorce-appraisal" class="hover:text-white transition-colors">Divorce Appraisal</a></li>
+                        <li><a href="/london/property-tax-appeal" class="hover:text-white transition-colors">Property Tax Appeal</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/team" class="hover:text-white transition-colors">Our Team</a></li>
+                        <li><a href="/insights/" class="hover:text-white transition-colors">Market Insights</a></li>
+                        <li><a href="/contact" class="hover:text-white transition-colors">Contact</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors">Windsor Office</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="border-t border-gray-800 pt-8 text-center">
+                <p class="text-sm text-gray-400 mb-2">Professional Affiliations: AIC — Appraisal Institute of Canada &nbsp;|&nbsp; RICS — Royal Institution of Chartered Surveyors &nbsp;|&nbsp; AOLE &nbsp;|&nbsp; IRWA</p>
+                <p class="text-sm text-gray-400 mb-4">Reports completed in compliance with <a href="https://www.aicanada.ca/about-aic/cuspap/" target="_blank" rel="noopener noreferrer" class="hover:text-gray-300">CUSPAP</a></p>
+                <p class="text-sm text-gray-500">&copy; 2026 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-3 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-500 hover:text-gray-400 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-500 hover:text-gray-400 text-sm">Terms of Service</a>
+                    <a href="/llms.txt" class="text-gray-500 hover:text-gray-400 text-sm">LLMs.txt</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script>
+        const mobileMenuBtn = document.getElementById('mobile-menu-button');
+        const mobileMenu = document.getElementById('mobile-menu');
+        const mobileMenuOverlay = document.getElementById('mobile-menu-overlay');
+        const mobileMenuClose = document.getElementById('mobile-menu-close');
+        function openMenu() { mobileMenu.classList.add('open'); mobileMenuOverlay.classList.add('show'); document.body.classList.add('menu-open'); }
+        function closeMenu() { mobileMenu.classList.remove('open'); mobileMenuOverlay.classList.remove('show'); document.body.classList.remove('menu-open'); }
+        if (mobileMenuBtn) mobileMenuBtn.addEventListener('click', openMenu);
+        if (mobileMenuClose) mobileMenuClose.addEventListener('click', closeMenu);
+        if (mobileMenuOverlay) mobileMenuOverlay.addEventListener('click', closeMenu);
+        document.addEventListener('keydown', e => { if (e.key === 'Escape') closeMenu(); });
+    </script>
+    <script src="/assets/js/analytics-tracking.js"></script>
+</body>
+</html>

--- a/london/property-tax-appeal/index.html
+++ b/london/property-tax-appeal/index.html
@@ -1,0 +1,375 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Property Tax Assessment Appeal Appraisals London Ontario | Metrix Realty</title>
+    <link rel="icon" type="image/png" href="/favicon.png">
+    <meta name="description" content="Property tax assessment appeal appraisals in London, Ontario. AACI-designated appraisers supporting MPAC reviews and ARB hearings for residential and commercial properties.">
+    <link rel="canonical" href="https://metrixrealty.com/london/property-tax-appeal">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Metrix Realty Group">
+    <meta property="og:title" content="Property Tax Assessment Appeal Appraisals London Ontario | Metrix Realty">
+    <meta property="og:description" content="Property tax assessment appeal appraisals in London, Ontario. AACI-designated appraisers supporting MPAC reviews and ARB hearings for residential and commercial properties.">
+    <meta property="og:url" content="https://metrixrealty.com/london/property-tax-appeal">
+    <meta property="og:image" content="https://metrixrealty.com/assets/images/metrix-realty-logo.png">
+    <meta name="twitter:card" content="summary_large_image">
+
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: { 'metrix-blue': '#233c75', 'metrix-blue-light': '#3d5a9e', 'metrix-blue-dark': '#1a2d5a', 'metrix-green': '#3faa4d' },
+                    fontFamily: { 'inter': ['Inter', 'sans-serif'] }
+                }
+            }
+        }
+    </script>
+    <style>
+        body { font-family: 'Inter', sans-serif; }
+        .bg-hero { background: linear-gradient(135deg, #233c75 0%, #1a2d5a 70%, #3faa4d 100%); }
+        .mobile-menu { position: fixed; top: 0; right: 0; height: 100vh; width: 320px; background: #ffffff; box-shadow: -10px 0 25px rgba(0,0,0,0.15); z-index: 99999; transform: translateX(100%); transition: transform 0.3s ease; }
+        .mobile-menu.open { transform: translateX(0); }
+        .mobile-menu-close { position: absolute; top: 24px; right: 24px; background: none; border: none; padding: 8px; cursor: pointer; color: #9ca3af; border-radius: 8px; }
+        .mobile-menu-content { padding: 80px 32px 32px; height: 100%; overflow-y: auto; }
+        .mobile-nav { display: flex; flex-direction: column; gap: 8px; }
+        .mobile-nav-link { display: block; padding: 16px 0; color: #374151; font-weight: 500; font-size: 18px; text-decoration: none; border-bottom: 1px solid #f3f4f6; transition: all 0.2s ease; }
+        .mobile-nav-link:hover { color: #233c75; }
+        .mobile-menu-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 99998; opacity: 0; visibility: hidden; transition: all 0.3s ease; }
+        .mobile-menu-overlay.show { opacity: 1; visibility: visible; }
+        body.menu-open { overflow: hidden; }
+        .nav-link { position: relative; transition: all 0.3s ease; }
+        .nav-link::after { content: ''; position: absolute; bottom: -2px; left: 0; width: 0; height: 2px; background: #233c75; transition: width 0.3s ease; }
+        .nav-link:hover::after { width: 100%; }
+        .nav-link:hover { color: #233c75; }
+        .feature-card { transition: all 0.3s ease; border: 1px solid #e5e7eb; }
+        .feature-card:hover { transform: translateY(-3px); box-shadow: 0 10px 25px rgba(35,60,117,0.1); border-color: #233c75; }
+    </style>
+
+    <!-- Structured Data -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Service",
+      "name": "Property Tax Assessment Appeal Appraisals — London, Ontario",
+      "url": "https://metrixrealty.com/london/property-tax-appeal",
+      "serviceType": "Property Tax Assessment Review Appraisal",
+      "description": "Independent appraisals supporting property tax assessment reviews and ARB appeal hearings for residential and commercial properties in London and Southwestern Ontario.",
+      "provider": {
+        "@type": ["LocalBusiness", "ProfessionalService"],
+        "name": "Metrix Realty Group",
+        "url": "https://metrixrealty.com/",
+        "telephone": "+15196727550",
+        "address": {
+          "@type": "PostalAddress",
+          "streetAddress": "620A Richmond Street, Suite 203",
+          "addressLocality": "London",
+          "addressRegion": "ON",
+          "postalCode": "N6A 5J9",
+          "addressCountry": "CA"
+        }
+      },
+      "areaServed": {
+        "@type": "Place",
+        "name": "London, Ontario and Southwestern Ontario"
+      }
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "Home", "item": "https://metrixrealty.com/"},
+        {"@type": "ListItem", "position": 2, "name": "London", "item": "https://metrixrealty.com/london/"},
+        {"@type": "ListItem", "position": 3, "name": "Property Tax Appeal", "item": "https://metrixrealty.com/london/property-tax-appeal"}
+      ]
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "How do I appeal my property tax assessment in London, Ontario?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "In Ontario, property assessments are set by MPAC (Municipal Property Assessment Corporation). If you believe your assessment is too high, you can first request a Request for Reconsideration (RfR) from MPAC at no cost. If you are not satisfied with the outcome, you can file an appeal with the Assessment Review Board (ARB). An independent appraisal from an AACI-designated appraiser is often the most effective evidence to support an ARB appeal for commercial or complex residential properties."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "What is the deadline to appeal a property tax assessment in Ontario?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "For most property types, the deadline to file a Request for Reconsideration with MPAC is March 31 of the tax year. The deadline to file an ARB appeal is typically April 1. Contact Metrix early to allow sufficient time for the appraisal to be completed before the filing deadline."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Is a formal appraisal required to appeal a property tax assessment?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "A formal appraisal is not always required for an MPAC Request for Reconsideration. However, for ARB appeal hearings — particularly for commercial properties — an independent appraisal from an AACI-designated appraiser is the standard evidence used to challenge MPAC's assessed value. A formal appraisal that documents market value as of the base valuation date provides the most compelling and defensible evidence in an ARB proceeding."
+          }
+        }
+      ]
+    }
+    </script>
+</head>
+<body class="bg-white">
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+
+    <div id="mobile-menu-overlay" class="mobile-menu-overlay"></div>
+
+    <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
+        <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center justify-between h-16 sm:h-20">
+                <div class="flex-shrink-0">
+                    <a href="/"><img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-10 sm:h-12 w-auto"></a>
+                </div>
+                <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
+                    <a href="/" class="nav-link text-gray-900 font-semibold">Home</a>
+                    <a href="/services" class="nav-link text-gray-900 font-semibold">Services</a>
+                    <a href="/market-areas" class="nav-link text-gray-900 font-semibold">Market Areas</a>
+                    <a href="/team" class="nav-link text-gray-900 font-semibold">Team</a>
+                    <a href="/contact" class="nav-link text-gray-900 font-semibold">Contact</a>
+                </div>
+                <div class="hidden md:block">
+                    <a href="/contact" class="inline-flex items-center px-4 lg:px-6 py-2 lg:py-3 bg-black text-white font-semibold rounded-lg hover:bg-gray-800 text-sm lg:text-base transition-colors">Connect with an Appraiser</a>
+                </div>
+                <div class="md:hidden">
+                    <button id="mobile-menu-button" class="text-gray-900 p-2" aria-label="Toggle menu">
+                        <div class="hamburger w-6 h-6 flex flex-col justify-center space-y-1">
+                            <span class="block h-0.5 w-6 bg-current transition-all"></span>
+                            <span class="block h-0.5 w-6 bg-current transition-all"></span>
+                            <span class="block h-0.5 w-6 bg-current transition-all"></span>
+                        </div>
+                    </button>
+                </div>
+            </div>
+        </nav>
+        <div id="mobile-menu" class="mobile-menu md:hidden">
+            <button id="mobile-menu-close" class="mobile-menu-close" aria-label="Close menu">
+                <svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
+            </button>
+            <div class="mobile-menu-content">
+                <nav class="mobile-nav">
+                    <a href="/" class="mobile-nav-link">Home</a>
+                    <a href="/services" class="mobile-nav-link">Services</a>
+                    <a href="/market-areas" class="mobile-nav-link">Market Areas</a>
+                    <a href="/london/" class="mobile-nav-link" style="padding-left:2rem">London, ON</a>
+                    <a href="/windsor/" class="mobile-nav-link" style="padding-left:2rem">Windsor, ON</a>
+                    <a href="/team" class="mobile-nav-link">Team</a>
+                    <a href="/contact" class="mobile-nav-link">Contact</a>
+                    <div style="margin-top:32px">
+                        <a href="/contact" class="block w-full text-center px-6 py-3 bg-black text-white font-semibold rounded-lg">Connect with an Appraiser</a>
+                    </div>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <div class="h-16 sm:h-20"></div>
+
+    <!-- Breadcrumb -->
+    <div class="bg-gray-50 border-b">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+            <nav class="flex text-sm" aria-label="Breadcrumb">
+                <ol class="inline-flex items-center space-x-2">
+                    <li><a href="/" class="text-gray-500 hover:text-metrix-blue">Home</a></li>
+                    <li><span class="text-gray-400 mx-1">/</span></li>
+                    <li><a href="/london/" class="text-gray-500 hover:text-metrix-blue">London</a></li>
+                    <li><span class="text-gray-400 mx-1">/</span></li>
+                    <li><span class="text-gray-700 font-medium">Property Tax Appeal</span></li>
+                </ol>
+            </nav>
+        </div>
+    </div>
+
+    <!-- Hero -->
+    <section class="bg-hero text-white py-16 md:py-24">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="max-w-3xl">
+                <div class="inline-flex items-center px-3 py-1 bg-white/10 rounded-full text-sm font-medium mb-6">London, Ontario</div>
+                <h1 class="text-4xl md:text-5xl font-bold mb-6 leading-tight">Property Tax Assessment Appeal Appraisals<br>in London, Ontario</h1>
+                <p class="text-xl text-gray-200 mb-8 leading-relaxed">Independent appraisals supporting MPAC reviews and ARB appeal hearings for residential and commercial properties in London and Southwestern Ontario.</p>
+                <a href="/contact" class="inline-block bg-white text-metrix-blue px-8 py-4 rounded-lg font-semibold hover:bg-gray-100 transition-colors">Request an Assessment Appraisal</a>
+            </div>
+        </div>
+    </section>
+
+    <!-- Main Content -->
+    <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 md:py-24">
+
+        <!-- Intro -->
+        <div class="max-w-3xl mb-16">
+            <h2 class="text-3xl font-bold text-gray-900 mb-6">Challenging Your Property Assessment in London, Ontario</h2>
+            <p class="text-lg text-gray-600 leading-relaxed mb-6">In Ontario, property tax is based on the assessed value set by MPAC — the Municipal Property Assessment Corporation. If your property's assessed value is higher than what an independent appraiser would support as market value, you are paying more property tax than the law requires.</p>
+            <p class="text-lg text-gray-600 leading-relaxed mb-6">Property owners in London can challenge their MPAC assessment through a Request for Reconsideration (RfR) and, if necessary, an appeal to the Assessment Review Board (ARB). For commercial and complex properties, an independent appraisal from an AACI-designated appraiser is the standard evidence used to demonstrate that the assessed value exceeds market value as of the base valuation date.</p>
+            <p class="text-lg text-gray-600 leading-relaxed">Metrix Realty Group prepares independent market value appraisals for property owners and their representatives pursuing MPAC reconsiderations and ARB appeals across London, Middlesex County, and Southwestern Ontario.</p>
+        </div>
+
+        <!-- The Process -->
+        <div class="bg-gray-50 rounded-2xl p-8 md:p-12 mb-16">
+            <h2 class="text-3xl font-bold text-gray-900 mb-8">The Ontario Property Tax Appeal Process</h2>
+            <div class="grid md:grid-cols-3 gap-8">
+                <div>
+                    <div class="w-12 h-12 bg-metrix-blue rounded-full flex items-center justify-center text-white font-bold text-xl mb-4">1</div>
+                    <h3 class="font-semibold text-gray-900 mb-2 text-lg">MPAC Request for Reconsideration</h3>
+                    <p class="text-gray-600 text-sm leading-relaxed">File an RfR with MPAC by March 31 of the tax year. This is a free process where MPAC reviews the assessment. An appraisal is not required but strengthens the submission, especially for commercial properties.</p>
+                </div>
+                <div>
+                    <div class="w-12 h-12 bg-metrix-blue rounded-full flex items-center justify-center text-white font-bold text-xl mb-4">2</div>
+                    <h3 class="font-semibold text-gray-900 mb-2 text-lg">Assessment Review Board Appeal</h3>
+                    <p class="text-gray-600 text-sm leading-relaxed">If the RfR outcome is unsatisfactory, file an ARB appeal by April 1. An independent appraisal establishing market value as of the base assessment date is the primary evidence in commercial ARB hearings.</p>
+                </div>
+                <div>
+                    <div class="w-12 h-12 bg-metrix-blue rounded-full flex items-center justify-center text-white font-bold text-xl mb-4">3</div>
+                    <h3 class="font-semibold text-gray-900 mb-2 text-lg">Hearing or Settlement</h3>
+                    <p class="text-gray-600 text-sm leading-relaxed">Most ARB appeals are resolved by settlement once MPAC reviews independent evidence. When hearings proceed, Metrix appraisers can provide expert testimony before the ARB.</p>
+                </div>
+            </div>
+        </div>
+
+        <!-- Services -->
+        <div class="mb-16">
+            <h2 class="text-3xl font-bold text-gray-900 mb-8">Who Metrix Serves for Property Tax Appeals</h2>
+            <div class="grid md:grid-cols-2 gap-6">
+                <div class="feature-card bg-white rounded-xl p-6">
+                    <h3 class="text-lg font-bold text-gray-900 mb-3">Commercial Property Owners</h3>
+                    <p class="text-gray-600 leading-relaxed">For office buildings, retail plazas, industrial facilities, and multi-family rental properties in London, the potential tax savings from a successful appeal often substantially exceed the cost of the appraisal. Metrix's AACI designation is required for commercial ARB evidence.</p>
+                </div>
+                <div class="feature-card bg-white rounded-xl p-6">
+                    <h3 class="text-lg font-bold text-gray-900 mb-3">Residential Property Owners</h3>
+                    <p class="text-gray-600 leading-relaxed">Single-family homes, condominiums, and residential rental properties. An independent residential appraisal at the base valuation date can demonstrate that MPAC's assessed value is not supported by the market.</p>
+                </div>
+                <div class="feature-card bg-white rounded-xl p-6">
+                    <h3 class="text-lg font-bold text-gray-900 mb-3">Property Tax Consultants & Lawyers</h3>
+                    <p class="text-gray-600 leading-relaxed">Tax consultants and lawyers who manage assessment appeal files across multiple properties rely on Metrix for the appraisal component of their submissions and for expert witness support at ARB hearings.</p>
+                </div>
+                <div class="feature-card bg-white rounded-xl p-6">
+                    <h3 class="text-lg font-bold text-gray-900 mb-3">Special-Purpose Properties</h3>
+                    <p class="text-gray-600 leading-relaxed">Hotels, gas stations, car washes, places of worship, and other special-use properties. These property types often require appraisers with specific experience in going-concern and special-purpose valuation methodology.</p>
+                </div>
+            </div>
+        </div>
+
+        <!-- FAQ -->
+        <div class="mb-16">
+            <h2 class="text-3xl font-bold text-gray-900 mb-8">Frequently Asked Questions</h2>
+            <div class="space-y-6">
+                <div class="border border-gray-200 rounded-xl p-6">
+                    <h3 class="font-semibold text-gray-900 mb-3">How do I appeal my property tax assessment in London, Ontario?</h3>
+                    <p class="text-gray-600">In Ontario, property assessments are set by MPAC. If you believe your assessment is too high, you can first request a Request for Reconsideration from MPAC at no cost. If you are not satisfied with the outcome, you can file an appeal with the Assessment Review Board (ARB). An independent appraisal from an AACI-designated appraiser is often the most effective evidence to support an ARB appeal for commercial or complex residential properties.</p>
+                </div>
+                <div class="border border-gray-200 rounded-xl p-6">
+                    <h3 class="font-semibold text-gray-900 mb-3">What is the deadline to appeal a property tax assessment in Ontario?</h3>
+                    <p class="text-gray-600">For most property types, the deadline to file a Request for Reconsideration with MPAC is March 31 of the tax year. The deadline to file an ARB appeal is typically April 1. Contact Metrix early to allow sufficient time for the appraisal to be completed before the filing deadline.</p>
+                </div>
+                <div class="border border-gray-200 rounded-xl p-6">
+                    <h3 class="font-semibold text-gray-900 mb-3">Is a formal appraisal required to appeal a property tax assessment?</h3>
+                    <p class="text-gray-600">A formal appraisal is not always required for an MPAC Request for Reconsideration. However, for ARB appeal hearings — particularly for commercial properties — an independent appraisal from an AACI-designated appraiser is the standard evidence used to challenge MPAC's assessed value. A formal appraisal that documents market value as of the base valuation date provides the most compelling and defensible evidence in an ARB proceeding.</p>
+                </div>
+            </div>
+        </div>
+
+        <!-- CTA -->
+        <div class="bg-gradient-to-r from-metrix-blue to-metrix-blue-dark rounded-2xl p-8 md:p-12 text-white text-center">
+            <h2 class="text-3xl font-bold mb-4">Ready to Challenge Your Property Assessment?</h2>
+            <p class="text-xl text-gray-200 mb-8 max-w-2xl mx-auto">Contact Metrix to discuss your property, the current assessed value, and the appeal deadline. We work with property owners and tax professionals across London and Southwestern Ontario.</p>
+            <div class="flex flex-col sm:flex-row gap-4 justify-center">
+                <a href="/contact" class="inline-block bg-white text-metrix-blue px-8 py-4 rounded-lg font-semibold hover:bg-gray-100 transition-colors">Request a Consultation</a>
+                <a href="/services/government-institutional-services" class="inline-block border-2 border-white text-white px-8 py-4 rounded-lg font-semibold hover:bg-white/10 transition-colors">View Government Services</a>
+            </div>
+        </div>
+    </main>
+
+    <!-- Footer -->
+    <footer class="bg-black text-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-12">
+                <div class="lg:col-span-1">
+                    <img src="/assets/images/metrix-realty-logo.png" alt="Metrix Realty Group" class="h-12 w-auto mb-6 brightness-0 invert">
+                    <p class="text-gray-300 mb-4">Trusted • Valued • Experienced</p>
+                    <div class="text-gray-300 text-sm">
+                        <p class="font-semibold text-white mb-1">620A Richmond Street, Suite 203</p>
+                        <p class="mb-3">London, ON N6A 5J9</p>
+                        <p><a href="tel:519-672-7550" class="text-white hover:text-gray-200">(519) 672-7550</a></p>
+                        <p>Toll Free: 1-866-672-9101</p>
+                        <p class="mt-2"><a href="mailto:info@metrixrealty.com" class="text-white hover:text-gray-200">info@metrixrealty.com</a></p>
+                    </div>
+                </div>
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Services</h3>
+                    <ul class="space-y-3 text-gray-300 text-sm">
+                        <li><a href="/services/commercial-property-valuations" class="hover:text-white transition-colors">Commercial Appraisal</a></li>
+                        <li><a href="/services/residential-property-appraisals" class="hover:text-white transition-colors">Residential Appraisal</a></li>
+                        <li><a href="/services/litigation-support-expert-testimony" class="hover:text-white transition-colors">Litigation Support</a></li>
+                        <li><a href="/services/real-estate-consulting" class="hover:text-white transition-colors">Real Estate Consulting</a></li>
+                        <li><a href="/services/government-institutional-services" class="hover:text-white transition-colors">Government & Institutional</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">London, Ontario</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/london/commercial-appraisal" class="hover:text-white transition-colors">Commercial Appraisal</a></li>
+                        <li><a href="/london/residential-appraisal" class="hover:text-white transition-colors">Residential Appraisal</a></li>
+                        <li><a href="/london/industrial-appraisal" class="hover:text-white transition-colors">Industrial Appraisal</a></li>
+                        <li><a href="/london/litigation-support" class="hover:text-white transition-colors">Litigation Support</a></li>
+                        <li><a href="/london/estate-appraisal" class="hover:text-white transition-colors">Estate Appraisal</a></li>
+                        <li><a href="/london/divorce-appraisal" class="hover:text-white transition-colors">Divorce Appraisal</a></li>
+                        <li><a href="/london/property-tax-appeal" class="hover:text-white transition-colors font-semibold text-white">Property Tax Appeal</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-white font-semibold text-lg mb-6">Company</h3>
+                    <ul class="space-y-2 text-gray-300 text-sm">
+                        <li><a href="/team" class="hover:text-white transition-colors">Our Team</a></li>
+                        <li><a href="/insights/" class="hover:text-white transition-colors">Market Insights</a></li>
+                        <li><a href="/contact" class="hover:text-white transition-colors">Contact</a></li>
+                        <li><a href="/windsor/" class="hover:text-white transition-colors">Windsor Office</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="border-t border-gray-800 pt-8 text-center">
+                <p class="text-sm text-gray-400 mb-2">Professional Affiliations: AIC — Appraisal Institute of Canada &nbsp;|&nbsp; RICS — Royal Institution of Chartered Surveyors &nbsp;|&nbsp; AOLE &nbsp;|&nbsp; IRWA</p>
+                <p class="text-sm text-gray-400 mb-4">Reports completed in compliance with <a href="https://www.aicanada.ca/about-aic/cuspap/" target="_blank" rel="noopener noreferrer" class="hover:text-gray-300">CUSPAP</a></p>
+                <p class="text-sm text-gray-500">&copy; 2026 Metrix Realty Group. All rights reserved.</p>
+                <div class="mt-3 space-x-4">
+                    <a href="/privacy-policy" class="text-gray-500 hover:text-gray-400 text-sm">Privacy Policy</a>
+                    <a href="/terms-of-service" class="text-gray-500 hover:text-gray-400 text-sm">Terms of Service</a>
+                    <a href="/llms.txt" class="text-gray-500 hover:text-gray-400 text-sm">LLMs.txt</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script>
+        const mobileMenuBtn = document.getElementById('mobile-menu-button');
+        const mobileMenu = document.getElementById('mobile-menu');
+        const mobileMenuOverlay = document.getElementById('mobile-menu-overlay');
+        const mobileMenuClose = document.getElementById('mobile-menu-close');
+        function openMenu() { mobileMenu.classList.add('open'); mobileMenuOverlay.classList.add('show'); document.body.classList.add('menu-open'); }
+        function closeMenu() { mobileMenu.classList.remove('open'); mobileMenuOverlay.classList.remove('show'); document.body.classList.remove('menu-open'); }
+        if (mobileMenuBtn) mobileMenuBtn.addEventListener('click', openMenu);
+        if (mobileMenuClose) mobileMenuClose.addEventListener('click', closeMenu);
+        if (mobileMenuOverlay) mobileMenuOverlay.addEventListener('click', closeMenu);
+        document.addEventListener('keydown', e => { if (e.key === 'Escape') closeMenu(); });
+    </script>
+    <script src="/assets/js/analytics-tracking.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Creates 4 new indexed service pages for high-intent London, Ontario searches where Metrix has zero current presence:

| Page | URL | Target Searches |
|------|-----|-----------------|
| Litigation Support | `/london/litigation-support` | "litigation appraisal london ontario", "expert witness real estate london" |
| Estate Appraisal | `/london/estate-appraisal` | "estate appraisal london ontario", "date of death appraisal london" |
| Divorce Appraisal | `/london/divorce-appraisal` | "divorce property appraisal london ontario", "matrimonial appraisal london" |
| Property Tax Appeal | `/london/property-tax-appeal` | "property tax appeal london ontario", "MPAC appeal london appraisal" |

## What each page includes

- Title tag, canonical URL, meta description optimized for the target keyword
- Service JSON-LD schema with `["LocalBusiness", "ProfessionalService"]` provider type
- BreadcrumbList JSON-LD schema
- FAQPage JSON-LD schema (3 questions per page)
- Hero section with H1
- 500–700 words of targeted service content
- Feature/service cards grid
- Contact CTA block
- Consistent nav and footer with full London sub-nav cross-linking all 7 London pages

## Notes

- All 4 pages are indexed (no noindex) — legitimate service pages with real content
- Cross-linking in footers covers all 7 London pages (3 existing + 4 new)
- No client approval needed — all describe services Metrix already provides

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add four SEO-focused service landing pages for London, Ontario to capture high-intent searches and expand local coverage. Each page is indexed and includes full metadata, schema, and internal linking across the London hub.

- **New Features**
  - New pages: `/london/litigation-support`, `/london/estate-appraisal`, `/london/divorce-appraisal`, `/london/property-tax-appeal`.
  - SEO setup: canonical URLs, title/meta/OG tags, Service JSON-LD (`LocalBusiness`, `ProfessionalService`), `BreadcrumbList`, and `FAQPage` (3 Qs each).
  - Content/UX: hero H1, 500–700 words of service content, feature cards, contact CTA, and consistent nav/footer with cross-links to all London pages.

<sup>Written for commit baefc175a81cc6e685cb3a512ba44eeb5f68c87d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

