### PR TITLE
Complete Metrix search-readiness cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,13 +212,6 @@
                   }
             }
       ],
-      "aggregateRating": {
-            "@type": "AggregateRating",
-            "ratingValue": 4.4,
-            "reviewCount": 35,
-            "bestRating": 5,
-            "worstRating": 1
-      },
       "priceRange": "$$",
       "knowsAbout": [
             "Commercial real estate appraisal",

--- a/insights/commercial-appraisal-documents-ontario.html
+++ b/insights/commercial-appraisal-documents-ontario.html
@@ -20,7 +20,7 @@
 
     <!-- Twitter Card Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="robots" content="noindex, nofollow">
+    <meta name="robots" content="index, follow">
     <meta name="twitter:title" content="Commercial Appraisal Documents Ontario: What to Prepare">
     <meta name="twitter:description" content="Ontario commercial appraisals typically require a rent roll, 2–3 years of operating statements, leases, and building specs. Here is the full checklist, by property type.">
     <meta name="twitter:image" content="https://images.unsplash.com/photo-1486325212027-8081e485255e?auto=format&fit=crop&w=1200&q=80">

--- a/insights/commercial-appraisal-documents-ontario/index.html
+++ b/insights/commercial-appraisal-documents-ontario/index.html
@@ -20,7 +20,7 @@
 
     <!-- Twitter Card Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="robots" content="noindex, nofollow">
+    <meta name="robots" content="index, follow">
     <meta name="twitter:title" content="Commercial Appraisal Documents Ontario: What to Prepare">
     <meta name="twitter:description" content="Ontario commercial appraisals typically require a rent roll, 2–3 years of operating statements, leases, and building specs. Here is the full checklist, by property type.">
     <meta name="twitter:image" content="https://images.unsplash.com/photo-1486325212027-8081e485255e?auto=format&fit=crop&w=1200&q=80">

--- a/insights/industrial-property-appraisal-factors-ontario.html
+++ b/insights/industrial-property-appraisal-factors-ontario.html
@@ -5,13 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Key Industrial Property Appraisal Factors in Ontario | Metrix Realty</title>
     <link rel="icon" type="image/png" href="/favicon.png">
-    <meta name="description" content="Clear height and loading configuration can shift Ontario industrial property value by 15–30%. Here is what AACI appraisers weigh in every assignment.">
+    <meta name="description" content="Clear height, loading, power, access, condition, and market demand can all affect an Ontario industrial property's value. See what appraisers examine.">
     <link rel="canonical" href="https://metrixrealty.com/insights/industrial-property-appraisal-factors-ontario/">
-    <meta name="robots" content="noindex, nofollow">
+    <meta name="robots" content="index, follow">
 
     <!-- Open Graph Meta Tags -->
     <meta property="og:title" content="Key Industrial Property Appraisal Factors in Ontario | Metrix Realty">
-    <meta property="og:description" content="Clear height and loading configuration can shift Ontario industrial property value by 15–30%. Here is what AACI appraisers weigh in every assignment.">
+    <meta property="og:description" content="Clear height, loading, power, access, condition, and market demand can all affect an Ontario industrial property's value.">
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://metrixrealty.com/insights/industrial-property-appraisal-factors-ontario/">
     <meta property="og:image" content="https://images.unsplash.com/photo-1553413077-190dd305871c?auto=format&fit=crop&w=1200&q=80">
@@ -22,7 +22,7 @@
     <!-- Twitter Card Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Key Industrial Property Appraisal Factors in Ontario">
-    <meta name="twitter:description" content="Clear height and loading configuration can shift Ontario industrial property value by 15–30%. Here is what AACI appraisers weigh in every assignment.">
+    <meta name="twitter:description" content="Clear height, loading, power, access, condition, and market demand can all affect an Ontario industrial property's value.">
     <meta name="twitter:image" content="https://images.unsplash.com/photo-1553413077-190dd305871c?auto=format&fit=crop&w=1200&q=80">
 
     <!-- Google Tag Manager -->
@@ -151,7 +151,7 @@
                 "name": "Does clear height have that big an impact on industrial property value?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "Yes. In the current Ontario industrial market, a building with 28 or more feet of clear height rents and sells at a meaningful premium over 20-foot clear product. The difference can be 15 to 30 percent in lease rate and sale price per square foot, depending on the market and property size."
+                    "text": "Clear height can affect which tenants can use a building and how efficiently they can operate. Appraisers compare the subject property with relevant local sales and leases to measure the effect in that market rather than applying one fixed percentage."
                 }
             },
             {
@@ -534,7 +534,7 @@
             <h2>FAQs</h2>
 
             <h3>Does clear height have that big an impact on value?</h3>
-            <p>Yes. In the current Ontario industrial market, a building with 28 or more feet of clear height rents and sells at a meaningful premium over 20-foot clear product. The difference can be 15 to 30 percent in lease rate and sale price per square foot, depending on the market and property size. The gap is widest in larger-format buildings where the tenant base is most sensitive to racking capacity and logistics throughput. For smaller-bay properties where the tenant pool is primarily trades and light manufacturing, the spread is narrower but still present.</p>
+            <p>Clear height can affect which tenants can use a building and how efficiently they can operate. Appraisers compare the subject property with relevant local sales and leases to measure the effect in that market rather than applying one fixed percentage.</p>
 
             <h3>How is industrial property valued if it is owner-occupied with no tenants?</h3>
             <p>The appraiser uses the sales comparison approach as the primary method and may apply the income approach using market rent — the rent a typical tenant would pay, rather than actual rent. The cost approach may also be applied, particularly for newer buildings or specialized improvements where comparable sales are limited. Owner-occupied industrial buildings are valued as if vacant and available for lease to a typical market tenant, which is how lenders and the market price them when they change hands.</p>

--- a/insights/industrial-property-appraisal-factors-ontario/index.html
+++ b/insights/industrial-property-appraisal-factors-ontario/index.html
@@ -5,13 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Key Industrial Property Appraisal Factors in Ontario | Metrix Realty</title>
     <link rel="icon" type="image/png" href="/favicon.png">
-    <meta name="description" content="Clear height and loading configuration can shift Ontario industrial property value by 15–30%. Here is what AACI appraisers weigh in every assignment.">
+    <meta name="description" content="Clear height, loading, power, access, condition, and market demand can all affect an Ontario industrial property's value. See what appraisers examine.">
     <link rel="canonical" href="https://metrixrealty.com/insights/industrial-property-appraisal-factors-ontario/">
-    <meta name="robots" content="noindex, nofollow">
+    <meta name="robots" content="index, follow">
 
     <!-- Open Graph Meta Tags -->
     <meta property="og:title" content="Key Industrial Property Appraisal Factors in Ontario | Metrix Realty">
-    <meta property="og:description" content="Clear height and loading configuration can shift Ontario industrial property value by 15–30%. Here is what AACI appraisers weigh in every assignment.">
+    <meta property="og:description" content="Clear height, loading, power, access, condition, and market demand can all affect an Ontario industrial property's value.">
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://metrixrealty.com/insights/industrial-property-appraisal-factors-ontario/">
     <meta property="og:image" content="https://images.unsplash.com/photo-1553413077-190dd305871c?auto=format&fit=crop&w=1200&q=80">
@@ -22,7 +22,7 @@
     <!-- Twitter Card Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Key Industrial Property Appraisal Factors in Ontario">
-    <meta name="twitter:description" content="Clear height and loading configuration can shift Ontario industrial property value by 15–30%. Here is what AACI appraisers weigh in every assignment.">
+    <meta name="twitter:description" content="Clear height, loading, power, access, condition, and market demand can all affect an Ontario industrial property's value.">
     <meta name="twitter:image" content="https://images.unsplash.com/photo-1553413077-190dd305871c?auto=format&fit=crop&w=1200&q=80">
 
     <!-- Google Tag Manager -->
@@ -151,7 +151,7 @@
                 "name": "Does clear height have that big an impact on industrial property value?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "Yes. In the current Ontario industrial market, a building with 28 or more feet of clear height rents and sells at a meaningful premium over 20-foot clear product. The difference can be 15 to 30 percent in lease rate and sale price per square foot, depending on the market and property size."
+                    "text": "Clear height can affect which tenants can use a building and how efficiently they can operate. Appraisers compare the subject property with relevant local sales and leases to measure the effect in that market rather than applying one fixed percentage."
                 }
             },
             {
@@ -534,7 +534,7 @@
             <h2>FAQs</h2>
 
             <h3>Does clear height have that big an impact on value?</h3>
-            <p>Yes. In the current Ontario industrial market, a building with 28 or more feet of clear height rents and sells at a meaningful premium over 20-foot clear product. The difference can be 15 to 30 percent in lease rate and sale price per square foot, depending on the market and property size. The gap is widest in larger-format buildings where the tenant base is most sensitive to racking capacity and logistics throughput. For smaller-bay properties where the tenant pool is primarily trades and light manufacturing, the spread is narrower but still present.</p>
+            <p>Clear height can affect which tenants can use a building and how efficiently they can operate. Appraisers compare the subject property with relevant local sales and leases to measure the effect in that market rather than applying one fixed percentage.</p>
 
             <h3>How is industrial property valued if it is owner-occupied with no tenants?</h3>
             <p>The appraiser uses the sales comparison approach as the primary method and may apply the income approach using market rent — the rent a typical tenant would pay, rather than actual rent. The cost approach may also be applied, particularly for newer buildings or specialized improvements where comparable sales are limited. Owner-occupied industrial buildings are valued as if vacant and available for lease to a typical market tenant, which is how lenders and the market price them when they change hands.</p>

--- a/london/commercial-appraisal/index.html
+++ b/london/commercial-appraisal/index.html
@@ -98,13 +98,6 @@
                   "name": "Ontario"
             }
       },
-      "aggregateRating": {
-            "@type": "AggregateRating",
-            "ratingValue": 4.4,
-            "reviewCount": 35,
-            "bestRating": 5,
-            "worstRating": 1
-      },
       "hasCredential": [
             "AACI",
             "CUSPAP",

--- a/london/index.html
+++ b/london/index.html
@@ -137,13 +137,6 @@
                   }
             ]
       },
-      "aggregateRating": {
-            "@type": "AggregateRating",
-            "ratingValue": 4.4,
-            "reviewCount": 35,
-            "bestRating": 5,
-            "worstRating": 1
-      },
       "knowsAbout": [
             "Best commercial appraiser London Ontario",
             "ICI property valuation London",

--- a/london/industrial-appraisal/index.html
+++ b/london/industrial-appraisal/index.html
@@ -97,13 +97,6 @@
                   "name": "Ontario"
             }
       },
-      "aggregateRating": {
-            "@type": "AggregateRating",
-            "ratingValue": 4.4,
-            "reviewCount": 35,
-            "bestRating": 5,
-            "worstRating": 1
-      },
       "author": {
             "@type": "Person",
             "name": "Roman Virk",

--- a/london/residential-appraisal/index.html
+++ b/london/residential-appraisal/index.html
@@ -97,13 +97,6 @@
                   "name": "Ontario"
             }
       },
-      "aggregateRating": {
-            "@type": "AggregateRating",
-            "ratingValue": 4.4,
-            "reviewCount": 35,
-            "bestRating": 5,
-            "worstRating": 1
-      },
       "author": {
             "@type": "Person",
             "name": "Roman Virk",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "1.0.0",
   "description": "Metrix Realty Group - Professional Real Estate Appraisal Services",
   "scripts": {
-    "build": "npm run test:routes",
+    "build": "npm run test:routes && npm run test:search",
     "test:routes": "node scripts/check-clean-url-loops.mjs",
+    "test:search": "node scripts/check-search-readiness.mjs",
     "start": "echo 'This is a static site' && exit 1"
   },
   "engines": {

--- a/scripts/check-search-readiness.mjs
+++ b/scripts/check-search-readiness.mjs
@@ -1,0 +1,93 @@
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+
+const root = process.cwd();
+const failures = [];
+
+const pagesThatShouldBeIndexable = [
+  "insights/commercial-appraisal-documents-ontario/index.html",
+  "insights/industrial-property-appraisal-factors-ontario/index.html",
+  "windsor/commercial-appraisal/index.html",
+  "windsor/industrial-appraisal/index.html",
+  "windsor/investment-appraisal/index.html",
+  "windsor/litigation-support/index.html",
+];
+
+const expectedSitemapRoutes = [
+  "/insights/commercial-appraisal-documents-ontario/",
+  "/insights/industrial-property-appraisal-factors-ontario/",
+  "/windsor/commercial-appraisal",
+  "/windsor/industrial-appraisal",
+  "/windsor/investment-appraisal",
+  "/windsor/litigation-support",
+];
+
+for (const relativePath of pagesThatShouldBeIndexable) {
+  const html = await readFile(path.join(root, relativePath), "utf8");
+  if (/noindex/i.test(html)) failures.push(`${relativePath}: still contains noindex`);
+  for (const pattern of [
+    /50,000\+?\s+(?:appraisal\s+)?files/i,
+    /all major (?:Canadian )?(?:banks|lenders|financial institutions)/i,
+    /15\s*(?:to|–|-)\s*30\s*percent/i,
+    /driving meaningful demand growth/i,
+  ]) {
+    if (pattern.test(html)) failures.push(`${relativePath}: contains an unsupported strong claim`);
+  }
+}
+
+const sitemap = await readFile(path.join(root, "sitemap.xml"), "utf8");
+for (const route of expectedSitemapRoutes) {
+  if (!sitemap.includes(`https://metrixrealty.com${route}`)) {
+    failures.push(`sitemap.xml: missing ${route}`);
+  }
+}
+
+const vercel = JSON.parse(await readFile(path.join(root, "vercel.json"), "utf8"));
+const redirectMap = new Map(
+  (vercel.redirects ?? []).map(({ source, destination }) => [source, destination]),
+);
+for (const [source, destination] of [
+  ["/insights/aaci-vs-cra-appraisal-designations", "/insights/what-is-aaci-designation/"],
+  ["/insights/cuspap-2026-ontario-appraisal-clients", "/insights/what-is-cuspap/"],
+]) {
+  if (redirectMap.get(source) !== destination) {
+    failures.push(`vercel.json: ${source} should redirect to ${destination}`);
+  }
+}
+
+async function findHtmlFiles(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    if ([".git", ".vercel", "node_modules"].includes(entry.name)) continue;
+    const absolutePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) files.push(...(await findHtmlFiles(absolutePath)));
+    if (entry.isFile() && entry.name.endsWith(".html")) files.push(absolutePath);
+  }
+  return files;
+}
+
+for (const absolutePath of await findHtmlFiles(root)) {
+  const html = await readFile(absolutePath, "utf8");
+  const relativePath = path.relative(root, absolutePath);
+  if (/"aggregateRating"/i.test(html)) {
+    failures.push(`${relativePath}: contains self-serving aggregateRating markup`);
+  }
+
+  const jsonLdPattern = /<script\b[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+  for (const match of html.matchAll(jsonLdPattern)) {
+    try {
+      JSON.parse(match[1]);
+    } catch (error) {
+      failures.push(`${relativePath}: contains invalid JSON-LD (${error.message})`);
+    }
+  }
+}
+
+if (failures.length) {
+  console.error("Search-readiness check failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("Search-readiness check passed: approved pages are indexable, routed, and contain valid search markup.");

--- a/services/commercial-property-valuations/index.html
+++ b/services/commercial-property-valuations/index.html
@@ -121,13 +121,6 @@
       "areaServed": {
             "@type": "Place",
             "name": "Southwestern Ontario"
-      },
-      "aggregateRating": {
-            "@type": "AggregateRating",
-            "ratingValue": 4.4,
-            "reviewCount": 35,
-            "bestRating": 5,
-            "worstRating": 1
       }
 }
     </script>

--- a/services/government-institutional-services/index.html
+++ b/services/government-institutional-services/index.html
@@ -98,13 +98,6 @@
       "areaServed": {
             "@type": "Place",
             "name": "Southwestern Ontario"
-      },
-      "aggregateRating": {
-            "@type": "AggregateRating",
-            "ratingValue": 4.4,
-            "reviewCount": 35,
-            "bestRating": 5,
-            "worstRating": 1
       }
 }
     </script>

--- a/services/litigation-support-expert-testimony/index.html
+++ b/services/litigation-support-expert-testimony/index.html
@@ -98,13 +98,6 @@
       "areaServed": {
             "@type": "Place",
             "name": "Southwestern Ontario"
-      },
-      "aggregateRating": {
-            "@type": "AggregateRating",
-            "ratingValue": 4.4,
-            "reviewCount": 35,
-            "bestRating": 5,
-            "worstRating": 1
       }
 }
     </script>

--- a/services/real-estate-consulting/index.html
+++ b/services/real-estate-consulting/index.html
@@ -98,13 +98,6 @@
       "areaServed": {
             "@type": "Place",
             "name": "Southwestern Ontario"
-      },
-      "aggregateRating": {
-            "@type": "AggregateRating",
-            "ratingValue": 4.4,
-            "reviewCount": 35,
-            "bestRating": 5,
-            "worstRating": 1
       }
 }
     </script>

--- a/services/residential-property-appraisals/index.html
+++ b/services/residential-property-appraisals/index.html
@@ -108,13 +108,6 @@
       "areaServed": {
             "@type": "Place",
             "name": "Southwestern Ontario"
-      },
-      "aggregateRating": {
-            "@type": "AggregateRating",
-            "ratingValue": 4.4,
-            "reviewCount": 35,
-            "bestRating": 5,
-            "worstRating": 1
       }
 }
     </script>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -105,6 +105,10 @@
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
+  <url><loc>https://metrixrealty.com/windsor/commercial-appraisal</loc><lastmod>2026-08-10</lastmod><priority>0.8</priority></url>
+  <url><loc>https://metrixrealty.com/windsor/industrial-appraisal</loc><lastmod>2026-08-10</lastmod><priority>0.8</priority></url>
+  <url><loc>https://metrixrealty.com/windsor/investment-appraisal</loc><lastmod>2026-08-10</lastmod><priority>0.8</priority></url>
+  <url><loc>https://metrixrealty.com/windsor/litigation-support</loc><lastmod>2026-08-10</lastmod><priority>0.8</priority></url>
 
   <url>
     <loc>https://metrixrealty.com/market-areas</loc>
@@ -158,5 +162,7 @@
   <url><loc>https://metrixrealty.com/insights/sentimental-equity-problem/</loc><lastmod>2026-05-05</lastmod><priority>0.6</priority></url>
   <url><loc>https://metrixrealty.com/insights/what-is-aaci-designation/</loc><lastmod>2026-06-16</lastmod><priority>0.7</priority></url>
   <url><loc>https://metrixrealty.com/insights/what-is-cuspap/</loc><lastmod>2026-06-16</lastmod><priority>0.7</priority></url>
+  <url><loc>https://metrixrealty.com/insights/commercial-appraisal-documents-ontario/</loc><lastmod>2026-08-10</lastmod><priority>0.7</priority></url>
+  <url><loc>https://metrixrealty.com/insights/industrial-property-appraisal-factors-ontario/</loc><lastmod>2026-08-10</lastmod><priority>0.7</priority></url>
 
 </urlset>

--- a/vercel.json
+++ b/vercel.json
@@ -14,6 +14,8 @@
     { "source": "/contact-enhanced", "destination": "/contact", "permanent": true },
     { "source": "/market-insights.html", "destination": "/insights/", "permanent": true },
     { "source": "/market-insights", "destination": "/insights/", "permanent": true },
+    { "source": "/insights/aaci-vs-cra-appraisal-designations", "destination": "/insights/what-is-aaci-designation/", "permanent": true },
+    { "source": "/insights/cuspap-2026-ontario-appraisal-clients", "destination": "/insights/what-is-cuspap/", "permanent": true },
     { "source": "/services/index.html", "destination": "/services", "permanent": true },
     { "source": "/services/index", "destination": "/services", "permanent": true },
     { "source": "/windsor", "destination": "/windsor/", "permanent": true },

--- a/windsor/commercial-appraisal/index.html
+++ b/windsor/commercial-appraisal/index.html
@@ -5,17 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Commercial Appraisal Windsor Ontario | Metrix Realty</title>
     <link rel="icon" type="image/png" href="/favicon.png">
-    <meta name="description" content="AACI-designated commercial appraisers in Windsor-Essex. Office, retail, industrial, and multi-family valuations accepted by all major lenders.">
+    <meta name="description" content="AACI-designated commercial appraisers serving Windsor-Essex for office, retail, industrial, multi-family, and development property valuations.">
     <meta name="keywords" content="commercial appraisal Windsor Ontario, commercial appraiser Windsor, ICI appraisal Windsor Essex, AACI appraiser Windsor, office appraisal Windsor, retail appraisal Windsor">
     <link rel="canonical" href="https://metrixrealty.com/windsor/commercial-appraisal">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Metrix Realty Group">
     <meta property="og:title" content="Commercial Appraisal Windsor Ontario | Metrix Realty">
-    <meta property="og:description" content="AACI-designated commercial appraisers in Windsor-Essex. Office, retail, industrial, and multi-family valuations accepted by all major lenders.">
+    <meta property="og:description" content="AACI-designated commercial appraisers serving Windsor-Essex for office, retail, industrial, multi-family, and development property valuations.">
     <meta property="og:url" content="https://metrixrealty.com/windsor/commercial-appraisal">
     <meta property="og:image" content="https://metrixrealty.com/assets/images/metrix-realty-logo.png">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="robots" content="noindex, nofollow">
+    <meta name="robots" content="index, follow">
 
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -79,7 +79,7 @@
       "@type": ["LocalBusiness", "ProfessionalService"],
       "name": "Metrix Realty Group – Commercial Appraisal Windsor Ontario",
       "url": "https://metrixrealty.com/windsor/commercial-appraisal",
-      "description": "AACI-designated commercial real estate appraisers in Windsor-Essex. Office, retail, industrial, and multi-family valuations accepted by all major Canadian lenders.",
+      "description": "AACI-designated commercial real estate appraisers serving Windsor-Essex for office, retail, industrial, multi-family, and development property valuations.",
       "telephone": "+1-519-672-7550",
       "address": {
         "@type": "PostalAddress",
@@ -120,7 +120,7 @@
           "name": "Who provides commercial appraisals in Windsor, Ontario?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "Metrix Realty Group provides commercial appraisals in Windsor, Ontario through its Windsor office at 2557 Dougall Ave #6. Founded in 1995 with over 50,000 appraisal files completed, Metrix is one of Southwestern Ontario's most experienced commercial appraisal firms with AACI-designated appraisers serving Windsor-Essex and all of Essex County."
+            "text": "Metrix Realty Group provides commercial appraisals through its Windsor office at 2557 Dougall Ave #6. AACI-designated appraisers serve Windsor-Essex and the surrounding communities for office, retail, industrial, multi-family, and development property assignments."
           }
         },
         {
@@ -136,7 +136,7 @@
           "name": "Are commercial appraisals from Metrix Realty accepted by Windsor lenders?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "Yes. Metrix Realty's AACI-designated appraisers produce CUSPAP-compliant reports accepted by all major Canadian financial institutions including chartered banks, credit unions, CMHC, and private lenders for commercial mortgage financing, refinancing, and construction loans in Windsor, Essex County, and throughout Southwestern Ontario."
+            "text": "Metrix prepares CUSPAP-compliant reports for commercial financing assignments. Tell the team which lender and loan type are involved before work begins so the intended user, scope, and reporting requirements can be confirmed."
           }
         },
         {
@@ -276,7 +276,7 @@
             <div class="max-w-4xl" data-aos="fade-up">
                 <p class="text-metrix-green font-semibold text-sm uppercase tracking-wider mb-3">Windsor, Ontario</p>
                 <h1 class="text-3xl sm:text-4xl lg:text-5xl font-bold mb-6 leading-tight">Commercial Appraisal in Windsor, Ontario</h1>
-                <p class="text-lg sm:text-xl text-white/85 mb-8 leading-relaxed max-w-3xl">Lender-approved commercial property valuations by <a href="https://www.aicanada.ca/designation/aaci/" target="_blank" rel="noopener noreferrer" class="underline hover:text-white">AACI</a>-designated appraisers serving Windsor-Essex and all of Essex County. Over 30 years and 50,000+ files completed across Southwestern Ontario.</p>
+                <p class="text-lg sm:text-xl text-white/85 mb-8 leading-relaxed max-w-3xl">Commercial property valuations by <a href="https://www.aicanada.ca/designation/aaci/" target="_blank" rel="noopener noreferrer" class="underline hover:text-white">AACI</a>-designated appraisers serving Windsor-Essex and all of Essex County.</p>
                 <div class="flex flex-col sm:flex-row gap-4">
                     <a href="/contact" class="inline-flex items-center justify-center px-8 py-4 bg-white text-metrix-blue font-semibold rounded-lg hover:bg-gray-100 transition-colors text-lg">
                         Request a Quote
@@ -300,7 +300,7 @@
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6" data-aos="fade-up" data-aos-delay="100">
                 <div class="p-6 rounded-xl border border-gray-200 hover:border-metrix-blue hover:shadow-md transition-all">
                     <h3 class="font-semibold text-gray-900 mb-2">Financing &amp; Refinancing</h3>
-                    <p class="text-gray-600 text-sm">Lender-approved appraisals for commercial mortgage applications, refinancing, and construction financing. Accepted by all major Canadian financial institutions operating in Windsor-Essex.</p>
+                    <p class="text-gray-600 text-sm">Commercial appraisals for mortgage applications, refinancing, and construction financing, prepared to the intended lender's confirmed requirements.</p>
                 </div>
                 <div class="p-6 rounded-xl border border-gray-200 hover:border-metrix-blue hover:shadow-md transition-all">
                     <h3 class="font-semibold text-gray-900 mb-2">Acquisition &amp; Disposition</h3>
@@ -392,7 +392,7 @@
                             <div class="flex items-start gap-3">
                                 <span class="text-metrix-green text-xl font-bold">✓</span>
                                 <div>
-                                    <p class="font-semibold">30+ Years &amp; 50,000+ Files</p>
+                                    <p class="font-semibold">Serving Southwestern Ontario Since 1995</p>
                                     <p class="text-white/75 text-sm">Founded in 1995. Decades of Southwestern Ontario appraisal experience behind every report.</p>
                                 </div>
                             </div>
@@ -406,8 +406,8 @@
                             <div class="flex items-start gap-3">
                                 <span class="text-metrix-green text-xl font-bold">✓</span>
                                 <div>
-                                    <p class="font-semibold">All Major Lenders Accepted</p>
-                                    <p class="text-white/75 text-sm">Reports accepted by all Canadian banks, credit unions, <a href="https://www.cmhc-schl.gc.ca/" target="_blank" rel="noopener noreferrer" class="underline">CMHC</a>, and private lenders.</p>
+                                    <p class="font-semibold">Financing Assignments</p>
+                                    <p class="text-white/75 text-sm">The intended lender and reporting requirements are confirmed before the assignment begins.</p>
                                 </div>
                             </div>
                             <div class="flex items-start gap-3">
@@ -485,7 +485,7 @@
                 <div class="space-y-6" data-aos="fade-up" data-aos-delay="100">
                     <div class="border border-gray-200 rounded-xl p-6">
                         <h3 class="font-semibold text-gray-900 mb-2">Who provides commercial appraisals in Windsor, Ontario?</h3>
-                        <p class="text-gray-600">Metrix Realty Group provides commercial appraisals in Windsor through its local office at 2557 Dougall Ave #6. Founded in 1995 with over 50,000 files completed, Metrix brings AACI-designated appraisers with deep Windsor-Essex market knowledge to every assignment. Our team serves clients from Windsor through LaSalle, Tecumseh, Amherstburg, and throughout Essex County.</p>
+                        <p class="text-gray-600">Metrix Realty Group provides commercial appraisals through its local office at 2557 Dougall Ave #6. AACI-designated appraisers serve Windsor, LaSalle, Tecumseh, Amherstburg, and communities throughout Essex County.</p>
                     </div>
                     <div class="border border-gray-200 rounded-xl p-6">
                         <h3 class="font-semibold text-gray-900 mb-2">What commercial property types are appraised in Windsor-Essex?</h3>
@@ -493,7 +493,7 @@
                     </div>
                     <div class="border border-gray-200 rounded-xl p-6">
                         <h3 class="font-semibold text-gray-900 mb-2">Are Metrix commercial appraisals accepted by Windsor lenders?</h3>
-                        <p class="text-gray-600">Yes. Our <a href="https://www.aicanada.ca/designation/aaci/" target="_blank" rel="noopener noreferrer" class="text-metrix-blue hover:underline">AACI</a>-designated appraisers produce CUSPAP-compliant reports accepted by all major Canadian financial institutions including banks, credit unions, CMHC, and private lenders for commercial mortgage financing, refinancing, and construction loans in Windsor, Essex County, and throughout Southwestern Ontario.</p>
+                        <p class="text-gray-600">Metrix prepares CUSPAP-compliant reports for commercial financing assignments. Share the lender and loan type before work begins so the intended user, scope, and reporting requirements can be confirmed.</p>
                     </div>
                     <div class="border border-gray-200 rounded-xl p-6">
                         <h3 class="font-semibold text-gray-900 mb-2">How does the Windsor commercial real estate market differ from other Ontario cities?</h3>

--- a/windsor/index.html
+++ b/windsor/index.html
@@ -134,13 +134,6 @@
                   }
             ]
       },
-      "aggregateRating": {
-            "@type": "AggregateRating",
-            "ratingValue": 5.0,
-            "reviewCount": 13,
-            "bestRating": 5,
-            "worstRating": 1
-      },
       "sameAs": [
             "https://www.google.com/maps/place/Metrix+Realty+Group/@42.2833357,-83.0237483,17z"
       ],

--- a/windsor/industrial-appraisal/index.html
+++ b/windsor/industrial-appraisal/index.html
@@ -15,7 +15,7 @@
     <meta property="og:url" content="https://metrixrealty.com/windsor/industrial-appraisal">
     <meta property="og:image" content="https://metrixrealty.com/assets/images/metrix-realty-logo.png">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="robots" content="noindex, nofollow">
+    <meta name="robots" content="index, follow">
 
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -79,7 +79,7 @@
       "@type": ["LocalBusiness", "ProfessionalService"],
       "name": "Metrix Realty Group – Industrial Appraisal Windsor Ontario",
       "url": "https://metrixrealty.com/windsor/industrial-appraisal",
-      "description": "AACI-designated industrial property appraisers in Windsor-Essex. Manufacturing, warehouse, flex industrial, automotive plant, and food processing valuations accepted by all major Canadian lenders.",
+      "description": "AACI-designated industrial property appraisers serving Windsor-Essex for manufacturing, warehouse, flex industrial, automotive, and food processing assignments.",
       "telephone": "+1-519-672-7550",
       "address": {
         "@type": "PostalAddress",
@@ -136,7 +136,7 @@
           "name": "How is the Gordie Howe International Bridge affecting Windsor industrial property values?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "The Gordie Howe International Bridge is driving meaningful demand growth in Windsor's industrial market. Properties in the bridge corridor and surrounding logistics zones are experiencing increased interest from distribution, warehousing, and cross-border logistics operators. This has contributed to tightening vacancy and upward pressure on industrial land and building values in the affected sub-markets. Our appraisers monitor this evolving market condition closely."
+            "text": "The Gordie Howe International Bridge can affect access, traffic patterns, logistics demand, land use, and development expectations near the corridor. An appraiser measures any effect using current local sales, leases, and the specific property's location and utility."
           }
         },
         {
@@ -295,7 +295,7 @@
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6" data-aos="fade-up" data-aos-delay="100">
                 <div class="p-6 rounded-xl border border-gray-200 hover:border-metrix-blue hover:shadow-md transition-all">
                     <h3 class="font-semibold text-gray-900 mb-2">Financing &amp; Refinancing</h3>
-                    <p class="text-gray-600 text-sm">Lender-approved industrial property appraisals for mortgage financing, refinancing, and construction loans. Accepted by all major Canadian financial institutions and CMHC.</p>
+                    <p class="text-gray-600 text-sm">Industrial property appraisals for mortgage financing, refinancing, and construction loans, prepared to the intended lender's confirmed requirements.</p>
                 </div>
                 <div class="p-6 rounded-xl border border-gray-200 hover:border-metrix-blue hover:shadow-md transition-all">
                     <h3 class="font-semibold text-gray-900 mb-2">Sale &amp; Acquisition</h3>
@@ -394,15 +394,15 @@
                             <div class="flex items-start gap-3">
                                 <span class="text-metrix-green text-xl font-bold">✓</span>
                                 <div>
-                                    <p class="font-semibold">30+ Years &amp; 50,000+ Files</p>
+                                    <p class="font-semibold">Serving Southwestern Ontario Since 1995</p>
                                     <p class="text-white/75 text-sm">Founded 1995. Decades of Southwestern Ontario industrial appraisal experience behind every report.</p>
                                 </div>
                             </div>
                             <div class="flex items-start gap-3">
                                 <span class="text-metrix-green text-xl font-bold">✓</span>
                                 <div>
-                                    <p class="font-semibold">All Major Lenders Accepted</p>
-                                    <p class="text-white/75 text-sm">CUSPAP-compliant reports accepted by all Canadian banks, credit unions, <a href="https://www.cmhc-schl.gc.ca/" target="_blank" rel="noopener noreferrer" class="underline">CMHC</a>, and private lenders.</p>
+                                    <p class="font-semibold">Financing Assignments</p>
+                                    <p class="text-white/75 text-sm">The intended lender and reporting requirements are confirmed before the assignment begins.</p>
                                 </div>
                             </div>
                             <div class="flex items-start gap-3">
@@ -488,7 +488,7 @@
                     </div>
                     <div class="border border-gray-200 rounded-xl p-6">
                         <h3 class="font-semibold text-gray-900 mb-2">How is the Gordie Howe International Bridge affecting Windsor industrial values?</h3>
-                        <p class="text-gray-600">The Gordie Howe International Bridge is driving meaningful demand growth in Windsor's industrial market. Properties in the bridge corridor and surrounding logistics zones are experiencing increased interest from distribution, warehousing, and cross-border logistics operators. This has contributed to tightening vacancy and upward pressure on industrial land and building values in affected sub-markets — a dynamic our Windsor appraisers monitor closely.</p>
+                        <p class="text-gray-600">The Gordie Howe International Bridge can affect access, traffic patterns, logistics demand, land use, and development expectations near the corridor. An appraiser measures any effect using current local sales, leases, and the specific property's location and utility.</p>
                     </div>
                     <div class="border border-gray-200 rounded-xl p-6">
                         <h3 class="font-semibold text-gray-900 mb-2">Do Metrix industrial appraisals include replacement cost estimates?</h3>

--- a/windsor/investment-appraisal/index.html
+++ b/windsor/investment-appraisal/index.html
@@ -15,7 +15,7 @@
     <meta property="og:url" content="https://metrixrealty.com/windsor/investment-appraisal">
     <meta property="og:image" content="https://metrixrealty.com/assets/images/metrix-realty-logo.png">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="robots" content="noindex, nofollow">
+    <meta name="robots" content="index, follow">
 
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -79,7 +79,7 @@
       "@type": ["LocalBusiness", "ProfessionalService"],
       "name": "Metrix Realty Group – Investment Property Appraisal Windsor Ontario",
       "url": "https://metrixrealty.com/windsor/investment-appraisal",
-      "description": "AACI-designated investment property and multi-family appraisers in Windsor-Essex. Apartment buildings, rental complexes, and commercial investment valuations accepted by all major Canadian lenders including CMHC.",
+      "description": "AACI-designated appraisers serving Windsor-Essex for apartment buildings, rental complexes, mixed-use properties, and commercial investment valuations.",
       "telephone": "+1-519-672-7550",
       "address": {
         "@type": "PostalAddress",
@@ -120,7 +120,7 @@
           "name": "Who provides investment property appraisals in Windsor, Ontario?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "Metrix Realty Group provides investment property and multi-family appraisals in Windsor through its local office at 2557 Dougall Ave #6. Metrix AACI-designated appraisers have completed investment property valuations across Windsor-Essex for lenders, investors, and portfolio managers. Reports are accepted by all major Canadian lenders including CMHC."
+            "text": "Metrix Realty Group provides investment property and multi-family appraisals through its Windsor office at 2557 Dougall Ave #6. AACI-designated appraisers serve lenders, investors, owners, and portfolio managers across Windsor-Essex."
           }
         },
         {
@@ -267,7 +267,7 @@
             <div class="max-w-4xl" data-aos="fade-up">
                 <p class="text-metrix-green font-semibold text-sm uppercase tracking-wider mb-3">Windsor, Ontario</p>
                 <h1 class="text-3xl sm:text-4xl lg:text-5xl font-bold mb-6 leading-tight">Investment Property Appraisal in Windsor, Ontario</h1>
-                <p class="text-lg sm:text-xl text-white/85 mb-8 leading-relaxed max-w-3xl">Lender-approved valuations for multi-family and commercial investment properties in Windsor-Essex. <a href="https://www.aicanada.ca/designation/aaci/" target="_blank" rel="noopener noreferrer" class="underline hover:text-white">AACI</a>-designated appraisers accepted by all major Canadian lenders including <a href="https://www.cmhc-schl.gc.ca/" target="_blank" rel="noopener noreferrer" class="underline hover:text-white">CMHC</a>.</p>
+                <p class="text-lg sm:text-xl text-white/85 mb-8 leading-relaxed max-w-3xl">Valuations for multi-family and commercial investment properties in Windsor-Essex by <a href="https://www.aicanada.ca/designation/aaci/" target="_blank" rel="noopener noreferrer" class="underline hover:text-white">AACI</a>-designated appraisers.</p>
                 <div class="flex flex-col sm:flex-row gap-4">
                     <a href="/contact" class="inline-flex items-center justify-center px-8 py-4 bg-white text-metrix-blue font-semibold rounded-lg hover:bg-gray-100 transition-colors text-lg">
                         Request a Quote
@@ -299,7 +299,7 @@
                 </div>
                 <div class="p-6 rounded-xl border border-gray-200 hover:border-metrix-blue hover:shadow-md transition-all">
                     <h3 class="font-semibold text-gray-900 mb-2">Conventional Mortgage Financing</h3>
-                    <p class="text-gray-600 text-sm">Lender-recognized appraisals for conventional commercial and multi-family mortgage applications, refinancing, and construction draws. Accepted by all major Canadian chartered banks, credit unions, and private lenders.</p>
+                    <p class="text-gray-600 text-sm">Appraisals for commercial and multi-family mortgage applications, refinancing, and construction draws, prepared to the intended lender's confirmed requirements.</p>
                 </div>
                 <div class="p-6 rounded-xl border border-gray-200 hover:border-metrix-blue hover:shadow-md transition-all">
                     <h3 class="font-semibold text-gray-900 mb-2">Portfolio Management &amp; Reporting</h3>
@@ -393,14 +393,14 @@
                             <div class="flex items-start gap-3">
                                 <span class="text-metrix-green text-xl font-bold">✓</span>
                                 <div>
-                                    <p class="font-semibold">All Major Lenders Accepted</p>
-                                    <p class="text-white/75 text-sm">Reports recognized by all Canadian chartered banks, credit unions, and private lenders for commercial and multi-family investment financing.</p>
+                                    <p class="font-semibold">Financing Assignments</p>
+                                    <p class="text-white/75 text-sm">The intended lender and reporting requirements are confirmed before the assignment begins.</p>
                                 </div>
                             </div>
                             <div class="flex items-start gap-3">
                                 <span class="text-metrix-green text-xl font-bold">✓</span>
                                 <div>
-                                    <p class="font-semibold">30+ Years &amp; 50,000+ Files</p>
+                                    <p class="font-semibold">Serving Southwestern Ontario Since 1995</p>
                                     <p class="text-white/75 text-sm">Founded in 1995. Decades of Southwestern Ontario investment property appraisal experience behind every report.</p>
                                 </div>
                             </div>
@@ -479,7 +479,7 @@
                 <div class="space-y-6" data-aos="fade-up" data-aos-delay="100">
                     <div class="border border-gray-200 rounded-xl p-6">
                         <h3 class="font-semibold text-gray-900 mb-2">Who provides investment property appraisals in Windsor, Ontario?</h3>
-                        <p class="text-gray-600">Metrix Realty Group provides investment property and multi-family appraisals in Windsor through its local office at 2557 Dougall Ave #6. AACI-designated appraisers with Windsor-Essex market experience serve investors, lenders, and portfolio managers. Reports are accepted by all major Canadian lenders including CMHC.</p>
+                        <p class="text-gray-600">Metrix Realty Group provides investment property and multi-family appraisals through its local office at 2557 Dougall Ave #6. AACI-designated appraisers serve investors, lenders, owners, and portfolio managers across Windsor-Essex.</p>
                     </div>
                     <div class="border border-gray-200 rounded-xl p-6">
                         <h3 class="font-semibold text-gray-900 mb-2">What investment property types does Metrix appraise in Windsor?</h3>

--- a/windsor/litigation-support/index.html
+++ b/windsor/litigation-support/index.html
@@ -15,7 +15,7 @@
     <meta property="og:url" content="https://metrixrealty.com/windsor/litigation-support">
     <meta property="og:image" content="https://metrixrealty.com/assets/images/metrix-realty-logo.png">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="robots" content="noindex, nofollow">
+    <meta name="robots" content="index, follow">
 
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -402,7 +402,7 @@
                             <div class="flex items-start gap-3">
                                 <span class="text-metrix-green text-xl font-bold">✓</span>
                                 <div>
-                                    <p class="font-semibold">30+ Years &amp; 50,000+ Files</p>
+                                    <p class="font-semibold">Serving Southwestern Ontario Since 1995</p>
                                     <p class="text-white/75 text-sm">Founded in 1995. Decades of Southwestern Ontario appraisal experience behind every litigation report.</p>
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary\n- make approved Windsor service and appraisal insight pages indexable\n- redirect two overlapping articles to the established canonical guides\n- remove unsupported self-review rating markup and soften unsourced claims\n- add a regression check for indexability, routes, claims, and valid JSON-LD\n\n## Verification\n- npm run build\n- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static HTML, SEO metadata, and copy changes with no application logic or auth; main risk is unintended indexing or redirect behavior if URLs are wrong.
> 
> **Overview**
> Prepares selected Windsor service pages and Ontario insight articles for search indexing while tightening structured data and marketing copy.
> 
> **Indexing & routing:** Approved pages move from `noindex, nofollow` to `index, follow`. `sitemap.xml` gains Windsor commercial/industrial/investment/litigation URLs and the two insight articles. `vercel.json` adds permanent redirects from overlapping insight paths to canonical guides (`what-is-aaci-designation`, `what-is-cuspap`).
> 
> **Structured data:** `aggregateRating` blocks are removed from JSON-LD across the homepage, London/Windsor location pages, and service pages to avoid self-serving rating markup.
> 
> **Copy & claims:** Windsor landing pages and related FAQ/schema text drop broad lender-acceptance and volume claims in favor of confirming intended user and scope. The industrial factors article revises meta descriptions and clear-height FAQ/body copy to avoid fixed percentage value impacts.
> 
> **Regression guard:** `scripts/check-search-readiness.mjs` runs in `npm run build`, asserting indexability, sitemap presence, redirect targets, banned claim patterns on approved pages, no `aggregateRating` in HTML, and valid JSON-LD sitewide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53a634f9814228bfad9b8beec803f463e0683dac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make approved Windsor service pages and two Insights indexable, clean up structured data and unsourced claims, add canonical redirects, and enforce it all with a new search-readiness check in the build. Improves indexability, sitemap coverage, and avoids search policy issues.

- New Features
  - Added `scripts/check-search-readiness.mjs` and wired it into `npm run build`.
  - The check verifies indexability, required sitemap routes, expected redirects, and valid JSON-LD.
  - Expanded `sitemap.xml` with Windsor routes and the two Insights.

- Bug Fixes
  - Switched approved Windsor pages and two Insights from `noindex` to `index, follow`.
  - Removed self-serving `aggregateRating` JSON-LD and softened unsourced claims (e.g., “all major lenders”, “50,000+ files”, fixed the clear-height % statement); ensured JSON-LD parses.
  - Added redirects in `vercel.json`:
    - `/insights/aaci-vs-cra-appraisal-designations` → `/insights/what-is-aaci-designation/`
    - `/insights/cuspap-2026-ontario-appraisal-clients` → `/insights/what-is-cuspap/`

<sup>Written for commit 53a634f9814228bfad9b8beec803f463e0683dac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/guestgetter/metrix-realty-website/pull/39?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

