### PR TITLE
fix(analytics): migrate to GuestGetter-owned GTM container

### DIFF
--- a/accessibility/index.html
+++ b/accessibility/index.html
@@ -2,6 +2,14 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
+    <!-- End Google Tag Manager -->
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Accessibility Statement | Metrix Realty Group</title>
     <link rel="icon" type="image/png" href="/favicon.png">
@@ -31,6 +39,11 @@
     </script>
 </head>
 <body class="font-inter bg-gray-50">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    
     <!-- Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/ali-mahfoud/index.html
+++ b/ali-mahfoud/index.html
@@ -2,6 +2,14 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
+    <!-- End Google Tag Manager -->
+    
     <link rel="canonical" href="https://metrixrealty.com/ali-mahfoud">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Ali Mahfoud | Senior Appraiser | Metrix Realty Group</title>
@@ -88,6 +96,11 @@
     </script>
 </head>
 <body class="font-inter">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    
     <!-- Global Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/assets/js/ab-testing.js
+++ b/assets/js/ab-testing.js
@@ -70,15 +70,6 @@ class ABTesting {
         this.userVariants[testName] = variant;
         localStorage.setItem('ab_test_variants', JSON.stringify(this.userVariants));
 
-        // Track variant assignment in GA4
-        gtag('event', 'ab_test_assigned', {
-            'event_category': 'ab_testing',
-            'event_label': `${testName}_${variant}`,
-            'custom_parameter_1': testName,
-            'custom_parameter_2': variant
-        });
-
-        // Send to GTM
         window.dataLayer = window.dataLayer || [];
         window.dataLayer.push({
             'event': 'ab_test_assigned',
@@ -99,17 +90,6 @@ class ABTesting {
             return;
         }
 
-        // Track conversion in GA4
-        gtag('event', 'ab_test_conversion', {
-            'event_category': 'ab_testing',
-            'event_label': `${testName}_${variant}_${conversionType}`,
-            'value': value,
-            'custom_parameter_1': testName,
-            'custom_parameter_2': variant,
-            'custom_parameter_3': conversionType
-        });
-
-        // Send to GTM
         window.dataLayer = window.dataLayer || [];
         window.dataLayer.push({
             'event': 'ab_test_conversion',

--- a/assets/js/analytics-tracking.js
+++ b/assets/js/analytics-tracking.js
@@ -74,15 +74,7 @@ document.addEventListener('DOMContentLoaded', function() {
         button.addEventListener('click', function() {
             const buttonText = this.textContent.trim() || this.getAttribute('aria-label') || 'CTA Button';
             const destination = this.href || 'button_action';
-            
-            // Send to GA4
-            gtag('event', 'cta_click', {
-                'event_category': 'engagement',
-                'event_label': buttonText,
-                'value': 1
-            });
-            
-            // Send to GTM
+
             window.dataLayer = window.dataLayer || [];
             window.dataLayer.push({
                 'event': 'cta_click',
@@ -104,24 +96,6 @@ document.addEventListener('DOMContentLoaded', function() {
             // Track different Calendly events
             switch(eventType) {
                 case 'calendly.event_scheduled':
-                    // CONVERSION EVENT - Someone booked a meeting!
-                    gtag('event', 'conversion', {
-                        'send_to': 'G-TB55XJ4B9D',
-                        'event_category': 'conversion',
-                        'event_label': 'calendar_booking',
-                        'value': 100, // Assign monetary value to conversion
-                        'currency': 'CAD'
-                    });
-                    
-                    // Also send as custom conversion event
-                    gtag('event', 'calendar_booking', {
-                        'event_category': 'conversion',
-                        'event_label': 'calendly_scheduled',
-                        'value': 100,
-                        'currency': 'CAD'
-                    });
-                    
-                    // Send to GTM for advanced tracking
                     window.dataLayer = window.dataLayer || [];
                     window.dataLayer.push({
                         'event': 'conversion',
@@ -136,12 +110,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     break;
                     
                 case 'calendly.profile_page_viewed':
-                    gtag('event', 'calendar_viewed', {
-                        'event_category': 'engagement',
-                        'event_label': 'calendly_opened',
-                        'value': 1
-                    });
-                    
+                    window.dataLayer = window.dataLayer || [];
                     window.dataLayer.push({
                         'event': 'calendar_viewed',
                         'page_location': window.location.href
@@ -151,12 +120,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     break;
                     
                 case 'calendly.date_and_time_selected':
-                    gtag('event', 'calendar_time_selected', {
-                        'event_category': 'engagement',
-                        'event_label': 'time_slot_selected',
-                        'value': 10
-                    });
-                    
+                    window.dataLayer = window.dataLayer || [];
                     window.dataLayer.push({
                         'event': 'calendar_time_selected',
                         'page_location': window.location.href
@@ -166,13 +130,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     break;
                     
                 default:
-                    // Track any other Calendly interactions
-                    gtag('event', 'calendly_interaction', {
-                        'event_category': 'engagement',
-                        'event_label': eventType,
-                        'value': 1
-                    });
-                    
+                    window.dataLayer = window.dataLayer || [];
                     window.dataLayer.push({
                         'event': 'calendly_interaction',
                         'calendly_event': eventType,
@@ -195,14 +153,6 @@ document.addEventListener('DOMContentLoaded', function() {
             if (scrollPercent >= milestone && maxScroll < milestone) {
                 maxScroll = milestone;
                 
-                // Send to GA4
-                gtag('event', 'scroll_depth', {
-                    'event_category': 'engagement',
-                    'event_label': milestone + '%',
-                    'value': milestone
-                });
-                
-                // Send to GTM
                 window.dataLayer = window.dataLayer || [];
                 window.dataLayer.push({
                     'event': 'scroll_depth',

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -300,14 +300,13 @@ document.addEventListener('DOMContentLoaded', function() {
     
     // ===== ANALYTICS TRACKING (Placeholder) =====
     function trackEvent(category, action, label) {
-        // Google Analytics 4 event tracking
-        if (typeof gtag !== 'undefined') {
-            gtag('event', action, {
-                event_category: category,
-                event_label: label
-            });
-        }
-        
+        window.dataLayer = window.dataLayer || [];
+        window.dataLayer.push({
+            event: action,
+            event_category: category,
+            event_label: label
+        });
+
         console.log(`Event tracked: ${category} - ${action} - ${label}`);
     }
     
@@ -396,4 +395,4 @@ function formatPhoneNumber(phoneNumber) {
 function isValidEmail(email) {
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     return emailRegex.test(email);
-} 
+}

--- a/contact/index.html
+++ b/contact/index.html
@@ -15,7 +15,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
 
     <script type="application/ld+json">
@@ -319,7 +319,7 @@
 
 <body class="font-inter text-smooth bg-white">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV"
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
     

--- a/contact/thank-you/index.html
+++ b/contact/thank-you/index.html
@@ -13,7 +13,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
 
     <script type="application/ld+json">
@@ -68,7 +68,7 @@
 
 <body class="font-inter text-smooth bg-white">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV"
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
 

--- a/dan-van-houtte/index.html
+++ b/dan-van-houtte/index.html
@@ -2,6 +2,14 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
+    <!-- End Google Tag Manager -->
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Daniel J. Van Houtte | CEO & President | Metrix Realty Group</title>
     <link rel="icon" type="image/png" href="/favicon.png">
@@ -163,6 +171,11 @@
     </script>
 </head>
 <body class="font-inter">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    
     <!-- Global Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
     
 
@@ -713,7 +713,7 @@
 </head>
 <body class="font-inter">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV"
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
     

--- a/insights/aaci-vs-cra-appraisal-designations.html
+++ b/insights/aaci-vs-cra-appraisal-designations.html
@@ -30,7 +30,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
 
     <script src="https://cdn.tailwindcss.com"></script>
@@ -197,7 +197,7 @@
 </head>
 <body class="bg-white">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <div class="overlay" id="overlay"></div>
 

--- a/insights/aaci-vs-cra-appraisal-designations/index.html
+++ b/insights/aaci-vs-cra-appraisal-designations/index.html
@@ -30,7 +30,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
 
     <script src="https://cdn.tailwindcss.com"></script>
@@ -197,7 +197,7 @@
 </head>
 <body class="bg-white">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <div class="overlay" id="overlay"></div>
 

--- a/insights/appraisal-vs-realtor-cma-ontario.html
+++ b/insights/appraisal-vs-realtor-cma-ontario.html
@@ -27,7 +27,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
 
     <script src="https://cdn.tailwindcss.com"></script>
@@ -180,7 +180,7 @@
 </head>
 <body class="bg-white">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <div class="overlay" id="overlay"></div>
 

--- a/insights/appraisal-vs-realtor-cma-ontario/index.html
+++ b/insights/appraisal-vs-realtor-cma-ontario/index.html
@@ -27,7 +27,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
 
     <script src="https://cdn.tailwindcss.com"></script>
@@ -180,7 +180,7 @@
 </head>
 <body class="bg-white">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <div class="overlay" id="overlay"></div>
 

--- a/insights/bank-appraisal-vs-private-appraisal-ontario.html
+++ b/insights/bank-appraisal-vs-private-appraisal-ontario.html
@@ -27,7 +27,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
 
     <script src="https://cdn.tailwindcss.com"></script>
@@ -178,7 +178,7 @@
 </head>
 <body class="bg-white">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <div class="overlay" id="overlay"></div>
 

--- a/insights/bank-appraisal-vs-private-appraisal-ontario/index.html
+++ b/insights/bank-appraisal-vs-private-appraisal-ontario/index.html
@@ -27,7 +27,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
 
     <script src="https://cdn.tailwindcss.com"></script>
@@ -178,7 +178,7 @@
 </head>
 <body class="bg-white">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <div class="overlay" id="overlay"></div>
 

--- a/insights/commercial-appraisal-documents-ontario.html
+++ b/insights/commercial-appraisal-documents-ontario.html
@@ -30,7 +30,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
 
     <script src="https://cdn.tailwindcss.com"></script>
@@ -197,7 +197,7 @@
 </head>
 <body class="bg-white">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <div class="overlay" id="overlay"></div>
 

--- a/insights/commercial-appraisal-documents-ontario/index.html
+++ b/insights/commercial-appraisal-documents-ontario/index.html
@@ -30,7 +30,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
 
     <script src="https://cdn.tailwindcss.com"></script>
@@ -197,7 +197,7 @@
 </head>
 <body class="bg-white">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <div class="overlay" id="overlay"></div>
 

--- a/insights/cuspap-2026-ontario-appraisal-clients.html
+++ b/insights/cuspap-2026-ontario-appraisal-clients.html
@@ -30,7 +30,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
 
     <script src="https://cdn.tailwindcss.com"></script>
@@ -198,7 +198,7 @@
 </head>
 <body class="bg-white">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <div class="overlay" id="overlay"></div>
 

--- a/insights/cuspap-2026-ontario-appraisal-clients/index.html
+++ b/insights/cuspap-2026-ontario-appraisal-clients/index.html
@@ -30,7 +30,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
 
     <script src="https://cdn.tailwindcss.com"></script>
@@ -198,7 +198,7 @@
 </head>
 <body class="bg-white">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <div class="overlay" id="overlay"></div>
 

--- a/insights/index.html
+++ b/insights/index.html
@@ -26,7 +26,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
     
     <script src="https://cdn.tailwindcss.com"></script>
@@ -263,7 +263,7 @@
 </head>
 <body class="bg-white">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV"
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
 

--- a/insights/industrial-property-appraisal-factors-ontario.html
+++ b/insights/industrial-property-appraisal-factors-ontario.html
@@ -30,7 +30,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
 
     <script src="https://cdn.tailwindcss.com"></script>
@@ -197,7 +197,7 @@
 </head>
 <body class="bg-white">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <div class="overlay" id="overlay"></div>
 

--- a/insights/industrial-property-appraisal-factors-ontario/index.html
+++ b/insights/industrial-property-appraisal-factors-ontario/index.html
@@ -30,7 +30,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
 
     <script src="https://cdn.tailwindcss.com"></script>
@@ -197,7 +197,7 @@
 </head>
 <body class="bg-white">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <div class="overlay" id="overlay"></div>
 

--- a/insights/listing-prices-misconception.html
+++ b/insights/listing-prices-misconception.html
@@ -27,7 +27,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
     
     <script src="https://cdn.tailwindcss.com"></script>
@@ -377,7 +377,7 @@
 </head>
 <body class="bg-white">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV"
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
     

--- a/insights/listing-prices-misconception/index.html
+++ b/insights/listing-prices-misconception/index.html
@@ -27,7 +27,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
     
     <script src="https://cdn.tailwindcss.com"></script>
@@ -377,7 +377,7 @@
 </head>
 <body class="bg-white">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV"
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
     

--- a/insights/ontario-market-analysis-2016-2024.html
+++ b/insights/ontario-market-analysis-2016-2024.html
@@ -27,7 +27,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
     
     <script src="https://cdn.tailwindcss.com"></script>
@@ -400,7 +400,7 @@
 </head>
 <body class="bg-white">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV"
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
     

--- a/insights/ontario-market-analysis-2016-2024/index.html
+++ b/insights/ontario-market-analysis-2016-2024/index.html
@@ -27,7 +27,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
     
     <script src="https://cdn.tailwindcss.com"></script>
@@ -400,7 +400,7 @@
 </head>
 <body class="bg-white">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV"
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
     

--- a/insights/sentimental-equity-problem.html
+++ b/insights/sentimental-equity-problem.html
@@ -27,7 +27,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
     
     <script src="https://cdn.tailwindcss.com"></script>
@@ -370,7 +370,7 @@
 </head>
 <body class="bg-white">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV"
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
     

--- a/insights/sentimental-equity-problem/index.html
+++ b/insights/sentimental-equity-problem/index.html
@@ -27,7 +27,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
     
     <script src="https://cdn.tailwindcss.com"></script>
@@ -370,7 +370,7 @@
 </head>
 <body class="bg-white">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV"
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
     

--- a/insights/what-is-aaci-designation.html
+++ b/insights/what-is-aaci-designation.html
@@ -29,7 +29,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
 
     <script src="https://cdn.tailwindcss.com"></script>
@@ -196,7 +196,7 @@
 </head>
 <body class="bg-white">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <div class="overlay" id="overlay"></div>
 

--- a/insights/what-is-aaci-designation/index.html
+++ b/insights/what-is-aaci-designation/index.html
@@ -29,7 +29,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
 
     <script src="https://cdn.tailwindcss.com"></script>
@@ -196,7 +196,7 @@
 </head>
 <body class="bg-white">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <div class="overlay" id="overlay"></div>
 

--- a/insights/what-is-cuspap.html
+++ b/insights/what-is-cuspap.html
@@ -29,7 +29,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
 
     <script src="https://cdn.tailwindcss.com"></script>
@@ -196,7 +196,7 @@
 </head>
 <body class="bg-white">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <div class="overlay" id="overlay"></div>
 

--- a/insights/what-is-cuspap/index.html
+++ b/insights/what-is-cuspap/index.html
@@ -29,7 +29,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
 
     <script src="https://cdn.tailwindcss.com"></script>
@@ -196,7 +196,7 @@
 </head>
 <body class="bg-white">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <div class="overlay" id="overlay"></div>
 

--- a/james-sibbald/index.html
+++ b/james-sibbald/index.html
@@ -13,18 +13,8 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
-    
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-TB55XJ4B9D"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-TB55XJ4B9D');
-    </script>
     
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -105,7 +95,7 @@
 </head>
 <body class="font-inter">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV"
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
     

--- a/jeff-petruzella/index.html
+++ b/jeff-petruzella/index.html
@@ -2,6 +2,14 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
+    <!-- End Google Tag Manager -->
+    
     <link rel="canonical" href="https://metrixrealty.com/jeff-petruzella">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Jeff J.N. Petruzella | Vice-President of Residential Operations | Metrix Realty Group</title>
@@ -88,6 +96,11 @@
     </script>
 </head>
 <body class="font-inter">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    
     <!-- Global Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/john-carter/index.html
+++ b/john-carter/index.html
@@ -2,6 +2,14 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
+    <!-- End Google Tag Manager -->
+    
     <link rel="canonical" href="https://metrixrealty.com/john-carter">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>John S. Carter | Senior Appraiser | Metrix Realty Group</title>
@@ -88,6 +96,11 @@
     </script>
 </head>
 <body class="font-inter">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    
     <!-- Global Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/london/commercial-appraisal/index.html
+++ b/london/commercial-appraisal/index.html
@@ -20,7 +20,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
 
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -217,7 +217,7 @@
     </script>
 </head>
 <body class="font-inter">
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <!-- Global Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">

--- a/london/divorce-appraisal/index.html
+++ b/london/divorce-appraisal/index.html
@@ -20,7 +20,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
 
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -131,7 +131,7 @@
     </script>
 </head>
 <body class="bg-white">
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <div id="mobile-menu-overlay" class="mobile-menu-overlay"></div>
 

--- a/london/estate-appraisal/index.html
+++ b/london/estate-appraisal/index.html
@@ -20,7 +20,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
 
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -131,7 +131,7 @@
     </script>
 </head>
 <body class="bg-white">
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <div id="mobile-menu-overlay" class="mobile-menu-overlay"></div>
 

--- a/london/index.html
+++ b/london/index.html
@@ -21,7 +21,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
 
     <!-- Open Graph / Facebook -->
@@ -442,7 +442,7 @@
 </head>
 <body class="font-inter">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV"
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     
     <!-- Header -->

--- a/london/industrial-appraisal/index.html
+++ b/london/industrial-appraisal/index.html
@@ -20,7 +20,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
 
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -171,7 +171,7 @@
     </script>
 </head>
 <body class="font-inter">
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <!-- Global Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">

--- a/london/litigation-support/index.html
+++ b/london/litigation-support/index.html
@@ -20,7 +20,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
 
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -99,7 +99,7 @@
     </script>
 </head>
 <body class="bg-white">
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <div id="mobile-menu-overlay" class="mobile-menu-overlay"></div>
 

--- a/london/property-tax-appeal/index.html
+++ b/london/property-tax-appeal/index.html
@@ -20,7 +20,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
 
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -131,7 +131,7 @@
     </script>
 </head>
 <body class="bg-white">
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <div id="mobile-menu-overlay" class="mobile-menu-overlay"></div>
 

--- a/london/residential-appraisal/index.html
+++ b/london/residential-appraisal/index.html
@@ -20,7 +20,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
 
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -179,7 +179,7 @@
     </script>
 </head>
 <body class="font-inter">
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <!-- Global Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">

--- a/madison-collver/index.html
+++ b/madison-collver/index.html
@@ -2,6 +2,14 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
+    <!-- End Google Tag Manager -->
+    
     <link rel="canonical" href="https://metrixrealty.com/madison-collver">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Madison Collver | Appraiser | Metrix Realty Group</title>
@@ -88,6 +96,11 @@
     </script>
 </head>
 <body class="font-inter">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    
     <!-- Global Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/maia-mcclintock/index.html
+++ b/maia-mcclintock/index.html
@@ -2,6 +2,14 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
+    <!-- End Google Tag Manager -->
+    
     <link rel="canonical" href="https://metrixrealty.com/maia-mcclintock">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Maia McClintock | Senior Appraiser | Metrix Realty Group</title>
@@ -88,6 +96,11 @@
     </script>
 </head>
 <body class="font-inter">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    
     <!-- Global Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/mark-penhale/index.html
+++ b/mark-penhale/index.html
@@ -2,6 +2,14 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
+    <!-- End Google Tag Manager -->
+    
     <link rel="canonical" href="https://metrixrealty.com/mark-penhale">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Mark Penhale | Agricultural & Industrial Property Specialist | Metrix Realty Group</title>
@@ -88,6 +96,11 @@
     </script>
 </head>
 <body class="font-inter">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    
     <!-- Global Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/market-areas/index.html
+++ b/market-areas/index.html
@@ -15,7 +15,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
 
     <script type="application/ld+json">
@@ -334,7 +334,7 @@
 </head>
 <body class="font-inter">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV"
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
     

--- a/mason-hewitt/index.html
+++ b/mason-hewitt/index.html
@@ -13,18 +13,8 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
-    
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-TB55XJ4B9D"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-TB55XJ4B9D');
-    </script>
     
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -105,7 +95,7 @@
 </head>
 <body class="font-inter">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV"
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
     

--- a/michael-fry/index.html
+++ b/michael-fry/index.html
@@ -2,6 +2,14 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
+    <!-- End Google Tag Manager -->
+    
     <link rel="canonical" href="https://metrixrealty.com/michael-fry">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Michael R. Fry | AIC Candidate Member | Metrix Realty Group</title>
@@ -85,6 +93,11 @@
     </script>
 </head>
 <body class="font-inter">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    
     <!-- Global Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/paula-busch/index.html
+++ b/paula-busch/index.html
@@ -2,6 +2,14 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
+    <!-- End Google Tag Manager -->
+    
     <link rel="canonical" href="https://metrixrealty.com/paula-busch">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paula E. Busch | Vice President Commercial Operations | Metrix Realty Group</title>
@@ -88,6 +96,11 @@
     </script>
 </head>
 <body class="font-inter">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    
     <!-- Global Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/privacy-policy/index.html
+++ b/privacy-policy/index.html
@@ -13,7 +13,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
     
     <script src="https://cdn.tailwindcss.com"></script>
@@ -23,7 +23,7 @@
 </head>
 <body class="bg-white">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV"
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
 

--- a/roman-virk/index.html
+++ b/roman-virk/index.html
@@ -2,6 +2,14 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
+    <!-- End Google Tag Manager -->
+    
     <link rel="canonical" href="https://metrixrealty.com/roman-virk">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Roman Virk | AACI Designated Appraiser | Metrix Realty Group</title>
@@ -88,6 +96,11 @@
     </script>
 </head>
 <body class="font-inter">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    
     <!-- Global Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/sam-van-houtte/index.html
+++ b/sam-van-houtte/index.html
@@ -2,6 +2,14 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
+    <!-- End Google Tag Manager -->
+    
     <link rel="canonical" href="https://metrixrealty.com/sam-van-houtte">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sam Van Houtte | Vice-President Operations | Metrix Realty Group</title>
@@ -88,6 +96,11 @@
     </script>
 </head>
 <body class="font-inter">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    
     <!-- Global Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/services-enhanced.html
+++ b/services-enhanced.html
@@ -23,7 +23,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
 
     <script type="application/ld+json">
@@ -374,7 +374,7 @@
 </head>
 <body class="font-inter">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV"
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
 

--- a/services/commercial-property-valuations.html
+++ b/services/commercial-property-valuations.html
@@ -21,7 +21,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
 
     <script src="https://cdn.tailwindcss.com"></script>
@@ -134,7 +134,7 @@
     </script>
 </head>
 <body class="font-inter">
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <!-- Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">

--- a/services/commercial-property-valuations/index.html
+++ b/services/commercial-property-valuations/index.html
@@ -21,7 +21,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
 
     <script src="https://cdn.tailwindcss.com"></script>
@@ -184,7 +184,7 @@
     </script>
 </head>
 <body class="font-inter">
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <!-- Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">

--- a/services/government-institutional-services.html
+++ b/services/government-institutional-services.html
@@ -21,7 +21,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
 
     <script src="https://cdn.tailwindcss.com"></script>
@@ -111,7 +111,7 @@
     </script>
 </head>
 <body class="font-inter">
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/services/government-institutional-services/index.html
+++ b/services/government-institutional-services/index.html
@@ -21,7 +21,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
 
     <script src="https://cdn.tailwindcss.com"></script>
@@ -161,7 +161,7 @@
     </script>
 </head>
 <body class="font-inter">
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/services/index.html
+++ b/services/index.html
@@ -23,7 +23,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
 
     <script type="application/ld+json">
@@ -423,7 +423,7 @@
 </head>
 <body class="font-inter">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV"
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
 

--- a/services/litigation-support-expert-testimony.html
+++ b/services/litigation-support-expert-testimony.html
@@ -21,7 +21,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
 
     <script src="https://cdn.tailwindcss.com"></script>
@@ -111,7 +111,7 @@
     </script>
 </head>
 <body class="font-inter">
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/services/litigation-support-expert-testimony/index.html
+++ b/services/litigation-support-expert-testimony/index.html
@@ -21,7 +21,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
 
     <script src="https://cdn.tailwindcss.com"></script>
@@ -161,7 +161,7 @@
     </script>
 </head>
 <body class="font-inter">
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/services/real-estate-consulting.html
+++ b/services/real-estate-consulting.html
@@ -21,7 +21,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
 
     <script src="https://cdn.tailwindcss.com"></script>
@@ -111,7 +111,7 @@
     </script>
 </head>
 <body class="font-inter">
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/services/real-estate-consulting/index.html
+++ b/services/real-estate-consulting/index.html
@@ -21,7 +21,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
 
     <script src="https://cdn.tailwindcss.com"></script>
@@ -161,7 +161,7 @@
     </script>
 </head>
 <body class="font-inter">
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/services/residential-property-appraisals.html
+++ b/services/residential-property-appraisals.html
@@ -21,7 +21,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
 
     <script src="https://cdn.tailwindcss.com"></script>
@@ -121,7 +121,7 @@
     </script>
 </head>
 <body class="font-inter">
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <!-- Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">

--- a/services/residential-property-appraisals/index.html
+++ b/services/residential-property-appraisals/index.html
@@ -21,7 +21,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
 
     <script src="https://cdn.tailwindcss.com"></script>
@@ -171,7 +171,7 @@
     </script>
 </head>
 <body class="font-inter">
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <!-- Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">

--- a/suzanne-de-jong/index.html
+++ b/suzanne-de-jong/index.html
@@ -2,6 +2,14 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
+    <!-- End Google Tag Manager -->
+    
     <link rel="canonical" href="https://metrixrealty.com/suzanne-de-jong">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Suzanne De Jong | Vice President Commercial Operations | Metrix Realty Group</title>
@@ -88,6 +96,11 @@
     </script>
 </head>
 <body class="font-inter">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    
     <!-- Global Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/team/index.html
+++ b/team/index.html
@@ -15,7 +15,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
 
     <script type="application/ld+json">
@@ -241,7 +241,7 @@
 </head>
 <body class="font-inter">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV"
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
     

--- a/terms-of-service/index.html
+++ b/terms-of-service/index.html
@@ -13,7 +13,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
     
     <script src="https://cdn.tailwindcss.com"></script>
@@ -23,7 +23,7 @@
 </head>
 <body class="bg-white">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV"
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
 

--- a/tyler-munn/index.html
+++ b/tyler-munn/index.html
@@ -2,6 +2,14 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
+    <!-- End Google Tag Manager -->
+    
     <link rel="canonical" href="https://metrixrealty.com/tyler-munn">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Tyler Munn | AIC Candidate | Metrix Realty Group</title>
@@ -85,6 +93,11 @@
     </script>
 </head>
 <body class="font-inter">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    
     <!-- Global Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/windsor/commercial-appraisal/index.html
+++ b/windsor/commercial-appraisal/index.html
@@ -22,7 +22,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
 
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -152,7 +152,7 @@
     </script>
 </head>
 <body class="font-inter">
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <!-- Global Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">

--- a/windsor/index.html
+++ b/windsor/index.html
@@ -20,7 +20,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
     <!-- End Google Tag Manager -->
 
     <!-- Open Graph / Facebook -->
@@ -415,7 +415,7 @@
 </head>
 <body class="font-inter">
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV"
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     
     <!-- Header -->

--- a/windsor/industrial-appraisal/index.html
+++ b/windsor/industrial-appraisal/index.html
@@ -22,7 +22,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
 
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -152,7 +152,7 @@
     </script>
 </head>
 <body class="font-inter">
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <!-- Global Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">

--- a/windsor/investment-appraisal/index.html
+++ b/windsor/investment-appraisal/index.html
@@ -22,7 +22,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
 
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -152,7 +152,7 @@
     </script>
 </head>
 <body class="font-inter">
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <!-- Global Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">

--- a/windsor/litigation-support/index.html
+++ b/windsor/litigation-support/index.html
@@ -22,7 +22,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
 
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -152,7 +152,7 @@
     </script>
 </head>
 <body class="font-inter">
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <!-- Global Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">

--- a/windsor/residential-appraisal/index.html
+++ b/windsor/residential-appraisal/index.html
@@ -21,7 +21,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5XX7VHJV');</script>
+    })(window,document,'script','dataLayer','GTM-58BSN5FV');</script>
 
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -144,7 +144,7 @@
     </script>
 </head>
 <body class="font-inter">
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5XX7VHJV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <!-- Global Header -->
     <header class="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-100">


### PR DESCRIPTION
## What this does

Transfers GTM ownership from Kyle's personal container to GuestGetter's account, with zero impact on GA4 data or the live site's behaviour.

## Changes

- **GTM ID swap** — `GTM-5XX7VHJV` → `GTM-58BSN5FV` across all 58 tracked pages
- **14 new pages tracked** — all agent profile pages (Sam, Dan, Roman etc.) had zero tracking; now have GTM
- **Fix broken JS** — `analytics-tracking.js` had 7 `gtag()` calls that were silently failing (Kyle removed the direct `gtag.js` embed but left the calls). All replaced with `dataLayer.push()`
- **Fix double-tracking** — `mason-hewitt` and `james-sibbald` had both GTM and a direct GA4 embed, inflating pageviews 2× on those pages. Direct embed removed

## What does NOT change

- GA4 property `G-TB55XJ4B9D` — identical measurement ID in the new container
- All historical GA4 data — stored on Google's servers, untouched
- Site appearance or functionality — purely analytics infrastructure
- Kyle's GTM container — still exists, we just stop referencing it

## Verification (before merging)

1. Import `gtm-container-export.json` into `GTM-58BSN5FV` → publish
2. GTM Preview → confirm GA4 Configuration tag fires on page load
3. GA4 DebugView → confirm `page_view` events arriving
4. Merge and deploy

## Reverting if needed

```bash
git revert HEAD
git push
```

One command returns the live site to Kyle's GTM instantly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrate site tracking to the GuestGetter-owned Google Tag Manager container `GTM-58BSN5FV`, add tracking to untracked profile pages, and route all analytics through `dataLayer.push()`. No change to GA4 property `G-TB55XJ4B9D`, historical data, or site behavior.

- **Migration**
  - Swap `GTM-5XX7VHJV` → `GTM-58BSN5FV` across 58 pages.
  - Add GTM to 14 agent/team profile pages previously untracked.

- **Bug Fixes**
  - Remove remaining `gtag()` calls and send all events via `dataLayer.push()` in `assets/js/analytics-tracking.js`, `assets/js/ab-testing.js`, and `assets/js/main.js`.
  - Remove duplicate direct GA4 `gtag.js` embeds on `mason-hewitt` and `james-sibbald` to stop 2× pageview inflation.

<sup>Written for commit 46db5efcf774db1f6cdf93ab9110d9d7c6c8d795. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/guestgetter/metrix-realty-website/pull/36?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

