### PR TITLE
Update Suzanne De Jong retirement status

### DIFF
--- a/suzanne-de-jong.html
+++ b/suzanne-de-jong.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="overflow-x-hidden">
 <head>
     <meta charset="UTF-8">
     <!-- Google Tag Manager -->
@@ -12,9 +12,9 @@
 
     <link rel="canonical" href="https://metrixrealty.com/suzanne-de-jong">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Suzanne De Jong | Vice President Commercial Operations | Metrix Realty Group</title>
+    <title>Suzanne De Jong | Retired Appraiser | Metrix Realty Group</title>
     <link rel="icon" type="image/png" href="/favicon.png">
-    <meta name="description" content="Meet Suzanne De Jong, Vice President of Commercial Appraisal Operations at Metrix Realty Group. Hons. B.A, P. App., AACI with extensive experience in commercial property valuations.">
+    <meta name="description" content="Learn about retired Metrix Realty Group appraiser Suzanne De Jong, Hons. B.A, P. App., AACI, and her extensive commercial property valuation career.">
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -69,9 +69,9 @@
     "@type": "Person",
     "name": "Suzanne De Jong",
     "honorificSuffix": "Hons. B.A., P.App., AACI",
-    "jobTitle": "Vice President of Commercial Appraisal Operations",
+    "jobTitle": "Retired Appraiser",
     "url": "https://metrixrealty.com/suzanne-de-jong/",
-    "worksFor": {
+    "alumniOf": {
         "@type": "Organization",
         "@id": "https://metrixrealty.com/#organization",
         "name": "Metrix Realty Group",
@@ -95,7 +95,7 @@
 }
     </script>
 </head>
-<body class="font-inter">
+<body class="font-inter overflow-x-hidden">
     <!-- Google Tag Manager (noscript) -->
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -178,7 +178,7 @@
                 </div>
 
                 <div class="w-48 h-48 mx-auto mb-8 overflow-hidden rounded-full border-4 border-white/20" data-aos="fade-up" data-aos-duration="800">
-                    <img src="Metrix Photos New Site/suzanne-de-jong-metrix-final.png" alt="Suzanne De Jong" class="w-full h-full object-cover">
+                    <img src="/Metrix Photos New Site/suzanne-de-jong-metrix-final.png" alt="Suzanne De Jong" class="w-full h-full object-cover">
                 </div>
 
                 <h1 class="text-4xl sm:text-5xl lg:text-6xl font-bold mb-4 leading-tight" data-aos="fade-up" data-aos-duration="1000">
@@ -188,22 +188,22 @@
                     Hons. B.A, P. App., <a href="https://www.aicanada.ca/designation/aaci/" target="_blank" rel="noopener noreferrer">AACI</a>
                 </p>
                 <p class="text-lg sm:text-xl mb-8 opacity-80" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="200">
-                    Vice President of Commercial Appraisal Operations
+                    Retired
                 </p>
 
                 <!-- Contact Info -->
                 <div class="flex flex-col sm:flex-row items-center justify-center gap-6" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="300">
-                    <a href="mailto:sdejong@metrixrealty.com" class="inline-flex items-center text-white/90 hover:text-white transition-colors">
+                    <a href="mailto:info@metrixrealty.com" class="inline-flex items-center text-white/90 hover:text-white transition-colors">
                         <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
                         </svg>
-                        sdejong@metrixrealty.com
+                        Contact the Metrix office
                     </a>
                     <a href="tel:519-672-7550" class="inline-flex items-center text-white/90 hover:text-white transition-colors">
                         <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
                         </svg>
-                        519.672.7550 Ext. 225
+                        519.672.7550
                     </a>
                 </div>
             </div>
@@ -217,13 +217,13 @@
                 <h2 class="text-3xl sm:text-4xl font-bold text-gray-900 mb-8" data-aos="fade-up" data-aos-duration="800">Biography</h2>
                 <div class="prose prose-lg max-w-none text-gray-600 leading-relaxed space-y-6" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
                     <p>
-                        Suzanne grew up in Mississauga, Ontario and graduated with an Honours Bachelor of Arts degree specializing in Urban Development from the University of Western Ontario in 1989. Realising her love for London she decided to remain in the city and seek experience in the real estate appraisal field. Suzanne obtained her CRA designation in 1993 and went on to receive her AACI in 2003. Suzanne currently balances her time as a member of commercial appraisal team at Metrix Realty Group and also actively mentors several junior staff members.
+                        Suzanne grew up in Mississauga, Ontario and graduated with an Honours Bachelor of Arts degree specializing in Urban Development from the University of Western Ontario in 1989. Realising her love for London she decided to remain in the city and seek experience in the real estate appraisal field. Suzanne obtained her CRA designation in 1993 and went on to receive her AACI in 2003. Before retiring, Suzanne was a valued member of the commercial appraisal team at Metrix Realty Group and mentored several junior staff members.
                     </p>
                     <p>
-                        Suzanne's appraisal experience spans from 1989 and has included apartment, office, retail commercial, industrial and residential development land. She works with a broad range of clients including financial institutions, real estate development firms, insurance companies, lawyers, accountants, and local investors. Suzanne enjoys interacting with clients and providing assistance. She has significant experience appraising unique properties with title issues and enjoys the challenge of developing a reasonable solution. She also has experience providing expert witness testimony at the Board of Negotiation and at the Ontario Municipal Board.
+                        Suzanne's appraisal career began in 1989 and included apartment, office, retail commercial, industrial and residential development land. She worked with a broad range of clients including financial institutions, real estate development firms, insurance companies, lawyers, accountants, and local investors. Suzanne developed significant experience appraising unique properties with title issues and providing expert witness testimony at the Board of Negotiation and at the Ontario Municipal Board.
                     </p>
                     <p>
-                        Suzanne has been actively involved with the <a href="https://www.aicanada.ca/" target="_blank" rel="noopener noreferrer">Appraisal Institute of Canada</a> at the Local, Provincial and National Level since 1996. She has served on the Executive of the London Chapter of the Appraisal Institute of Canada since 1996, is a past and current Member of the Executive Board of Directors for the Ontario Association, and is the past chair of the Appraisal Institute of Canada Applied Experience Sub Committee that worked closely with The University of British Columbia and the Sauders School of Business to develop an applied experience program for Candidates working towards their designations within the Appraisal Institute of Canada. In 2015, Suzanne was awarded The Presidents Award of Excellence by the Ontario Association of Appraisal Institute of Canada.
+                        Suzanne was actively involved with the <a href="https://www.aicanada.ca/" target="_blank" rel="noopener noreferrer">Appraisal Institute of Canada</a> at the local, provincial and national levels. Her service included the Executive of the London Chapter, the Executive Board of Directors for the Ontario Association, and chairing the Appraisal Institute of Canada Applied Experience Sub Committee. In 2015, Suzanne was awarded the Presidents Award of Excellence by the Ontario Association of Appraisal Institute of Canada.
                     </p>
                     <p>
                         In her spare time, Suzanne loves the outdoors, antique shopping and most importantly making and eating good food. With her family and friends, she likes to spend time at the cottage and travelling to warm climates.
@@ -327,8 +327,8 @@
                     <div class="flex items-start justify-between mb-4">
                         <div>
                             <h4 class="text-xl font-bold text-gray-600 mb-2">Metrix Realty Group, London ON</h4>
-                            <p class="text-lg font-semibold text-gray-900 mb-2">Senior Appraiser & VP Commercial Appraisal Operations</p>
-                            <p class="text-gray-600">1998 – Present</p>
+                            <p class="text-lg font-semibold text-gray-900 mb-2">Retired Senior Appraiser</p>
+                            <p class="text-gray-600">1998 to retirement</p>
                         </div>
                     </div>
 
@@ -409,23 +409,23 @@
         <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
             <div data-aos="fade-up" data-aos-duration="800">
                 <h2 class="text-3xl sm:text-4xl font-bold text-gray-900 mb-6">
-                    Ready to Work with Suzanne?
+                    Looking to Reconnect?
                 </h2>
                 <p class="text-lg text-gray-600 mb-8 leading-relaxed">
-                    Contact our Vice President of Commercial Appraisal Operations for expert commercial property valuations and consulting services.
+                    Suzanne is retired. For questions about past work or to connect with a current Metrix appraiser, please contact our office.
                 </p>
                 <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
-                    <a href="mailto:sdejong@metrixrealty.com" class="inline-flex items-center px-8 py-4 bg-gray-600 text-white font-semibold rounded-lg hover:bg-gray-700 transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg">
+                    <a href="mailto:info@metrixrealty.com" class="inline-flex items-center px-8 py-4 bg-gray-600 text-white font-semibold rounded-lg hover:bg-gray-700 transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg">
                         <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
                         </svg>
-                        Send Email
+                        Email the Office
                     </a>
                     <a href="tel:519-672-7550" class="inline-flex items-center px-8 py-4 border-2 border-gray-600 text-gray-600 font-semibold rounded-lg hover:bg-gray-600 hover:text-white transition-all duration-300">
                         <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
                         </svg>
-                        Call Now
+                        Call the Office
                     </a>
                 </div>
             </div>

--- a/suzanne-de-jong/index.html
+++ b/suzanne-de-jong/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="overflow-x-hidden">
 <head>
     <meta charset="UTF-8">
     <!-- Google Tag Manager -->
@@ -12,9 +12,9 @@
     
     <link rel="canonical" href="https://metrixrealty.com/suzanne-de-jong">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Suzanne De Jong | Vice President Commercial Operations | Metrix Realty Group</title>
+    <title>Suzanne De Jong | Retired Appraiser | Metrix Realty Group</title>
     <link rel="icon" type="image/png" href="/favicon.png">
-    <meta name="description" content="Meet Suzanne De Jong, Vice President of Commercial Appraisal Operations at Metrix Realty Group. Hons. B.A, P. App., AACI with extensive experience in commercial property valuations.">
+    <meta name="description" content="Learn about retired Metrix Realty Group appraiser Suzanne De Jong, Hons. B.A, P. App., AACI, and her extensive commercial property valuation career.">
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -69,9 +69,9 @@
     "@type": "Person",
     "name": "Suzanne De Jong",
     "honorificSuffix": "Hons. B.A., P.App., AACI",
-    "jobTitle": "Vice President of Commercial Appraisal Operations",
+    "jobTitle": "Retired Appraiser",
     "url": "https://metrixrealty.com/suzanne-de-jong/",
-    "worksFor": {
+    "alumniOf": {
         "@type": "Organization",
         "@id": "https://metrixrealty.com/#organization",
         "name": "Metrix Realty Group",
@@ -95,7 +95,7 @@
 }
     </script>
 </head>
-<body class="font-inter">
+<body class="font-inter overflow-x-hidden">
     <!-- Google Tag Manager (noscript) -->
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-58BSN5FV"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -178,7 +178,7 @@
                 </div>
                 
                 <div class="w-48 h-48 mx-auto mb-8 overflow-hidden rounded-full border-4 border-white/20" data-aos="fade-up" data-aos-duration="800">
-                    <img src="Metrix Photos New Site/suzanne-de-jong-metrix-final.png" alt="Suzanne De Jong" class="w-full h-full object-cover">
+                    <img src="/Metrix Photos New Site/suzanne-de-jong-metrix-final.png" alt="Suzanne De Jong" class="w-full h-full object-cover">
                 </div>
                 
                 <h1 class="text-4xl sm:text-5xl lg:text-6xl font-bold mb-4 leading-tight" data-aos="fade-up" data-aos-duration="1000">
@@ -188,22 +188,22 @@
                     Hons. B.A, P. App., <a href="https://www.aicanada.ca/designation/aaci/" target="_blank" rel="noopener noreferrer">AACI</a>
                 </p>
                 <p class="text-lg sm:text-xl mb-8 opacity-80" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="200">
-                    Vice President of Commercial Appraisal Operations
+                    Retired
                 </p>
                 
                 <!-- Contact Info -->
                 <div class="flex flex-col sm:flex-row items-center justify-center gap-6" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="300">
-                    <a href="mailto:sdejong@metrixrealty.com" class="inline-flex items-center text-white/90 hover:text-white transition-colors">
+                    <a href="mailto:info@metrixrealty.com" class="inline-flex items-center text-white/90 hover:text-white transition-colors">
                         <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
                         </svg>
-                        sdejong@metrixrealty.com
+                        Contact the Metrix office
                     </a>
                     <a href="tel:519-672-7550" class="inline-flex items-center text-white/90 hover:text-white transition-colors">
                         <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
                         </svg>
-                        519.672.7550 Ext. 225
+                        519.672.7550
                     </a>
                 </div>
             </div>
@@ -217,13 +217,13 @@
                 <h2 class="text-3xl sm:text-4xl font-bold text-gray-900 mb-8" data-aos="fade-up" data-aos-duration="800">Biography</h2>
                 <div class="prose prose-lg max-w-none text-gray-600 leading-relaxed space-y-6" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
                     <p>
-                        Suzanne grew up in Mississauga, Ontario and graduated with an Honours Bachelor of Arts degree specializing in Urban Development from the University of Western Ontario in 1989. Realising her love for London she decided to remain in the city and seek experience in the real estate appraisal field. Suzanne obtained her CRA designation in 1993 and went on to receive her AACI in 2003. Suzanne currently balances her time as a member of commercial appraisal team at Metrix Realty Group and also actively mentors several junior staff members.
+                        Suzanne grew up in Mississauga, Ontario and graduated with an Honours Bachelor of Arts degree specializing in Urban Development from the University of Western Ontario in 1989. Realising her love for London she decided to remain in the city and seek experience in the real estate appraisal field. Suzanne obtained her CRA designation in 1993 and went on to receive her AACI in 2003. Before retiring, Suzanne was a valued member of the commercial appraisal team at Metrix Realty Group and mentored several junior staff members.
                     </p>
                     <p>
-                        Suzanne's appraisal experience spans from 1989 and has included apartment, office, retail commercial, industrial and residential development land. She works with a broad range of clients including financial institutions, real estate development firms, insurance companies, lawyers, accountants, and local investors. Suzanne enjoys interacting with clients and providing assistance. She has significant experience appraising unique properties with title issues and enjoys the challenge of developing a reasonable solution. She also has experience providing expert witness testimony at the Board of Negotiation and at the Ontario Municipal Board.
+                        Suzanne's appraisal career began in 1989 and included apartment, office, retail commercial, industrial and residential development land. She worked with a broad range of clients including financial institutions, real estate development firms, insurance companies, lawyers, accountants, and local investors. Suzanne developed significant experience appraising unique properties with title issues and providing expert witness testimony at the Board of Negotiation and at the Ontario Municipal Board.
                     </p>
                     <p>
-                        Suzanne has been actively involved with the <a href="https://www.aicanada.ca/" target="_blank" rel="noopener noreferrer">Appraisal Institute of Canada</a> at the Local, Provincial and National Level since 1996. She has served on the Executive of the London Chapter of the Appraisal Institute of Canada since 1996, is a past and current Member of the Executive Board of Directors for the Ontario Association, and is the past chair of the Appraisal Institute of Canada Applied Experience Sub Committee that worked closely with The University of British Columbia and the Sauders School of Business to develop an applied experience program for Candidates working towards their designations within the Appraisal Institute of Canada. In 2015, Suzanne was awarded The Presidents Award of Excellence by the Ontario Association of Appraisal Institute of Canada.
+                        Suzanne was actively involved with the <a href="https://www.aicanada.ca/" target="_blank" rel="noopener noreferrer">Appraisal Institute of Canada</a> at the local, provincial and national levels. Her service included the Executive of the London Chapter, the Executive Board of Directors for the Ontario Association, and chairing the Appraisal Institute of Canada Applied Experience Sub Committee. In 2015, Suzanne was awarded the Presidents Award of Excellence by the Ontario Association of Appraisal Institute of Canada.
                     </p>
                     <p>
                         In her spare time, Suzanne loves the outdoors, antique shopping and most importantly making and eating good food. With her family and friends, she likes to spend time at the cottage and travelling to warm climates.
@@ -327,8 +327,8 @@
                     <div class="flex items-start justify-between mb-4">
                         <div>
                             <h4 class="text-xl font-bold text-gray-600 mb-2">Metrix Realty Group, London ON</h4>
-                            <p class="text-lg font-semibold text-gray-900 mb-2">Senior Appraiser & VP Commercial Appraisal Operations</p>
-                            <p class="text-gray-600">1998 – Present</p>
+                            <p class="text-lg font-semibold text-gray-900 mb-2">Retired Senior Appraiser</p>
+                            <p class="text-gray-600">1998 to retirement</p>
                         </div>
                     </div>
                     
@@ -409,23 +409,23 @@
         <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
             <div data-aos="fade-up" data-aos-duration="800">
                 <h2 class="text-3xl sm:text-4xl font-bold text-gray-900 mb-6">
-                    Ready to Work with Suzanne?
+                    Looking to Reconnect?
                 </h2>
                 <p class="text-lg text-gray-600 mb-8 leading-relaxed">
-                    Contact our Vice President of Commercial Appraisal Operations for expert commercial property valuations and consulting services.
+                    Suzanne is retired. For questions about past work or to connect with a current Metrix appraiser, please contact our office.
                 </p>
                 <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
-                    <a href="mailto:sdejong@metrixrealty.com" class="inline-flex items-center px-8 py-4 bg-gray-600 text-white font-semibold rounded-lg hover:bg-gray-700 transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg">
+                    <a href="mailto:info@metrixrealty.com" class="inline-flex items-center px-8 py-4 bg-gray-600 text-white font-semibold rounded-lg hover:bg-gray-700 transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg">
                         <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
                         </svg>
-                        Send Email
+                        Email the Office
                     </a>
                     <a href="tel:519-672-7550" class="inline-flex items-center px-8 py-4 border-2 border-gray-600 text-gray-600 font-semibold rounded-lg hover:bg-gray-600 hover:text-white transition-all duration-300">
                         <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
                         </svg>
-                        Call Now
+                        Call the Office
                     </a>
                 </div>
             </div>
@@ -523,4 +523,4 @@
         });
     </script>
 </body>
-</html> 
+</html>

--- a/team.html
+++ b/team.html
@@ -40,7 +40,7 @@
             {"@type": "ListItem", "position": 2,  "url": "https://metrixrealty.com/sam-van-houtte",   "name": "Sam Van Houtte, BMOS, P. APP, AACI — VP Operations & Senior Appraiser"},
             {"@type": "ListItem", "position": 3,  "url": "https://metrixrealty.com/paula-busch",      "name": "Paula Busch, HONS. B.A., P. APP, AACI — VP Commercial Operations"},
             {"@type": "ListItem", "position": 4,  "url": "https://metrixrealty.com/jeff-petruzella",  "name": "Jeff Petruzella, HONS. B.A., P. APP, CRA — VP Residential Appraisals"},
-            {"@type": "ListItem", "position": 5,  "url": "https://metrixrealty.com/suzanne-de-jong",  "name": "Suzanne De Jong, HONS. B.A., P. APP, AACI — VP Commercial Appraisals"},
+            {"@type": "ListItem", "position": 5,  "url": "https://metrixrealty.com/suzanne-de-jong",  "name": "Suzanne De Jong, HONS. B.A., P. APP, AACI — Retired"},
             {"@type": "ListItem", "position": 6,  "url": "https://metrixrealty.com/john-carter",      "name": "John Carter, HONS. B. COMM., P. APP, AACI — Senior Appraiser"},
             {"@type": "ListItem", "position": 7,  "url": "https://metrixrealty.com/ali-mahfoud",      "name": "Ali Mahfoud, B.A., P. APP, AACI — Senior Appraiser"},
             {"@type": "ListItem", "position": 8,  "url": "https://metrixrealty.com/mark-penhale",     "name": "Mark Penhale, HONS. B.A., P. APP, AACI — Senior Appraiser"},
@@ -476,7 +476,7 @@
                             </a>
                         </div>
                     </div>
-                    <div class="grid grid-cols-1 md:grid-cols-2 gap-8 mb-12 max-w-3xl mx-auto">
+                    <div class="grid grid-cols-1 gap-8 mb-12 max-w-md mx-auto">
                         <!-- Jeff Petruzella -->
                         <div class="bg-gradient-to-br from-gray-50 to-white rounded-xl p-8 border border-gray-200 professional-hover text-center h-full flex flex-col" data-aos="fade-up" data-aos-duration="800" data-aos-delay="100">
                             <div class="w-32 h-32 mx-auto mb-6 overflow-hidden rounded-full">
@@ -493,21 +493,6 @@
                             </a>
                         </div>
 
-                        <!-- Suzanne De Jong -->
-                        <div class="bg-gradient-to-br from-gray-50 to-white rounded-xl p-8 border border-gray-200 professional-hover text-center h-full flex flex-col" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
-                            <div class="w-32 h-32 mx-auto mb-6 overflow-hidden rounded-full">
-                                <img src="Metrix Photos New Site/suzanne-de-jong-metrix-final.png" alt="Suzanne De Jong" class="w-full h-full object-cover">
-                            </div>
-                            <h4 class="text-xl font-bold text-gray-900 mb-2">Suzanne De Jong</h4>
-                            <p class="text-gray-700 font-semibold text-base mb-3">HONS. B.A, P. APP, AACI</p>
-                            <p class="text-gray-600 text-base mb-4">Vice President, Commercial Appraisals</p>
-                            <p class="text-gray-600 text-sm leading-relaxed mb-6 flex-grow">
-                                Overseeing commercial appraisal services with AACI designation expertise.
-                            </p>
-                            <a href="/suzanne-de-jong" class="flex items-center justify-center px-4 py-3 bg-slate-700 text-white text-sm font-semibold rounded-lg hover:bg-slate-800 transition-colors mt-auto min-h-[40px]">
-                                View Full Bio
-                            </a>
-                        </div>
                     </div>
                 </div>
 
@@ -750,6 +735,36 @@
                             <div class="text-sm text-gray-500 space-y-1 mt-auto">
                                 <div>ekwateng@metrixrealty.com</div>
                                 <div><a href="tel:519-672-7550" class="text-gray-700 hover:text-metrix-navy transition-colors">519.672.7550</a></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Retired Team Members -->
+                <div id="retired-team" class="mt-20 text-center scroll-mt-28">
+                    <h3 class="text-3xl font-bold text-gray-900 mb-4" data-aos="fade-up" data-aos-duration="800">Retired Team Members</h3>
+                    <p class="text-gray-600 mb-10 max-w-2xl mx-auto" data-aos="fade-up" data-aos-duration="800" data-aos-delay="100">
+                        For questions regarding past work or to reconnect with a retired team member, please contact the Metrix Realty Group office.
+                    </p>
+                    <div class="max-w-md mx-auto">
+                        <!-- Suzanne De Jong -->
+                        <div class="bg-gradient-to-br from-gray-50 to-white rounded-xl p-8 border border-gray-200 professional-hover text-center h-full flex flex-col" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
+                            <div class="w-32 h-32 mx-auto mb-6 overflow-hidden rounded-full">
+                                <img src="/Metrix Photos New Site/suzanne-de-jong-metrix-final.png" alt="Suzanne De Jong" class="w-full h-full object-cover">
+                            </div>
+                            <h4 class="text-xl font-bold text-gray-900 mb-2">Suzanne De Jong</h4>
+                            <p class="text-gray-700 font-semibold text-base mb-3">HONS. B.A, P. APP, AACI</p>
+                            <p class="text-gray-600 text-base mb-4">Retired</p>
+                            <p class="text-gray-600 text-sm leading-relaxed mb-6 flex-grow">
+                                Suzanne served Metrix clients through a distinguished career in commercial property appraisal.
+                            </p>
+                            <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-auto">
+                                <a href="/suzanne-de-jong" class="flex items-center justify-center px-4 py-3 border border-slate-700 text-slate-700 text-sm font-semibold rounded-lg hover:bg-slate-50 transition-colors min-h-[40px]">
+                                    View Career Bio
+                                </a>
+                                <a href="/contact" class="flex items-center justify-center px-4 py-3 bg-slate-700 text-white text-sm font-semibold rounded-lg hover:bg-slate-800 transition-colors min-h-[40px]">
+                                    Contact the Office
+                                </a>
                             </div>
                         </div>
                     </div>

--- a/team/index.html
+++ b/team/index.html
@@ -40,7 +40,7 @@
             {"@type": "ListItem", "position": 2,  "url": "https://metrixrealty.com/sam-van-houtte",   "name": "Sam Van Houtte, BMOS, P. APP, AACI — VP Operations & Senior Appraiser"},
             {"@type": "ListItem", "position": 3,  "url": "https://metrixrealty.com/paula-busch",      "name": "Paula Busch, HONS. B.A., P. APP, AACI — VP Commercial Operations"},
             {"@type": "ListItem", "position": 4,  "url": "https://metrixrealty.com/jeff-petruzella",  "name": "Jeff Petruzella, HONS. B.A., P. APP, CRA — VP Residential Appraisals"},
-            {"@type": "ListItem", "position": 5,  "url": "https://metrixrealty.com/suzanne-de-jong",  "name": "Suzanne De Jong, HONS. B.A., P. APP, AACI — VP Commercial Appraisals"},
+            {"@type": "ListItem", "position": 5,  "url": "https://metrixrealty.com/suzanne-de-jong",  "name": "Suzanne De Jong, HONS. B.A., P. APP, AACI — Retired"},
             {"@type": "ListItem", "position": 6,  "url": "https://metrixrealty.com/john-carter",      "name": "John Carter, HONS. B. COMM., P. APP, AACI — Senior Appraiser"},
             {"@type": "ListItem", "position": 7,  "url": "https://metrixrealty.com/ali-mahfoud",      "name": "Ali Mahfoud, B.A., P. APP, AACI — Senior Appraiser"},
             {"@type": "ListItem", "position": 8,  "url": "https://metrixrealty.com/mark-penhale",     "name": "Mark Penhale, HONS. B.A., P. APP, AACI — Senior Appraiser"},
@@ -476,7 +476,7 @@
                             </a>
                         </div>
                     </div>
-                    <div class="grid grid-cols-1 md:grid-cols-2 gap-8 mb-12 max-w-3xl mx-auto">
+                    <div class="grid grid-cols-1 gap-8 mb-12 max-w-md mx-auto">
                         <!-- Jeff Petruzella -->
                         <div class="bg-gradient-to-br from-gray-50 to-white rounded-xl p-8 border border-gray-200 professional-hover text-center h-full flex flex-col" data-aos="fade-up" data-aos-duration="800" data-aos-delay="100">
                             <div class="w-32 h-32 mx-auto mb-6 overflow-hidden rounded-full">
@@ -493,21 +493,6 @@
                             </a>
                         </div>
                         
-                        <!-- Suzanne De Jong -->
-                        <div class="bg-gradient-to-br from-gray-50 to-white rounded-xl p-8 border border-gray-200 professional-hover text-center h-full flex flex-col" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
-                            <div class="w-32 h-32 mx-auto mb-6 overflow-hidden rounded-full">
-                                <img src="Metrix Photos New Site/suzanne-de-jong-metrix-final.png" alt="Suzanne De Jong" class="w-full h-full object-cover">
-                            </div>
-                            <h4 class="text-xl font-bold text-gray-900 mb-2">Suzanne De Jong</h4>
-                            <p class="text-gray-700 font-semibold text-base mb-3">HONS. B.A, P. APP, AACI</p>
-                            <p class="text-gray-600 text-base mb-4">Vice President, Commercial Appraisals</p>
-                            <p class="text-gray-600 text-sm leading-relaxed mb-6 flex-grow">
-                                Overseeing commercial appraisal services with AACI designation expertise.
-                            </p>
-                            <a href="/suzanne-de-jong" class="flex items-center justify-center px-4 py-3 bg-slate-700 text-white text-sm font-semibold rounded-lg hover:bg-slate-800 transition-colors mt-auto min-h-[40px]">
-                                View Full Bio
-                            </a>
-                        </div>
                     </div>
                 </div>
                 
@@ -754,7 +739,37 @@
                         </div>
                     </div>
                 </div>
-                
+
+                <!-- Retired Team Members -->
+                <div id="retired-team" class="mt-20 text-center scroll-mt-28">
+                    <h3 class="text-3xl font-bold text-gray-900 mb-4" data-aos="fade-up" data-aos-duration="800">Retired Team Members</h3>
+                    <p class="text-gray-600 mb-10 max-w-2xl mx-auto" data-aos="fade-up" data-aos-duration="800" data-aos-delay="100">
+                        For questions regarding past work or to reconnect with a retired team member, please contact the Metrix Realty Group office.
+                    </p>
+                    <div class="max-w-md mx-auto">
+                        <!-- Suzanne De Jong -->
+                        <div class="bg-gradient-to-br from-gray-50 to-white rounded-xl p-8 border border-gray-200 professional-hover text-center h-full flex flex-col" data-aos="fade-up" data-aos-duration="800" data-aos-delay="200">
+                            <div class="w-32 h-32 mx-auto mb-6 overflow-hidden rounded-full">
+                                <img src="/Metrix Photos New Site/suzanne-de-jong-metrix-final.png" alt="Suzanne De Jong" class="w-full h-full object-cover">
+                            </div>
+                            <h4 class="text-xl font-bold text-gray-900 mb-2">Suzanne De Jong</h4>
+                            <p class="text-gray-700 font-semibold text-base mb-3">HONS. B.A, P. APP, AACI</p>
+                            <p class="text-gray-600 text-base mb-4">Retired</p>
+                            <p class="text-gray-600 text-sm leading-relaxed mb-6 flex-grow">
+                                Suzanne served Metrix clients through a distinguished career in commercial property appraisal.
+                            </p>
+                            <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-auto">
+                                <a href="/suzanne-de-jong" class="flex items-center justify-center px-4 py-3 border border-slate-700 text-slate-700 text-sm font-semibold rounded-lg hover:bg-slate-50 transition-colors min-h-[40px]">
+                                    View Career Bio
+                                </a>
+                                <a href="/contact" class="flex items-center justify-center px-4 py-3 bg-slate-700 text-white text-sm font-semibold rounded-lg hover:bg-slate-800 transition-colors min-h-[40px]">
+                                    Contact the Office
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
                 <!-- Team Description -->
                 <div class="mt-20 max-w-4xl mx-auto text-center">
                     <div class="bg-gradient-to-br from-gray-50 to-gray-50 rounded-2xl p-8 border border-gray-100" data-aos="fade-up" data-aos-duration="800">


### PR DESCRIPTION
## Summary
- move Suzanne De Jong out of the leadership team into a dedicated retired-team section
- replace her VP title with Retired across the team and profile pages
- route former-client inquiries to the Metrix office instead of Suzanne's direct email and extension
- update profile metadata and structured data to reflect her retired status

## Verification
- npm run build
- valid JSON-LD on team and Suzanne profile variants
- desktop and 390px responsive visual checks
- no horizontal overflow on modified pages
- preview deployment READY

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Suzanne De Jong’s profile and team pages to reflect her retirement. Adds a Retired Team Members section and routes inquiries to the Metrix office; also resolves a horizontal overflow issue.

- **New Features**
  - Added a Retired Team Members section and moved Suzanne there.
  - Updated Suzanne’s profile: title to “Retired Appraiser”, CTAs to office email/phone, and copy reflecting retirement.
  - Updated SEO/structured data: page title/meta description; JSON-LD jobTitle set to “Retired Appraiser” with `alumniOf`; team schema list shows “Retired”.

- **Bug Fixes**
  - Prevented horizontal overflow by applying `overflow-x-hidden` to `html` and `body`.
  - Corrected image path to root-relative `/Metrix Photos New Site/...`.

<sup>Written for commit 0ccd7d8be17aa33494a000d2ad0be76c862dcc10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/guestgetter/metrix-realty-website/pull/38?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

