### PR TITLE
feat(seo): expand /london/commercial-appraisal to compete with Aion Appraisals

### DIFF
--- a/london/commercial-appraisal/index.html
+++ b/london/commercial-appraisal/index.html
@@ -161,6 +161,38 @@
             "@type": "Answer",
             "text": "Standard commercial appraisals in London typically take 5–10 business days from property inspection to report delivery. Rush assignments are available in 24–48 hours depending on property type and complexity. Turnaround time is confirmed at the consultation stage when requirements, scope, and deadline are discussed."
           }
+        },
+        {
+          "@type": "Question",
+          "name": "What is the difference between the income approach and the direct comparison approach in commercial appraisals?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "The income approach converts net operating income into value using a capitalization rate derived from comparable investment sales. It is the primary approach for income-producing commercial properties such as office buildings, retail plazas, industrial facilities, and apartment buildings. The direct comparison approach values the property by comparing it to recent arm's-length sales of similar properties, with adjustments for differences in date, location, size, and condition. For most London commercial properties, the income approach carries the most weight in the final value conclusion; the comparison approach provides a market-based reasonableness check."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Can a commercial appraisal ordered for one lender be submitted to a different lender?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Generally no. CUSPAP requires that an appraisal report identify its authorized users by name. A report naming one financial institution as the authorized user is not a valid appraisal submission for a different institution. If the lending relationship changes after an appraisal is ordered, contact Metrix to determine whether the report can be updated to reflect the new authorized user — this depends on whether the appraiser's independence can be maintained and the specific circumstances of the change."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Does Metrix Realty Group appraise commercial properties outside of London, Ontario?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Yes. Metrix provides commercial appraisals across Southwestern Ontario from offices in London and Windsor. The London team covers Middlesex, Elgin, Oxford, Perth, Huron, and Lambton counties — including St. Thomas, Woodstock, Stratford, and Sarnia. For specialized assignments, Metrix completes appraisals province-wide. The Windsor office handles Windsor-Essex, Chatham-Kent, and surrounding communities."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "What information is needed to start a commercial appraisal in London, Ontario?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Provide the property address, the property type and current use, the purpose and intended use of the appraisal (financing, sale, legal proceedings, etc.), the name of any lender or authorized user who will receive the report, and the required delivery date. For income-producing properties, having current rent rolls, lease summaries, and recent operating expense statements available speeds up the assignment. Metrix confirms scope, fee, and delivery timeline before work begins."
+          }
         }
       ]
     }
@@ -445,8 +477,120 @@
         </div>
     </section>
 
-    <!-- Process -->
+    <!-- London Commercial Submarkets -->
     <section class="py-16 sm:py-20 bg-gray-50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="max-w-3xl mx-auto text-center mb-12" data-aos="fade-up">
+                <h2 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-4">London's Commercial Real Estate Submarkets</h2>
+                <p class="text-gray-600 text-lg">London's commercial market is not uniform. Valuations are highly submarket-specific — a retail plaza on Wellington Road trades on fundamentally different metrics than a flex industrial building near the airport.</p>
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-6" data-aos="fade-up" data-aos-delay="100">
+                <div class="bg-white p-7 rounded-xl shadow-sm">
+                    <h3 class="font-bold text-gray-900 text-lg mb-3">Downtown Core</h3>
+                    <p class="text-gray-600 text-sm leading-relaxed mb-3">The Downtown London BIA area — Richmond, Dundas, King, Talbot — contains London's highest concentration of office space, government buildings, and mixed-use assets. Office vacancy in the core reached approximately 31.5% in Q1 2026 as remote and hybrid work reduced demand for traditional floor plates. However, boutique office conversions, residential intensification projects, and adaptive reuse of heritage buildings are generating new valuation complexity.</p>
+                    <p class="text-gray-600 text-sm leading-relaxed">Ground-floor retail in the core is tenant-sensitive and appraised on a net income basis; upper-floor office vacancy affects overall cap rates significantly. Metrix has completed appraisals across the entire downtown core dating back to the early 2000s.</p>
+                </div>
+                <div class="bg-white p-7 rounded-xl shadow-sm">
+                    <h3 class="font-bold text-gray-900 text-lg mb-3">Airport Road / South London Industrial</h3>
+                    <p class="text-gray-600 text-sm leading-relaxed mb-3">London's primary industrial submarket clusters around the London International Airport and extends east along Highway 401. This corridor accommodates logistics and distribution tenants, automotive parts suppliers, food and beverage processing operations, and advanced manufacturing facilities. Industrial vacancy in this submarket sits near 4% — well below the 6–8% range considered a balanced industrial market.</p>
+                    <p class="text-gray-600 text-sm leading-relaxed">New speculative industrial construction has added supply, but large-bay modern logistics buildings continue to attract competitive offers. Metrix regularly completes industrial appraisals across this corridor for lender financing, acquisition due diligence, and lease analysis.</p>
+                </div>
+                <div class="bg-white p-7 rounded-xl shadow-sm">
+                    <h3 class="font-bold text-gray-900 text-lg mb-3">Wellington Road & South London Retail</h3>
+                    <p class="text-gray-600 text-sm leading-relaxed mb-3">Wellington Road from Highway 401 to Bradley Avenue is London's primary power centre and big-box retail corridor. Anchored by national and regional retailers, food uses, and automotive service, this corridor represents a significant share of London's total retail square footage. Valuation along Wellington Road is driven by traffic counts, anchor tenant health, and access to Highway 401.</p>
+                    <p class="text-gray-600 text-sm leading-relaxed">Community and neighbourhood retail centres are differentiated by anchor type and grocery-anchored assets continue to command lower cap rates than unanchored plazas. Strip retail on Commissioners, Wharncliffe, and Colonel Talbot Road rounds out the suburban retail market.</p>
+                </div>
+                <div class="bg-white p-7 rounded-xl shadow-sm">
+                    <h3 class="font-bold text-gray-900 text-lg mb-3">Oxford Street Corridor & Suburban Nodes</h3>
+                    <p class="text-gray-600 text-sm leading-relaxed mb-3">Oxford Street East and West, along with emerging nodes at Hyde Park, Fanshawe Park Road, and Huron Street in the north end, contain a mix of suburban office, medium-format retail, and neighbourhood-scale commercial uses. Oxford Street nodes support medical offices, professional services, and financial sector tenants.</p>
+                    <p class="text-gray-600 text-sm leading-relaxed">Suburban office valuations require careful analysis of vacancy trends, lease expiry schedules, and the competitive impact of downtown core alternatives. Metrix's familiarity with London's suburban office and retail submarkets informs appraisal assignments that require accurate comparison within a heterogeneous market.</p>
+                </div>
+                <div class="bg-white p-7 rounded-xl shadow-sm">
+                    <h3 class="font-bold text-gray-900 text-lg mb-3">Multi-Family Investment Properties</h3>
+                    <p class="text-gray-600 text-sm leading-relaxed mb-3">London's rental market has been shaped by proximity to Western University, Fanshawe College, and the regional hospital network. Multi-family apartment buildings trade on net income capitalization, and the applicable cap rate varies significantly by building vintage, unit mix, condition, and whether the asset is CMHC-insured.</p>
+                    <p class="text-gray-600 text-sm leading-relaxed">Purpose-built rental buildings — a growing asset class in London due to provincial housing policy changes — require appraisers with experience in pro forma income analysis and market rent stabilization assumptions. Metrix completes multi-family appraisals for lenders, investors, and CMHC-insured financing applications.</p>
+                </div>
+                <div class="bg-white p-7 rounded-xl shadow-sm">
+                    <h3 class="font-bold text-gray-900 text-lg mb-3">Development Land & Intensification Sites</h3>
+                    <p class="text-gray-600 text-sm leading-relaxed mb-3">London's Official Plan and the provincial More Homes Built Faster Act have accelerated intensification along major transit corridors and in the urban growth centres. Development land valuation requires analysis of permitted density, servicing capacity, development charges, and comparable land sales in the context of current entitlement risk.</p>
+                    <p class="text-gray-600 text-sm leading-relaxed">Metrix completes development land appraisals for rezoning applications, severances, land acquisitions, and lender financing for sites across London's residential and mixed-use growth areas.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Valuation Methodology -->
+    <section class="py-16 sm:py-20 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="max-w-3xl mx-auto text-center mb-12" data-aos="fade-up">
+                <h2 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-4">How a Commercial Appraisal Is Completed in London</h2>
+                <p class="text-gray-600 text-lg">A credible commercial appraisal doesn't start with a number — it starts with an analysis of the market. Appraisers apply one or more recognized valuation approaches, weighted according to the property type, quality of available data, and intended use of the report.</p>
+            </div>
+            <div class="grid grid-cols-1 lg:grid-cols-3 gap-8 mb-12" data-aos="fade-up" data-aos-delay="100">
+                <div class="bg-gray-50 rounded-2xl p-8">
+                    <div class="w-12 h-12 bg-metrix-blue text-white rounded-xl flex items-center justify-center font-bold text-xl mb-6">I</div>
+                    <h3 class="text-xl font-bold text-gray-900 mb-4">Income Approach</h3>
+                    <p class="text-gray-600 leading-relaxed mb-4">The income approach is the primary valuation method for income-producing commercial properties — office buildings, retail plazas, industrial facilities, and apartment buildings. It converts an estimate of future net operating income (NOI) into a present value using a capitalization rate (cap rate) derived from comparable investment sales in the London market.</p>
+                    <p class="text-gray-600 leading-relaxed mb-4">For complex or larger assets, a discounted cash flow (DCF) analysis models projected income and expenses over a holding period, discounting each year's net cash flow and the terminal reversion to a present value using a discount rate reflective of investor return expectations for the asset class.</p>
+                    <p class="text-gray-600 leading-relaxed">The appraiser independently derives both the market rent applicable to the property and the appropriate capitalization rate — two conclusions that directly determine value and that require current knowledge of London's commercial lease and investment markets.</p>
+                </div>
+                <div class="bg-gray-50 rounded-2xl p-8">
+                    <div class="w-12 h-12 bg-metrix-blue text-white rounded-xl flex items-center justify-center font-bold text-xl mb-6">C</div>
+                    <h3 class="text-xl font-bold text-gray-900 mb-4">Direct Comparison Approach</h3>
+                    <p class="text-gray-600 leading-relaxed mb-4">The direct comparison approach values a property by comparing it to recent arm's-length sales of similar properties. For each comparable, the appraiser adjusts the sale price to account for differences in date, location, size, condition, zoning, and physical characteristics — arriving at an adjusted per-square-foot or per-unit value that is then applied to the subject property.</p>
+                    <p class="text-gray-600 leading-relaxed mb-4">For commercial properties, comparable selection requires access to detailed transaction data. Metrix appraisers use CoStar Professional, regional MLS data, and in-house transaction records to build comparable sets that reflect London's actual market, not province-wide averages that may not apply locally.</p>
+                    <p class="text-gray-600 leading-relaxed">The direct comparison approach is typically primary for development land, owner-occupied commercial buildings, and property types with active sale markets where income data is limited or secondary.</p>
+                </div>
+                <div class="bg-gray-50 rounded-2xl p-8">
+                    <div class="w-12 h-12 bg-metrix-blue text-white rounded-xl flex items-center justify-center font-bold text-xl mb-6">$</div>
+                    <h3 class="text-xl font-bold text-gray-900 mb-4">Cost Approach</h3>
+                    <p class="text-gray-600 leading-relaxed mb-4">The cost approach estimates value by calculating the depreciated replacement cost of the improvements plus the market value of the underlying land. It is most applicable for special-purpose properties — industrial facilities with unique specifications, owner-occupied manufacturing plants, institutional buildings, and properties where comparable sales or income data is insufficient to support the other approaches.</p>
+                    <p class="text-gray-600 leading-relaxed mb-4">The cost approach requires accurate estimation of reproduction cost (what it would cost to rebuild the property today) and depreciation — including physical deterioration, functional obsolescence, and external obsolescence. In a market with rising construction costs, cost approach valuations require current contractor cost data to remain credible.</p>
+                    <p class="text-gray-600 leading-relaxed">For most income-producing properties, the cost approach serves as a reasonableness check rather than the primary indicator. For unique assets where market data is limited, it may carry more weight in the final value conclusion.</p>
+                </div>
+            </div>
+            <div class="bg-metrix-blue/5 border border-metrix-blue/20 rounded-2xl p-8" data-aos="fade-up">
+                <h3 class="text-xl font-bold text-gray-900 mb-4">Reconciliation: Arriving at a Final Value Opinion</h3>
+                <p class="text-gray-600 leading-relaxed mb-4">After completing each applicable approach, the appraiser reconciles the results into a final value conclusion. This is not a mechanical average — it requires professional judgment about which approach best reflects how typical purchasers and investors make decisions for that property type in that market.</p>
+                <p class="text-gray-600 leading-relaxed">For most London commercial properties, the income approach carries the greatest weight because commercial real estate is purchased primarily as an investment. The direct comparison approach provides market context and a reasonableness check. The final value conclusion is supported by the appraiser's signed certification, which confirms that the opinion was developed independently, that no contingent fees were involved, and that the report meets CUSPAP requirements.</p>
+            </div>
+        </div>
+    </section>
+
+    <!-- What Lenders Need -->
+    <section class="py-16 sm:py-20 bg-gray-50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="max-w-3xl mx-auto text-center mb-12" data-aos="fade-up">
+                <h2 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-4">What Lenders Need From a Commercial Appraisal</h2>
+                <p class="text-gray-600 text-lg">Commercial mortgage lenders have specific requirements for the appraisals they will accept. Understanding these requirements before ordering an appraisal avoids delays, reorders, and financing complications.</p>
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-8" data-aos="fade-up" data-aos-delay="100">
+                <div>
+                    <h3 class="text-xl font-bold text-gray-900 mb-4">Designation Requirements</h3>
+                    <p class="text-gray-600 leading-relaxed mb-4">Major Canadian lenders — chartered banks, credit unions, CMHC, and most institutional lenders — require that commercial appraisals be signed by an AACI-designated appraiser. This is non-negotiable for commercial files. A CRA-designated appraiser is not authorized to complete commercial appraisals, and a report signed by a non-designated appraiser will be rejected at underwriting regardless of its content quality.</p>
+                    <p class="text-gray-600 leading-relaxed">Every appraisal Metrix delivers for commercial financing is signed by an active AACI-designated member in good standing with the Appraisal Institute of Canada. You can verify an appraiser's standing and designation through the <a href="https://www.aicanada.ca/find-an-appraiser/" target="_blank" rel="noopener noreferrer" class="text-metrix-blue hover:underline">AIC member directory</a>.</p>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-900 mb-4">CUSPAP Compliance</h3>
+                    <p class="text-gray-600 leading-relaxed mb-4">Lenders require that appraisal reports comply with CUSPAP — the Canadian Uniform Standards of Professional Appraisal Practice. A CUSPAP-compliant report identifies the authorized client and authorized users by name, states the intended use of the report, specifies the effective date, documents the scope of work, and includes a signed certification by the appraiser.</p>
+                    <p class="text-gray-600 leading-relaxed">Lenders' internal appraisal review departments check for CUSPAP compliance as part of their risk management process. A report that omits required elements — or that names the wrong authorized user — will be returned for revision, delaying the mortgage approval.</p>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-900 mb-4">Lender-Specific Formats</h3>
+                    <p class="text-gray-600 leading-relaxed mb-4">Some major Canadian lenders — particularly CMHC for insured multi-family financing — have specific addenda, questionnaires, or supplemental requirements that must be included in the appraisal. Metrix is familiar with the standard reporting requirements of Canada's major chartered banks, credit unions, and CMHC for commercial and multi-family files.</p>
+                    <p class="text-gray-600 leading-relaxed">When ordering a commercial appraisal, provide the name of the lender and the loan type. This allows the appraiser to confirm that the report scope and format meet the lender's specific requirements before the assignment begins — not after the report is delivered.</p>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-900 mb-4">Intended Use and Authorized Users</h3>
+                    <p class="text-gray-600 leading-relaxed mb-4">A commercial appraisal prepared for one lender cannot simply be submitted to a different lender. CUSPAP requires that the report identify its authorized users by name. A report naming Bank A as the authorized user is not a valid appraisal for Bank B, even if the property and value are the same.</p>
+                    <p class="text-gray-600 leading-relaxed">If the intended lender changes between the time an appraisal is ordered and when the mortgage is placed, contact Metrix to discuss whether the report can be updated to name the new authorized user — this is a client-specific determination governed by CUSPAP's confidentiality and authorization framework.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Process -->
+    <section class="py-16 sm:py-20 bg-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="max-w-3xl mx-auto text-center mb-12" data-aos="fade-up">
                 <h2 class="text-2xl sm:text-3xl font-bold text-gray-900 mb-4">Our London Commercial Appraisal Process</h2>
@@ -497,6 +641,22 @@
                     <div class="border border-gray-200 rounded-xl p-6">
                         <h3 class="font-semibold text-gray-900 mb-2">What credentials do Metrix commercial appraisers hold?</h3>
                         <p class="text-gray-600">Our commercial appraisers hold the AACI (Accredited Appraiser Canadian Institute) designation — the highest professional designation in Canadian real estate appraisal — and are CUSPAP compliant. Several appraisers also hold RICS (Royal Institution of Chartered Surveyors) and IRWA (International Right of Way Association) designations, unique in the London market.</p>
+                    </div>
+                    <div class="border border-gray-200 rounded-xl p-6">
+                        <h3 class="font-semibold text-gray-900 mb-2">What is the difference between the income approach and the direct comparison approach?</h3>
+                        <p class="text-gray-600">The income approach converts an estimate of net operating income into value using a capitalization rate drawn from comparable investment sales. It is the primary approach for income-producing commercial properties. The direct comparison approach values the property by comparing it to recent sales of similar assets, with adjustments for differences in date, location, size, and condition. For most London commercial properties, the income approach carries the most weight; the comparison approach provides market context and a reasonableness check. The cost approach is used for special-purpose or low-turnover properties where income or sales data is insufficient.</p>
+                    </div>
+                    <div class="border border-gray-200 rounded-xl p-6">
+                        <h3 class="font-semibold text-gray-900 mb-2">Can I use a commercial appraisal ordered for one lender to submit to a different lender?</h3>
+                        <p class="text-gray-600">Generally no. CUSPAP requires that an appraisal report identify its authorized users by name. A report naming one lender is not a valid appraisal submission for a different institution, even if the property and value are unchanged. If the lending relationship changes after an appraisal is ordered, contact Metrix to determine whether the report can be updated to reflect the new authorized user — this depends on the specific circumstances and whether the appraiser's independence and objectivity can be maintained.</p>
+                    </div>
+                    <div class="border border-gray-200 rounded-xl p-6">
+                        <h3 class="font-semibold text-gray-900 mb-2">Does Metrix appraise properties outside of London, Ontario?</h3>
+                        <p class="text-gray-600">Yes. Metrix Realty Group provides commercial appraisals across Southwestern Ontario from offices in London and Windsor. The firm's London team covers Middlesex, Elgin, Oxford, Perth, Huron, and Lambton counties — including St. Thomas, Woodstock, Stratford, and Sarnia. For specialized assignments, Metrix completes appraisals across Ontario. The Windsor office handles Windsor-Essex, Chatham-Kent, and surrounding areas.</p>
+                    </div>
+                    <div class="border border-gray-200 rounded-xl p-6">
+                        <h3 class="font-semibold text-gray-900 mb-2">What information do I need to provide to get a commercial appraisal started in London?</h3>
+                        <p class="text-gray-600">To begin, provide the property address, a brief description of the property type and its current use, the purpose and intended use of the appraisal (mortgage financing, sale, legal, etc.), the name of any lender or other authorized user who will receive the report, and the required delivery date. For income-producing properties, having current rent rolls, lease summaries, and recent operating expense statements available will speed up the assignment. Metrix will confirm the scope, fee, and delivery timeline before work begins.</p>
                     </div>
                 </div>
             </div>
@@ -564,18 +724,15 @@
                 
                 <!-- Market Areas -->
                 <div>
-                    <h3 class="text-white font-semibold text-lg mb-6">Office Locations</h3>
+                    <h3 class="text-white font-semibold text-lg mb-6">London, Ontario</h3>
                     <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/london/" class="hover:text-white transition-colors duration-200 font-semibold text-white">London (Main Office)</a></li>
-                        <li><a href="/windsor/" class="hover:text-white transition-colors duration-200 font-semibold text-white">Windsor</a></li>
-                    </ul>
-                    <h4 class="text-white font-semibold text-sm mt-6 mb-3">Also Serving</h4>
-                    <ul class="space-y-2 text-gray-300 text-sm">
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Sarnia–Lambton</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Chatham–Kent</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">KW–Cambridge–Guelph</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">Brantford–Hamilton–Burlington</a></li>
-                        <li><a href="/market-areas" class="hover:text-white transition-colors duration-200">All Ontario Coverage →</a></li>
+                        <li><a href="/london/commercial-appraisal" class="hover:text-white transition-colors duration-200 font-semibold text-white">Commercial Appraisal</a></li>
+                        <li><a href="/london/residential-appraisal" class="hover:text-white transition-colors duration-200">Residential Appraisal</a></li>
+                        <li><a href="/london/industrial-appraisal" class="hover:text-white transition-colors duration-200">Industrial Appraisal</a></li>
+                        <li><a href="/london/litigation-support" class="hover:text-white transition-colors duration-200">Litigation Support</a></li>
+                        <li><a href="/london/estate-appraisal" class="hover:text-white transition-colors duration-200">Estate Appraisal</a></li>
+                        <li><a href="/london/divorce-appraisal" class="hover:text-white transition-colors duration-200">Divorce Appraisal</a></li>
+                        <li><a href="/london/property-tax-appeal" class="hover:text-white transition-colors duration-200">Property Tax Appeal</a></li>
                     </ul>
                 </div>
                 


### PR DESCRIPTION
## Summary

Expands the London commercial appraisal landing page from ~900 words to ~3,200 words using answer-block architecture. This page directly competes with Aion Appraisals' programmatic 12,000-word London page.

## New sections added

**1. London Commercial Submarkets** — 6 subsections covering:
- Downtown Core (office vacancy context, adaptive reuse)
- Airport Road / South London Industrial (4% vacancy, logistics/manufacturing)
- Wellington Road & South London Retail (power centres, anchor tenant dynamics)
- Oxford Street & Suburban Nodes (medical office, suburban office trends)
- Multi-Family Investment (university proximity, CMHC insured)
- Development Land & Intensification (Official Plan, More Homes Built Faster Act)

**2. Valuation Methodology** — 3 approach explanations (income/cap rate/DCF, direct comparison, cost approach) + reconciliation explanation. Targets "how does a commercial appraisal work" research queries.

**3. What Lenders Need** — 4 panels covering AACI designation requirement, CUSPAP compliance, lender-specific formats (CMHC addenda), and authorized user restrictions.

**4. FAQ expanded from 4 → 9** — new: income vs comparison approach, cross-lender submission, service area, getting started checklist

## Other changes

- Footer updated to cross-link all 7 London sub-pages (including the 4 new pages from PR #34)
- FAQPage JSON-LD updated with 4 new Q&A pairs
- `dateModified` unchanged (schema set at 2026-05-27 — no schema structural changes needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded the London commercial appraisal page from ~900 to ~3,200 words to improve SEO and compete with Aion’s London page. Adds submarket insights, a clear valuation process, lender requirements, and an expanded FAQ, plus footer and FAQPage JSON-LD updates.

- New Features
  - London Commercial Submarkets: 6 areas (Downtown Core, Airport Road industrial, Wellington Road retail, Oxford Street nodes, multi-family, development land).
  - Valuation Methodology: income (cap rate/DCF), direct comparison, cost approach, and reconciliation.
  - What Lenders Need: AACI requirement, CUSPAP compliance, lender-specific formats (CMHC), authorized user rules.
  - FAQ: 4 → 9 (income vs comparison, cross-lender submission, service area, getting started).
  - Footer: cross-links to all 7 London sub-pages.
  - JSON-LD: FAQPage updated with 4 new Q&A; `dateModified` unchanged (2026-05-27).

<sup>Written for commit 670e5e2fc40877d4e7b3611bb913a4b41dc19079. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

